### PR TITLE
check invalid port

### DIFF
--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -998,6 +998,10 @@ int Server::StartInternal(const butil::EndPoint& endpoint,
     }
     _listen_addr = endpoint;
     for (int port = port_range.min_port; port <= port_range.max_port; ++port) {
+        if (port < 0 || port > 65535) {
+            LOG(ERROR) << "Invalid port=" << port;
+            return -1;
+        }
         _listen_addr.port = port;
         butil::fd_guard sockfd(tcp_listen(_listen_addr));
         if (sockfd < 0) {
@@ -1047,6 +1051,10 @@ int Server::StartInternal(const butil::EndPoint& endpoint,
         break; // stop trying
     }
     if (_options.internal_port >= 0 && _options.has_builtin_services) {
+        if (_options.internal_port < 0 || _options.internal_port > 65535) {
+            LOG(ERROR) << "Invalid internal port=" << _options.internal_port;
+            return -1;
+        }
         if (_options.internal_port  == _listen_addr.port) {
             LOG(ERROR) << "ServerOptions.internal_port=" << _options.internal_port
                        << " is same with port=" << _listen_addr.port << " to Start()";
@@ -1143,10 +1151,6 @@ int Server::Start(const char* ip_port_str, const ServerOptions* opt) {
 }
 
 int Server::Start(int port, const ServerOptions* opt) {
-    if (port < 0 || port > 65535) {
-        LOG(ERROR) << "Invalid port=" << port;
-        return -1;
-    }
     return Start(butil::EndPoint(butil::IP_ANY, port), opt);
 }
 

--- a/test/brpc_server_unittest.cpp
+++ b/test/brpc_server_unittest.cpp
@@ -206,10 +206,30 @@ TEST_F(ServerTest, sanity) {
         ASSERT_EQ(-1, server.Start(99999, NULL));
         ASSERT_EQ(0, server.Start(8613, NULL));
     }
+
+    {
+        brpc::Server server1;
+        brpc::PortRange range1(65534, 65535);
+        ASSERT_EQ(0, server1.Start(range1, NULL));
+
+        brpc::Server server2;
+        ASSERT_EQ(0, server2.Start(range1, NULL));
+
+        brpc::Server server3;
+        ASSERT_EQ(-1, server3.Start(range1, NULL));
+
+        brpc::Server server4;
+        brpc::PortRange range4(65535, 65536);
+        ASSERT_EQ(-1, server4.Start(range4, NULL));
+    }
+
     {
         brpc::Server server;
         brpc::ServerOptions options;
         options.internal_port = 8613;          // The same as service port
+        ASSERT_EQ(-1, server.Start("127.0.0.1:8613", &options));
+        ASSERT_FALSE(server.IsRunning());      // Revert server's status
+        options.internal_port = 65536;          // Invalid port
         ASSERT_EQ(-1, server.Start("127.0.0.1:8613", &options));
         ASSERT_FALSE(server.IsRunning());      // Revert server's status
         // And release the listen port


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary: 目前未判断PortRange和internal_port的合法性，即使实际的port大于65535（不合法的port），Server::Start()也会返回成功。

### What is changed and the side effects?

Changed: 检查PortRange和internal_port是否合法，不合法则返回-1表示失败。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
