### PR TITLE
Set protected branches and limit merge methods

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -3,3 +3,14 @@ github:
   labels:
     - rpc
   homepage: https://brpc.apache.org
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
+  protected_branches:
+    master:
+      required_status_checks:
+        strict: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1


### PR DESCRIPTION
In most cases, we only need Squash merge and disable other merge methods to avoid loss of Git record coverage due to inadvertent operations.(such as #1817)