### PR TITLE
show server concurrency in status service

### DIFF
--- a/src/brpc/builtin/status_service.cpp
+++ b/src/brpc/builtin/status_service.cpp
@@ -109,7 +109,25 @@ void StatusService::default_method(::google::protobuf::RpcController* cntl_base,
         os << mc;
     }
     os << '\n';
-    
+
+    // concurrency
+    if (use_html) {
+        os << "<p class=\"variable\">";
+    }
+    os << "concurrency: ";
+    if (use_html) {
+        os << "<span id=\"value-" << server->ServerPrefix()
+           << "_concurrency\">";
+    }
+    os << server->Concurrency();
+    if (use_html) {
+        os << "</span></p><div class=\"detail\"><div id=\""
+           << server->ServerPrefix()
+           << "_concurrency\" class=\"flot-placeholder\"></div></div>";
+    }
+    os << '\n';
+
+
     const Server::ServiceMap &services = server->_fullname_service_map;
     std::ostringstream desc;
     DescribeOptions desc_options;

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -272,6 +272,10 @@ static bvar::Vector<unsigned, 2> GetSessionLocalDataCount(void* arg) {
     return v;
 }
 
+static int cast_no_barrier_int(void* arg) {
+    return butil::subtle::NoBarrier_Load(static_cast<int*>(arg));
+}
+
 std::string Server::ServerPrefix() const {
     if(_options.server_info_name.empty()) {
         return butil::string_printf("%s_%d", g_server_info_prefix, listen_address().port);
@@ -291,6 +295,8 @@ void* Server::UpdateDerivedVars(void* arg) {
     server->_nerror_bvar.expose_as(prefix, "error");
 
     server->_eps_bvar.expose_as(prefix, "eps");
+
+    server->_concurrency_bvar.expose_as(prefix, "concurrency");
 
     bvar::PassiveStatus<timeval> uptime_st(
         prefix, "uptime", GetUptime, (void*)(intptr_t)start_us);
@@ -401,7 +407,8 @@ Server::Server(ProfilerLinker)
     , _derivative_thread(INVALID_BTHREAD)
     , _keytable_pool(NULL)
     , _eps_bvar(&_nerror_bvar)
-    , _concurrency(0) {
+    , _concurrency(0)
+    , _concurrency_bvar(cast_no_barrier_int, &_concurrency) {
     BAIDU_CASSERT(offsetof(Server, _concurrency) % 64 == 0,
                   Server_concurrency_must_be_aligned_by_cacheline);
 }

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -547,6 +547,10 @@ public:
     int MaxConcurrencyOf(google::protobuf::Service* service,
                          const butil::StringPiece& method_name) const;
 
+    int Concurrency() const {
+        return butil::subtle::NoBarrier_Load(&_concurrency);
+    };
+
 private:
 friend class StatusService;
 friend class ProtobufsService;
@@ -696,6 +700,7 @@ friend class Controller;
     mutable bvar::Adder<int64_t> _nerror_bvar;
     mutable bvar::PerSecond<bvar::Adder<int64_t> > _eps_bvar;
     BAIDU_CACHELINE_ALIGNMENT mutable int32_t _concurrency;
+    bvar::PassiveStatus<int32_t> _concurrency_bvar;
 };
 
 // Get the data attached to current searching thread. The data is created by


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary: 内置服务目前只展示了方法级别的并发数，并未展示server级别的并发数。

### What is changed and the side effects?

Changed:
增加bvar统计server级别的并发数，同时在内置服务页面展示该并发数。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
