### PR TITLE
naming timer sampling and worker threads

### DIFF
--- a/src/brpc/details/usercode_backup_pool.cpp
+++ b/src/brpc/details/usercode_backup_pool.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <gflags/gflags.h>
 #include "butil/scoped_lock.h"
+#include "butil/threading/platform_thread.h"
 #ifdef BAIDU_INTERNAL
 #include "butil/comlog_sink.h"
 #endif
@@ -91,6 +92,7 @@ UserCodeBackupPool::UserCodeBackupPool()
 }
 
 static void* UserCodeRunner(void* args) {
+    butil::PlatformThread::SetName("brpc_user_code_runner");
     static_cast<UserCodeBackupPool*>(args)->UserCodeRunningLoop();
     return NULL;
 }

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -98,6 +98,7 @@ private:
     bool _stop;
     butil::atomic<int> _concurrency;
     std::vector<pthread_t> _workers;
+    butil::atomic<int> _next_worker_id;
 
     bvar::Adder<int64_t> _nworkers;
     butil::Mutex _pending_time_mutex;

--- a/src/bthread/timer_thread.cpp
+++ b/src/bthread/timer_thread.cpp
@@ -23,6 +23,7 @@
 #include "butil/logging.h"
 #include "butil/third_party/murmurhash3/murmurhash3.h"   // fmix64
 #include "butil/resource_pool.h"
+#include "butil/threading/platform_thread.h"
 #include "bvar/bvar.h"
 #include "bthread/sys_futex.h"
 #include "bthread/timer_thread.h"
@@ -117,6 +118,7 @@ inline bool task_greater(const TimerThread::Task* a, const TimerThread::Task* b)
 }
 
 void* TimerThread::run_this(void* arg) {
+    butil::PlatformThread::SetName("brpc_timer");
     static_cast<TimerThread*>(arg)->run();
     return NULL;
 }

--- a/src/bvar/collector.cpp
+++ b/src/bvar/collector.cpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <gflags/gflags.h>
 #include "butil/memory/singleton_on_pthread_once.h"
+#include "butil/threading/platform_thread.h"
 #include "bvar/bvar.h"
 #include "bvar/collector.h"
 
@@ -76,11 +77,13 @@ private:
                             int64_t interval_us);
 
     static void* run_grab_thread(void* arg) {
+        butil::PlatformThread::SetName("bvar_collector_grabber");
         static_cast<Collector*>(arg)->grab_thread();
         return NULL;
     }
 
     static void* run_dump_thread(void* arg) {
+        butil::PlatformThread::SetName("bvar_collector_dumper");
         static_cast<Collector*>(arg)->dump_thread();
         return NULL;
     }

--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -18,6 +18,7 @@
 // Date: Tue Jul 28 18:14:40 CST 2015
 
 #include <gflags/gflags.h>
+#include "butil/threading/platform_thread.h"
 #include "butil/time.h"
 #include "butil/memory/singleton_on_pthread_once.h"
 #include "bvar/reducer.h"
@@ -108,6 +109,7 @@ private:
     void run();
 
     static void* sampling_thread(void* arg) {
+        butil::PlatformThread::SetName("brpc_sampling");
         static_cast<SamplerCollector*>(arg)->run();
         return NULL;
     }

--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -109,7 +109,7 @@ private:
     void run();
 
     static void* sampling_thread(void* arg) {
-        butil::PlatformThread::SetName("brpc_sampling");
+        butil::PlatformThread::SetName("bvar_sampler");
         static_cast<SamplerCollector*>(arg)->run();
         return NULL;
     }

--- a/src/bvar/variable.cpp
+++ b/src/bvar/variable.cpp
@@ -29,6 +29,7 @@
 #include "butil/errno.h"                         // berror
 #include "butil/time.h"                          // milliseconds_from_now
 #include "butil/file_util.h"                     // butil::FilePath
+#include "butil/threading/platform_thread.h"
 #include "bvar/gflag.h"
 #include "bvar/variable.h"
 #include "bvar/mvariable.h"
@@ -728,6 +729,7 @@ static GFlag s_gflag_bvar_dump_interval("bvar_dump_interval");
 static void* dumping_thread(void*) {
     // NOTE: this variable was declared as static <= r34381, which was
     // destructed when program exits and caused coredumps.
+    butil::PlatformThread::SetName("bvar_dumper");
     const std::string command_name = read_command_name();
     std::string last_filename;
     std::string mbvar_last_filename;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/apache/brpc/issues/1923

Problem Summary: Naming threads for debugging.

线程命名方式： `brpc` 开头 + `线程用途`。
其中 worker 线程以 id 作为区分。

### What is changed and the side effects?
No
Changed:
Naming sampling, timer and worker threads.
Side effects:
- Performance effects(性能影响):
No
- Breaking backward compatibility(向后兼容性): 
No
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
