### PR TITLE
split large data when using brpc streaming

### DIFF
--- a/docs/cn/streaming_rpc.md
+++ b/docs/cn/streaming_rpc.md
@@ -16,8 +16,7 @@ Streaming RPC保证：
 - 全双工。
 - 支持流控。
 - 提供超时提醒
-
-目前的实现还没有自动切割过大的消息，同一个tcp连接上的多个Stream之间可能有[Head-of-line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking)问题，请尽量避免过大的单个消息，实现自动切割后我们会告知并更新文档。
+- 自动切割过大的消息
 
 例子见[example/streaming_echo_c++](https://github.com/brpc/brpc/tree/master/example/streaming_echo_c++/)。
 

--- a/docs/en/streaming_rpc.md
+++ b/docs/en/streaming_rpc.md
@@ -16,8 +16,7 @@ Streaming RPC ensures/provides:
 - Full duplex
 - Flow control
 - Notification on timeout
-
-We do not support segment large messages automatically so that multiple Streams on a single TCP connection may lead to [Head-of-line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking) problem. Please avoid putting huge data into single message until we provide automatic segmentation.
+- support segment large messages automaticall
 
 For examples please refer to [example/streaming_echo_c++](https://github.com/brpc/brpc/tree/master/example/streaming_echo_c++/).
 

--- a/docs/en/streaming_rpc.md
+++ b/docs/en/streaming_rpc.md
@@ -16,7 +16,7 @@ Streaming RPC ensures/provides:
 - Full duplex
 - Flow control
 - Notification on timeout
-- support segment large messages automaticall
+- support segment large messages automatically
 
 For examples please refer to [example/streaming_echo_c++](https://github.com/brpc/brpc/tree/master/example/streaming_echo_c++/).
 

--- a/src/brpc/stream.cpp
+++ b/src/brpc/stream.cpp
@@ -35,7 +35,7 @@
 namespace brpc {
 
 DECLARE_bool(usercode_in_pthread);
-DEFINE_uint64(max_trans_unit_size, 64 * 1024 * 1024,
+DEFINE_uint64(max_stream_data_frame_size, 64 * 1024 * 1024,
                   "Maximum size of a transmission unit that we used to cut the message.");
 const static butil::IOBuf *TIMEOUT_TASK = (butil::IOBuf*)-1L;
 
@@ -145,7 +145,9 @@ ssize_t Stream::CutMessageIntoFileDescriptor(int /*fd*/,
     for (size_t i = 0; i < size; ++i) {
       butil::IOBuf *data = data_list[i];
       size_t length = data->length();
-      uint64_t trans_unit = FLAGS_max_trans_unit_size;
+      uint64_t trans_unit = FLAGS_max_stream_data_frame_size == 0
+                                ? length
+                                : FLAGS_max_stream_data_frame_size;
       int packet_num = ceil((double)length / (double)trans_unit);
 
       butil::IOBuf split_data;


### PR DESCRIPTION
https://github.com/apache/incubator-brpc/blob/master/docs/cn/streaming_rpc.md

"目前的实现还没有自动切割过大的消息，同一个tcp连接上的多个Stream之间可能有[Head-of-line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking)问题，请尽量避免过大的单个消息，实现自动切割后我们会告知并更新文档"

尝试解决这个 todo.