### PR TITLE
修复CI流水线编译失败的问题

### DIFF
--- a/.github/actions/init-make-config/action.yml
+++ b/.github/actions/init-make-config/action.yml
@@ -5,5 +5,5 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: sh config_brpc.sh --headers="/usr/local/include /usr/include" --libs="/usr/local/lib /usr/local/lib64 /usr/lib /usr/lib64" --nodebugsymbols ${{inputs.options}}
+    - run: sh config_brpc.sh --headers="/usr/include" --libs="/usr/lib /usr/lib64" --nodebugsymbols ${{inputs.options}}
       shell: bash


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
CI流水线make编译会报错：`Fail to find libprotoc`
原因是config_brpc.sh脚本在寻找protobuf的时候找到了这个目录`/usr/local/lib/android/sdk/emulator/lib64` 中的protobuf，而这个目录中并没有libprotoc，应该找`/usr/lib/x86_64-linux-gnu` 中的protobuf。



### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
