### PR TITLE
Remove incubator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before the PR:
 
 After the PR:
 
-* Make sure the [travis-ci](https://app.travis-ci.com/github/apache/incubator-brpc/pull_requests) passed.
+* Make sure the [travis-ci](https://app.travis-ci.com/github/apache/brpc/pull_requests) passed.
 
 # Chinese version
 
@@ -26,4 +26,4 @@ After the PR:
 
 提交PR后请确认：
 
-* [travis-ci](https://app.travis-ci.com/github/apache/incubator-brpc/pull_requests)成功通过。
+* [travis-ci](https://app.travis-ci.com/github/apache/brpc/pull_requests)成功通过。

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [中文版](README_cn.md)
 
-[![Linux Build Status](https://github.com/apache/incubator-brpc/actions/workflows/ci-linux.yml/badge.svg)](https://github.com/apache/incubator-brpc/actions/workflows/ci-linux.yml)
-[![MacOs Build Status](https://github.com/apache/incubator-brpc/actions/workflows/ci-macos.yml/badge.svg)](https://github.com/apache/incubator-brpc/actions/workflows/ci-macos.yml)
+[![Linux Build Status](https://github.com/apache/brpc/actions/workflows/ci-linux.yml/badge.svg)](https://github.com/apache/brpc/actions/workflows/ci-linux.yml)
+[![MacOs Build Status](https://github.com/apache/brpc/actions/workflows/ci-macos.yml/badge.svg)](https://github.com/apache/brpc/actions/workflows/ci-macos.yml)
 
 # ![brpc](docs/images/logo.png)
 
@@ -102,7 +102,7 @@ You can use it to:
 Please refer to [here](CONTRIBUTING.md).
 
 # Feedback and Getting involved
-* Report bugs, ask questions or give suggestions by [Github Issues](https://github.com/apache/incubator-brpc/issues)
+* Report bugs, ask questions or give suggestions by [Github Issues](https://github.com/apache/brpc/issues)
 * Subscribe mailing list(dev-subscribe@brpc.apache.org) to get updated with the project
 
 # Code of Conduct

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,6 +1,6 @@
 [English version](README.md)
 
-[![Build Status](https://api.travis-ci.com/apache/incubator-brpc.svg?branch=master)](https://travis-ci.com/github/apache/incubator-brpc)
+[![Build Status](https://api.travis-ci.com/apache/brpc.svg?branch=master)](https://travis-ci.com/github/apache/brpc)
 
 # ![brpc](docs/images/logo.png)
 
@@ -107,7 +107,7 @@ brpc是用c++语言编写的工业级RPC框架，常用于搜索、存储、机�
 
 # 反馈和参与
 
-* bug、疑惑、修改建议都欢迎提在[Github Issues](https://github.com/apache/incubator-brpc/issues)中
+* bug、疑惑、修改建议都欢迎提在[Github Issues](https://github.com/apache/brpc/issues)中
 * 订阅邮件列表(dev-subscribe@brpc.apache.org)获得项目最新信息
 
 

--- a/community/release_cn.md
+++ b/community/release_cn.md
@@ -165,9 +165,9 @@ Version:	1.0.0
 ## 3. 创建发布 tag
 拉取发布分支，并推送tag
 ```bash
-git clone -b release-1.0 git@github.com:apache/incubator-brpc.git ~/incubator-brpc
+git clone -b release-1.0 git@github.com:apache/brpc.git ~/brpc
 
-cd ~/incubator-brpc
+cd ~/brpc
 
 git tag -a 1.0.0 -m "release 1.0.0"
 
@@ -228,11 +228,11 @@ mkdir -p ~/brpc_svn/dev/brpc/1.0.0
 
 cd ~/brpc_svn/dev/brpc/1.0.0
 
-cp ~/incubator-brpc/apache-brpc-1.0.0-incubating-src.tar.gz ~/brpc_svn/dev/brpc/1.0.0
+cp ~/brpc/apache-brpc-1.0.0-incubating-src.tar.gz ~/brpc_svn/dev/brpc/1.0.0
 
-cp ~/incubator-brpc/apache-brpc-1.0.0-incubating-src.tar.gz.asc ~/brpc_svn/dev/brpc/1.0.0
+cp ~/brpc/apache-brpc-1.0.0-incubating-src.tar.gz.asc ~/brpc_svn/dev/brpc/1.0.0
 
-cp ~/incubator-brpc/apache-brpc-1.0.0-incubating-src.tar.gz.sha512 ~/brpc_svn/dev/brpc/1.0.0
+cp ~/brpc/apache-brpc-1.0.0-incubating-src.tar.gz.sha512 ~/brpc_svn/dev/brpc/1.0.0
 ```
 
 ## 4. 提交SVN
@@ -305,13 +305,13 @@ gpg --verify apache-brpc-1.0.0-incubating-src.tar.gz.asc apache-brpc-1.0.0-incub
 ### 1. 对比源码包与github上的tag内容差异
 
 ```bash
-curl -Lo tag-1.0.0.tar.gz https://github.com/apache/incubator-brpc/archive/refs/tags/1.0.0.tar.gz
+curl -Lo tag-1.0.0.tar.gz https://github.com/apache/brpc/archive/refs/tags/1.0.0.tar.gz
 
 tar xvzf tag-1.0.0.tar.gz
 
 tar xvzf apache-brpc-1.0.0-incubating-src.tar.gz
 
-diff -r incubator-brpc-1.0.0 apache-brpc-1.0.0-incubating-src
+diff -r brpc-1.0.0 apache-brpc-1.0.0-incubating-src
 ```
 
 ### 2. 检查源码包的文件内容
@@ -360,10 +360,10 @@ The release candidates:
 https://dist.apache.org/repos/dist/dev/incubator/brpc/1.0.0/
 
 Git tag for the release:
-https://github.com/apache/incubator-brpc/releases/tag/1.0.0
+https://github.com/apache/brpc/releases/tag/1.0.0
 
 Release Commit ID:
-https://github.com/apache/incubator-brpc/commit/xxx
+https://github.com/apache/brpc/commit/xxx
 
 Keys to verify the Release Candidate:
 https://dist.apache.org/repos/dist/dev/incubator/brpc/KEYS
@@ -482,7 +482,7 @@ This release has been signed with a PGP available here:
 https://downloads.apache.org/incubator/brpc/KEYS
 
 Git tag for the release:
-https://github.com/apache/incubator-brpc/releases/tag/1.0.0
+https://github.com/apache/brpc/releases/tag/1.0.0
 
 Build guide and get started instructions can be found at:
 https://brpc.apache.org/docs/getting_started
@@ -549,12 +549,12 @@ svn mv https://dist.apache.org/repos/dist/dev/incubator/brpc/1.0.0 https://dist.
 
 ## 2. Github版本发布
 
-在 [GitHub Releases 页面](https://github.com/apache/incubator-brpc/tags)的对应版本上点击，创建新的Release页面
+在 [GitHub Releases 页面](https://github.com/apache/brpc/tags)的对应版本上点击，创建新的Release页面
 编辑版本号及版本说明，并点击 Publish release
 
 ## 3. 更新下载页面
 
-等待并确认新的发布版本同步至 Apache 镜像后，更新如下页面：<https://brpc.apache.org/docs/downloadbrpc/>, 更新方式在 <https://github.com/apache/incubator-brpc-website/> 仓库中，注意中英文都要更新。
+等待并确认新的发布版本同步至 Apache 镜像后，更新如下页面：<https://brpc.apache.org/docs/downloadbrpc/>, 更新方式在 <https://github.com/apache/brpc-website/> 仓库中，注意中英文都要更新。
 
 GPG签名文件和哈希校验文件的下载链接应该使用这个前缀：https://downloads.apache.org/incubator/brpc/
 
@@ -597,12 +597,12 @@ The release is available for download at:
 https://brpc.apache.org/docs/downloadbrpc/
 
 The release notes can be found here:
-https://github.com/apache/incubator-brpc/releases/tag/1.0.0
+https://github.com/apache/brpc/releases/tag/1.0.0
 
 Website: http://brpc.apache.org/
 
 brpc(Incubating) Resources:
-- Issue: https://github.com/apache/incubator-brpc/issues/
+- Issue: https://github.com/apache/brpc/issues/
 - Mailing list: dev@brpc.apache.org
 - Documents: https://brpc.apache.org/docs/
 

--- a/community/release_en.md
+++ b/community/release_en.md
@@ -170,9 +170,9 @@ Version:	1.0.0
 push the release branch to tag, For example:
 
 ```bash
-git clone -b release-1.0 git@github.com:apache/incubator-brpc.git ~/incubator-brpc
+git clone -b release-1.0 git@github.com:apache/brpc.git ~/brpc
 
-cd ~/incubator-brpc
+cd ~/brpc
 
 git tag -a 1.0.0 -m "release 1.0.0"
 
@@ -233,11 +233,11 @@ mkdir -p ~/brpc_svn/dev/brpc/1.0.0
 
 cd ~/brpc_svn/dev/brpc/1.0.0
 
-cp ~/incubator-brpc/apache-brpc-1.0.0-incubating-src.tar.gz ~/brpc_svn/dev/brpc/1.0.0
+cp ~/brpc/apache-brpc-1.0.0-incubating-src.tar.gz ~/brpc_svn/dev/brpc/1.0.0
 
-cp ~/incubator-brpc/apache-brpc-1.0.0-incubating-src.tar.gz.asc ~/brpc_svn/dev/brpc/1.0.0
+cp ~/brpc/apache-brpc-1.0.0-incubating-src.tar.gz.asc ~/brpc_svn/dev/brpc/1.0.0
 
-cp ~/incubator-brpc/apache-brpc-1.0.0-incubating-src.tar.gz.sha512 ~/brpc_svn/dev/brpc/1.0.0
+cp ~/brpc/apache-brpc-1.0.0-incubating-src.tar.gz.sha512 ~/brpc_svn/dev/brpc/1.0.0
 ```
 
 ## 4. Submit SVN
@@ -312,13 +312,13 @@ gpg --verify apache-brpc-1.0.0-incubating-src.tar.gz.asc apache-brpc-1.0.0-incub
 ### 1. Compare the difference of between the source code package and github tag
 
 ```bash
-curl -Lo tag-1.0.0.tar.gz https://github.com/apache/incubator-brpc/archive/refs/tags/1.0.0.tar.gz
+curl -Lo tag-1.0.0.tar.gz https://github.com/apache/brpc/archive/refs/tags/1.0.0.tar.gz
 
 tar xvzf tag-1.0.0.tar.gz
 
 tar xvzf apache-brpc-1.0.0-incubating-src.tar.gz
 
-diff -r incubator-brpc-1.0.0 apache-brpc-1.0.0-incubating-src
+diff -r brpc-1.0.0 apache-brpc-1.0.0-incubating-src
 ```
 
 ### 2. Check file content
@@ -370,10 +370,10 @@ The release candidates:
 https://dist.apache.org/repos/dist/dev/incubator/brpc/1.0.0/
 
 Git tag for the release:
-https://github.com/apache/incubator-brpc/releases/tag/1.0.0
+https://github.com/apache/brpc/releases/tag/1.0.0
 
 Release Commit ID:
-https://github.com/apache/incubator-brpc/commit/xxx
+https://github.com/apache/brpc/commit/xxx
 
 Keys to verify the Release Candidate:
 https://dist.apache.org/repos/dist/dev/incubator/brpc/KEYS
@@ -492,7 +492,7 @@ This release has been signed with a PGP available here:
 https://downloads.apache.org/incubator/brpc/KEYS
 
 Git tag for the release:
-https://github.com/apache/incubator-brpc/releases/tag/1.0.0
+https://github.com/apache/brpc/releases/tag/1.0.0
 
 Build guide and get started instructions can be found at:
 https://brpc.apache.org/docs/getting_started
@@ -559,12 +559,12 @@ svn mv https://dist.apache.org/repos/dist/dev/incubator/brpc/1.0.0 https://dist.
 
 ## 2. Create github release
 
-1. On the [GitHub Releases page](https://github.com/apache/incubator-brpc/tags) Click the corresponding version of to create a new Release
+1. On the [GitHub Releases page](https://github.com/apache/brpc/tags) Click the corresponding version of to create a new Release
 2. Edit the version number and version description, and click `Publish release`
 
 ## 3. Update download page
 
-After waiting and confirming that the new release is synchronized to the Apache image, update the following page: <https://brpc.apache.org/docs/downloadbrpc/> by change the code in <https://github.com/apache/incubator-brpc-website/>. Please update both Chinese and English.
+After waiting and confirming that the new release is synchronized to the Apache image, update the following page: <https://brpc.apache.org/docs/downloadbrpc/> by change the code in <https://github.com/apache/brpc-website/>. Please update both Chinese and English.
 
 The download links of GPG signature files and hash check files should use this prefix: `https://downloads.apache.org/incubator/brpc/`
 
@@ -609,12 +609,12 @@ The release is available for download at:
 https://brpc.apache.org/docs/downloadbrpc/
 
 The release notes can be found here:
-https://github.com/apache/incubator-brpc/releases/tag/1.0.0
+https://github.com/apache/brpc/releases/tag/1.0.0
 
 Website: http://brpc.apache.org/
 
 brpc(Incubating) Resources:
-- Issue: https://github.com/apache/incubator-brpc/issues/
+- Issue: https://github.com/apache/brpc/issues/
 - Mailing list: dev@brpc.apache.org
 - Documents: https://brpc.apache.org/docs/
 

--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -325,7 +325,7 @@ append_to_output "DYNAMIC_LINKINGS=$DYNAMIC_LINKINGS"
 CPPFLAGS="-DBRPC_WITH_GLOG=$WITH_GLOG -DGFLAGS_NS=$GFLAGS_NS"
 
 # Avoid over-optimizations of TLS variables by GCC>=4.8
-# See: https://github.com/apache/incubator-brpc/issues/1693
+# See: https://github.com/apache/brpc/issues/1693
 CPPFLAGS="${CPPFLAGS} -D__const__=__unused__"
 
 if [ ! -z "$DEBUGSYMBOLS" ]; then

--- a/docs/cn/auto_concurrency_limiter.md
+++ b/docs/cn/auto_concurrency_limiter.md
@@ -73,7 +73,7 @@ max_qps是最近一段时间测量到的qps的极大值。
 min_latency是最近一段时间测量到的latency较小值的ema，是noload_latency的估算值。
 
 注意：当计算出来的 max_concurrency 和当前的 max_concurrency 的值不同时，每次对 max_concurrency 的调整的比例有一个上限，让 max_concurrency
-的[变化更为平滑](https://github.com/apache/incubator-brpc/blob/master/src/brpc/policy/auto_concurrency_limiter.cpp#L249)。
+的[变化更为平滑](https://github.com/apache/brpc/blob/master/src/brpc/policy/auto_concurrency_limiter.cpp#L249)。
 
 当服务处于低负载时，min_latency约等于noload_latency，此时计算出来的max_concurrency会高于concurrency，但低于best_max_concurrency，给流量上涨留探索空间。而当服务过载时，服务的qps约等于max_qps，同时latency开始明显超过min_latency，此时max_concurrency则会接近concurrency，并通过定期衰减避免远离best_max_concurrency，保证服务不会过载。
 

--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -303,8 +303,8 @@ $ sh run_tests.sh
 ```shell
 $ mkdir -p ~/brpc
 $ cd ~/brpc
-$ git clone https://github.com/apache/incubator-brpc.git
-$ cd incubator-brpc
+$ git clone https://github.com/apache/brpc.git
+$ cd brpc
 $ docker build -t brpc:master .
 $ docker images
 $ docker run -it brpc:master /bin/bash

--- a/docs/en/bvar_c++.md
+++ b/docs/en/bvar_c++.md
@@ -180,9 +180,9 @@ int expose_as(const butil::StringPiece& prefix, const butil::StringPiece& name);
 ```
 # Export All Variables
 
-Common needs for exporting are querying by HTTP API and writing into local file, the former is provided by brpc [/vars](https://github.com/apache/incubator-brpc/blob/master/docs/cn/vars.md) service, the latter has been implemented in bvar, and it's turned off by default. A couple of methods can activate this function：
+Common needs for exporting are querying by HTTP API and writing into local file, the former is provided by brpc [/vars](https://github.com/apache/brpc/blob/master/docs/cn/vars.md) service, the latter has been implemented in bvar, and it's turned off by default. A couple of methods can activate this function：
 
--   Using [gflags](https://github.com/apache/incubator-brpc/blob/master/docs/cn/flags.md) to parse the input params. We can add `-bvar_dump` during the starup of program or we can dynamically change the params thru brpc [/flags](https://github.com/apache/incubator-brpc/blob/master/docs/cn/flags.md) service after starup. gflags parsing is as below
+-   Using [gflags](https://github.com/apache/brpc/blob/master/docs/cn/flags.md) to parse the input params. We can add `-bvar_dump` during the starup of program or we can dynamically change the params thru brpc [/flags](https://github.com/apache/brpc/blob/master/docs/cn/flags.md) service after starup. gflags parsing is as below
     ```C++
     #include <gflags/gflags.h>
     ...
@@ -224,7 +224,7 @@ Common needs for exporting are querying by HTTP API and writing into local file,
     
     such like we modify the gflags as below：
     
-    [![img](https://github.com/apache/incubator-brpc/raw/master/docs/images/bvar_dump_flags_2.png)](https://github.com/apache/incubator-brpc/blob/master/docs/images/bvar_dump_flags_2.png)
+    [![img](https://github.com/apache/brpc/raw/master/docs/images/bvar_dump_flags_2.png)](https://github.com/apache/brpc/blob/master/docs/images/bvar_dump_flags_2.png)
     
     exporting file will be like：
     ```

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -244,8 +244,8 @@ Compile brpc with docker:
 ```shell
 $ mkdir -p ~/brpc
 $ cd ~/brpc
-$ git clone https://github.com/apache/incubator-brpc.git
-$ cd incubator-brpc
+$ git clone https://github.com/apache/brpc.git
+$ cd brpc
 $ docker build -t brpc:master .
 $ docker images
 $ docker run -it brpc:master /bin/bash

--- a/example/build_with_bazel/brpc_workspace.bzl
+++ b/example/build_with_bazel/brpc_workspace.bzl
@@ -88,7 +88,7 @@ def brpc_workspace():
 
     http_archive(
         name = "apache_brpc",
-        strip_prefix = "incubator-brpc-1.3.0",
-        url = "https://github.com/apache/incubator-brpc/archive/refs/tags/1.3.0.tar.gz"
+        strip_prefix = "brpc-1.3.0",
+        url = "https://github.com/apache/brpc/archive/refs/tags/1.3.0.tar.gz"
     )
 

--- a/example/rdma_performance/client.cpp
+++ b/example/rdma_performance/client.cpp
@@ -314,7 +314,7 @@ int main(int argc, char* argv[]) {
 #else
 
 int main(int argc, char* argv[]) {
-    LOG(ERROR) << " brpc is not compiled with rdma. To enable it, please refer to https://github.com/apache/incubator-brpc/blob/master/docs/en/rdma.md";
+    LOG(ERROR) << " brpc is not compiled with rdma. To enable it, please refer to https://github.com/apache/brpc/blob/master/docs/en/rdma.md";
     return 0;
 }
 

--- a/example/rdma_performance/server.cpp
+++ b/example/rdma_performance/server.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
 
 
 int main(int argc, char* argv[]) {
-    LOG(ERROR) << " brpc is not compiled with rdma. To enable it, please refer to https://github.com/apache/incubator-brpc/blob/master/docs/en/rdma.md";
+    LOG(ERROR) << " brpc is not compiled with rdma. To enable it, please refer to https://github.com/apache/brpc/blob/master/docs/en/rdma.md";
     return 0;
 }
 

--- a/package/rpm/brpc.spec
+++ b/package/rpm/brpc.spec
@@ -24,7 +24,7 @@ Summary:	An industrial-grade RPC framework used throughout Baidu, with 1,000,000
 
 Group:		Development
 License:	Apache2
-URL:		https://github.com/apache/incubator-brpc
+URL:		https://github.com/apache/brpc
 Source0:	apache-brpc-%{version}-incubating-src.tar.gz
 
 # https://access.redhat.com/solutions/519993

--- a/src/brpc/builtin/pprof_service.cpp
+++ b/src/brpc/builtin/pprof_service.cpp
@@ -220,7 +220,7 @@ void PProfService::heap(
             extra_desc = " (no TCMALLOC_SAMPLE_PARAMETER in env)";
         }
         cntl->SetFailed(ENOMETHOD, "Heap profiler is not enabled%s,"
-                        "check out https://github.com/apache/incubator-brpc/blob/master/docs/cn/heap_profiler.md",
+                        "check out https://github.com/apache/brpc/blob/master/docs/cn/heap_profiler.md",
                         extra_desc);
         return;
     }

--- a/src/brpc/rdma/rdma_helper.cpp
+++ b/src/brpc/rdma/rdma_helper.cpp
@@ -657,7 +657,7 @@ namespace brpc {
 namespace rdma {
 void GlobalRdmaInitializeOrDie() {
     LOG(ERROR) << "brpc is not compiled with rdma. To enable it, please refer to "
-               << "https://github.com/apache/incubator-brpc/blob/master/docs/en/rdma.md";
+               << "https://github.com/apache/brpc/blob/master/docs/en/rdma.md";
     exit(1);
 }
 }

--- a/src/butil/errno.h
+++ b/src/butil/errno.h
@@ -24,7 +24,7 @@
 
 #ifndef __const__
 // Avoid over-optimizations of TLS variables by GCC>=4.8
-// See: https://github.com/apache/incubator-brpc/issues/1693
+// See: https://github.com/apache/brpc/issues/1693
 #define __const__ __unused__
 #endif
 


### PR DESCRIPTION
Since bRPC has graduated, we can remove `incubator` in the source code.