### PR TITLE
revert consul naming service

### DIFF
--- a/src/brpc/periodic_naming_service.cpp
+++ b/src/brpc/periodic_naming_service.cpp
@@ -51,6 +51,12 @@ int PeriodicNamingService::RunNamingService(
             actions->ResetServers(servers);
         }
 
+        // If `bthread_stop' is called to stop the ns bthread when `brpc::Join‘ is called
+        // in `GetServers' to wait for a rpc to complete. The bthread will be woken up,
+        // reset `TaskMeta::interrupted' and continue to join the rpc. After the rpc is complete,
+        // `bthread_usleep' will not sense the interrupt signal and sleep successfully.
+        // Finally, the ns bthread will never exit. So need to check the stop status of
+        // the bthread here and exit the bthread in time.
         if (bthread_stopped(bthread_self())) {
             RPC_VLOG << "Quit NamingServiceThread=" << bthread_self();
             return 0;

--- a/src/brpc/policy/consul_naming_service.h
+++ b/src/brpc/policy/consul_naming_service.h
@@ -48,8 +48,8 @@ private:
     Channel _channel;
     std::string _consul_index;
     std::string _consul_url;
-    bool _backup_file_loaded;
-    bool _consul_connected;
+    bool _backup_file_loaded = false;
+    bool _consul_connected = false;
 };
 
 }  // namespace policy

--- a/src/brpc/policy/consul_naming_service.h
+++ b/src/brpc/policy/consul_naming_service.h
@@ -19,7 +19,7 @@
 #ifndef  BRPC_POLICY_CONSUL_NAMING_SERVICE
 #define  BRPC_POLICY_CONSUL_NAMING_SERVICE
 
-#include "brpc/periodic_naming_service.h"
+#include "brpc/naming_service.h"
 #include "brpc/channel.h"
 
 
@@ -27,15 +27,13 @@ namespace brpc {
 class Channel;
 namespace policy {
 
-class ConsulNamingService : public PeriodicNamingService {
-public:
-    ConsulNamingService();
-
+class ConsulNamingService : public NamingService {
 private:
-    int GetServers(const char* service_name,
-                   std::vector<ServerNode>* servers) override;
+    int RunNamingService(const char* service_name,
+                         NamingServiceActions* actions) override;
 
-    int GetNamingServiceAccessIntervalMs() const override;
+    int GetServers(const char* service_name,
+                   std::vector<ServerNode>* servers);
 
     void Describe(std::ostream& os, const DescribeOptions&) const override;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2123 

Problem Summary:
ConsulNamingService其实不是PeriodicNamingService，不是简单的轮询，而是[长轮询](https://brpc.incubator.apache.org/zh/docs/client/basics/#consulservice-name)，每次rpc成功后，立即发起下一次长轮询。只有失败了，才会sleep。
   [Blocking Queries](https://developer.hashicorp.com/consul/api-docs/features/blocking)：
   > Many endpoints in Consul support a feature known as "blocking queries". A blocking query is used to wait for a potential change using long polling.
  
### What is changed and the side effects?

Changed:
回退#2123 ConsulNamingService的改动

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
