### PR TITLE
Keep bthread TaskGroup abi compatible with NDEBUG macro

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -175,9 +175,6 @@ void TaskGroup::run_main_task() {
 
 TaskGroup::TaskGroup(TaskControl* c)
     :
-#ifndef NDEBUG
-    _sched_recursive_guard(0),
-#endif
     _cur_meta(NULL)
     , _control(c)
     , _num_nosignal(0)
@@ -192,6 +189,9 @@ TaskGroup::TaskGroup(TaskControl* c)
     , _main_tid(0)
     , _remote_num_nosignal(0)
     , _remote_nsignaled(0)
+#ifndef NDEBUG
+    , _sched_recursive_guard(0)
+#endif
 {
     _steal_seed = butil::fast_rand();
     _steal_offset = OFFSET_TABLE[_steal_seed % ARRAY_SIZE(OFFSET_TABLE)];

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -221,10 +221,6 @@ friend class TaskControl;
         return _control->steal_task(tid, &_steal_seed, _steal_offset);
     }
 
-#ifndef NDEBUG
-    int _sched_recursive_guard;
-#endif
-
     TaskMeta* _cur_meta;
     
     // the control that this group belongs to
@@ -251,6 +247,8 @@ friend class TaskControl;
     RemoteTaskQueue _remote_rq;
     int _remote_num_nosignal;
     int _remote_nsignaled;
+
+    int _sched_recursive_guard;
 };
 
 }  // namespace bthread


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2042

Problem Summary: bthread::TaskGroup add a new member _sched_recursive_guard if NDEBUG is not defined, this cause abi incompatible.

### What is changed and the side effects?

Changed: define the _sched_recursive_guard whether NDEBUG is defined or not

Side effects:
- Performance effects(性能影响): No

- Breaking backward compatibility(向后兼容性): No

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
