### PR TITLE
Periodic ns quit

### DIFF
--- a/src/brpc/periodic_naming_service.cpp
+++ b/src/brpc/periodic_naming_service.cpp
@@ -37,7 +37,7 @@ int PeriodicNamingService::RunNamingService(
     const char* service_name, NamingServiceActions* actions) {
     std::vector<ServerNode> servers;
     bool ever_reset = false;
-    for (;;) {
+    while (true) {
         servers.clear();
         const int rc = GetServers(service_name, &servers);
         if (bthread_stopped(bthread_self())) {

--- a/src/brpc/periodic_naming_service.cpp
+++ b/src/brpc/periodic_naming_service.cpp
@@ -40,10 +40,6 @@ int PeriodicNamingService::RunNamingService(
     while (true) {
         servers.clear();
         const int rc = GetServers(service_name, &servers);
-        if (bthread_stopped(bthread_self())) {
-            RPC_VLOG << "Quit NamingServiceThread=" << bthread_self();
-            return 0;
-        }
         if (rc == 0) {
             ever_reset = true;
             actions->ResetServers(servers);
@@ -55,6 +51,10 @@ int PeriodicNamingService::RunNamingService(
             actions->ResetServers(servers);
         }
 
+        if (bthread_stopped(bthread_self())) {
+            RPC_VLOG << "Quit NamingServiceThread=" << bthread_self();
+            return 0;
+        }
         if (bthread_usleep(GetNamingServiceAccessIntervalMs() * 1000UL) < 0) {
             if (errno == ESTOP) {
                 RPC_VLOG << "Quit NamingServiceThread=" << bthread_self();

--- a/src/brpc/periodic_naming_service.cpp
+++ b/src/brpc/periodic_naming_service.cpp
@@ -40,6 +40,10 @@ int PeriodicNamingService::RunNamingService(
     for (;;) {
         servers.clear();
         const int rc = GetServers(service_name, &servers);
+        if (bthread_stopped(bthread_self())) {
+            RPC_VLOG << "Quit NamingServiceThread=" << bthread_self();
+            return 0;
+        }
         if (rc == 0) {
             ever_reset = true;
             actions->ResetServers(servers);

--- a/src/brpc/periodic_naming_service.h
+++ b/src/brpc/periodic_naming_service.h
@@ -32,7 +32,7 @@ protected:
     virtual int GetNamingServiceAccessIntervalMs() const;
 
     int RunNamingService(const char* service_name,
-                         NamingServiceActions* actions);
+                         NamingServiceActions* actions) override;
 };
 
 } // namespace brpc

--- a/src/brpc/policy/consul_naming_service.cpp
+++ b/src/brpc/policy/consul_naming_service.cpp
@@ -62,6 +62,14 @@ std::string RapidjsonValueToString(const BUTIL_RAPIDJSON_NAMESPACE::Value& value
     return buffer.GetString();
 }
 
+ConsulNamingService::ConsulNamingService()
+    : _backup_file_loaded(false), _consul_connected(false) {}
+
+int ConsulNamingService::GetNamingServiceAccessIntervalMs() const {
+    return FLAGS_consul_retry_interval_ms > 0 ? FLAGS_consul_retry_interval_ms :
+        PeriodicNamingService::GetNamingServiceAccessIntervalMs();
+}
+
 int ConsulNamingService::DegradeToOtherServiceIfNeeded(const char* service_name,
                                                        std::vector<ServerNode>* servers) {
     if (FLAGS_consul_enable_degrade_to_file_naming_service && !_backup_file_loaded) {
@@ -209,47 +217,9 @@ int ConsulNamingService::GetServers(const char* service_name,
     return 0;
 }
 
-int ConsulNamingService::RunNamingService(const char* service_name,
-                                          NamingServiceActions* actions) {
-    std::vector<ServerNode> servers;
-    bool ever_reset = false;
-    for (;;) {
-        servers.clear();
-        const int rc = GetServers(service_name, &servers);
-        if (bthread_stopped(bthread_self())) {
-            RPC_VLOG << "Quit NamingServiceThread=" << bthread_self();
-            return 0;
-        }
-        if (rc == 0) {
-            ever_reset = true;
-            actions->ResetServers(servers);
-        } else {
-            if (!ever_reset) {
-                // ResetServers must be called at first time even if GetServers
-                // failed, to wake up callers to `WaitForFirstBatchOfServers'
-                ever_reset = true;
-                servers.clear();
-                actions->ResetServers(servers);
-            }
-            if (bthread_usleep(std::max(FLAGS_consul_retry_interval_ms, 1) * butil::Time::kMicrosecondsPerMillisecond) < 0) {
-                if (errno == ESTOP) {
-                    RPC_VLOG << "Quit NamingServiceThread=" << bthread_self();
-                    return 0;
-                }
-                PLOG(FATAL) << "Fail to sleep";
-                return -1;
-            }
-        }
-    }
-    CHECK(false);
-    return -1;
-}
-
-
 void ConsulNamingService::Describe(std::ostream& os,
                                    const DescribeOptions&) const {
     os << "consul";
-    return;
 }
 
 NamingService* ConsulNamingService::New() const {

--- a/src/brpc/policy/consul_naming_service.h
+++ b/src/brpc/policy/consul_naming_service.h
@@ -19,7 +19,7 @@
 #ifndef  BRPC_POLICY_CONSUL_NAMING_SERVICE
 #define  BRPC_POLICY_CONSUL_NAMING_SERVICE
 
-#include "brpc/naming_service.h"
+#include "brpc/periodic_naming_service.h"
 #include "brpc/channel.h"
 
 
@@ -27,13 +27,15 @@ namespace brpc {
 class Channel;
 namespace policy {
 
-class ConsulNamingService : public NamingService {
-private:
-    int RunNamingService(const char* service_name,
-                         NamingServiceActions* actions) override;
+class ConsulNamingService : public PeriodicNamingService {
+public:
+    ConsulNamingService();
 
+private:
     int GetServers(const char* service_name,
-                   std::vector<ServerNode>* servers);
+                   std::vector<ServerNode>* servers) override;
+
+    int GetNamingServiceAccessIntervalMs() const override;
 
     void Describe(std::ostream& os, const DescribeOptions&) const override;
 
@@ -48,8 +50,8 @@ private:
     Channel _channel;
     std::string _consul_index;
     std::string _consul_url;
-    bool _backup_file_loaded = false;
-    bool _consul_connected = false;
+    bool _backup_file_loaded;
+    bool _consul_connected;
 };
 
 }  // namespace policy


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #584

Problem Summary: 继承自PeriodicNamingService的ns，例如DiscoveryNamingService、NacosNamingService、RemoteFileNamingService，在GetServers中通过rpc拉取节点的时候，NamingServiceThread析构调用bthread_stop并不能中断CallMethod，CallMethod只是被唤醒了一下，而且将interrupted置会为false，CallMethod依然会等到rpc结束。但是这时候bthread_usleep已经不能感知到bthread_interrupt而退出了。

### What is changed and the side effects?

1. PeriodicNamingService通过判断bthread_stopped来退出。
2. ConsulNamingService本质上是一个PeriodicNamingService，将其抽象为PeriodicNamingService的派生类。

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
