### PR TITLE
[draft]减少 lock 代码

### DIFF
--- a/src/butil/scoped_lock.h
+++ b/src/butil/scoped_lock.h
@@ -36,15 +36,8 @@
 #else
 
 // NOTE(gejun): c++11 deduces additional reference to the type.
-namespace butil {
-namespace detail {
-template <typename T>
-std::lock_guard<typename std::remove_reference<T>::type> get_lock_guard();
-}  // namespace detail
-}  // namespace butil
-
-#define BAIDU_SCOPED_LOCK(ref_of_lock)                                  \
-    decltype(::butil::detail::get_lock_guard<decltype(ref_of_lock)>()) \
+#define BAIDU_SCOPED_LOCK(ref_of_lock)                                            \
+    std::lock_guard<typename std::remove_reference<decltype(ref_of_lock)>::type>  \
     BAIDU_CONCAT(scoped_locker_dummy_at_line_, __LINE__)(ref_of_lock)
 #endif
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
`std::lock_guard<typename std::remove_reference<T>::type> get_lock_guard();` 
我对这里的实现不太理解：为什么要通过定义一个 get_lock_guard 函数（我理解是个函数？），来多套了一层？
我理解这里的目的是为了在传入引入类型时，把引用去掉。直接用这个 mr 中改动的代码，看起来也没有问题。
也怀疑可能是不同的操作系统或者编译器对 lock_guard 或者 remove_reference 的实现有区别，不过看这个 mr 的 check，在 linux 和 mac 上针对 g++ 和 clang 都能编译成功，看起来也不是操作系统或者编译器的问题。
哪位大佬能帮忙解答下 get_lock_guard 的目的么？

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
