### PR TITLE
add max concurrency for timeout concurrency limiter

### DIFF
--- a/src/brpc/policy/timeout_concurrency_limiter.h
+++ b/src/brpc/policy/timeout_concurrency_limiter.h
@@ -27,7 +27,7 @@ class TimeoutConcurrencyLimiter : public ConcurrencyLimiter {
    public:
     TimeoutConcurrencyLimiter();
 
-    bool OnRequested(int, Controller* cntl) override;
+    bool OnRequested(int current_concurrency, Controller* cntl) override;
 
     void OnResponded(int error_code, int64_t latency_us) override;
 


### PR DESCRIPTION
基于延迟的并发控制，在average latency的统计还没有刷新的时候，有可能因为一些慢请求导致服务排队很多请求，这个最大并发的设置，可以在这种情况下保护服务不被太多的请求压垮。
@wwbmmm 请PR