### PR TITLE
fix http head method request timeout

### DIFF
--- a/src/brpc/details/http_message.cpp
+++ b/src/brpc/details/http_message.cpp
@@ -135,6 +135,7 @@ int HttpMessage::on_header_value(http_parser *parser,
 int HttpMessage::on_headers_complete(http_parser *parser) {
     HttpMessage *http_message = (HttpMessage *)parser->data;
     http_message->_stage = HTTP_ON_HEADERS_COMPLETE;
+    http_message->header().set_content_length(parser->content_length);
     // Move content-type into the member field.
     const std::string* content_type = http_message->header().GetHeader("content-type");
     if (content_type) {

--- a/src/brpc/http_header.cpp
+++ b/src/brpc/http_header.cpp
@@ -49,6 +49,7 @@ void HttpHeader::Swap(HttpHeader &rhs) {
     _content_type.swap(rhs._content_type);
     _unresolved_path.swap(rhs._unresolved_path);
     std::swap(_version, rhs._version);
+    std::swap(_content_length, rhs._content_length);
 }
 
 void HttpHeader::Clear() {

--- a/src/brpc/http_header.h
+++ b/src/brpc/http_header.h
@@ -136,6 +136,9 @@ public:
     //   "/FileService//mydir///123.txt//"   "mydir/123.txt"
     const std::string& unresolved_path() const { return _unresolved_path; }
 
+    uint64_t content_length() const { return _content_length; }
+    void set_content_length(uint64_t length) { _content_length = length; }
+
 private:
 friend class HttpMessage;
 friend class HttpMessageSerializer;
@@ -156,6 +159,7 @@ friend void policy::ProcessHttpRequest(InputMessageBase *msg);
     std::string _content_type;
     std::string _unresolved_path;
     std::pair<int, int> _version;
+    uint64_t _content_length;
 };
 
 const HttpHeader& DefaultHttpHeader();


### PR DESCRIPTION
#764 

这里的实现是在ParseHttpMessage中增加了method判断；
似乎还有一种实现办法，利用[read_progressively](https://github.com/apache/incubator-brpc/blob/983b997066dee33022bfba27d7e00f207c092b21/src/brpc/controller.h#L275)，然后在ProcessHttpResponse再做判断处理，哪种实现会好一些？