### PR TITLE
add type BasicStringPiece::const_pointer, make it like string_view and more convenient

### DIFF
--- a/src/butil/strings/string_piece.h
+++ b/src/butil/strings/string_piece.h
@@ -165,6 +165,7 @@ template <typename STRING_TYPE> class BasicStringPiece {
   typedef size_t size_type;
   typedef typename STRING_TYPE::value_type value_type;
   typedef const value_type* pointer;
+  typedef const value_type* const_pointer;
   typedef const value_type& reference;
   typedef const value_type& const_reference;
   typedef ptrdiff_t difference_type;


### PR DESCRIPTION
### What problem does this PR solve?

add type BasicStringPiece::const_pointer, make it like [string_view](https://en.cppreference.com/w/cpp/string/basic_string_view) and more convenient.

e.g. we can using butil::StringPiece as a  key to invoking folly::F14FastMap [heterogeneous accessing method](https://github.com/facebook/folly/blob/main/folly/container/HeterogeneousAccess.h#L158-L183) by this mr make butil::StringPiece like string_view which can implicitly convert to [folly::StringPiece](https://github.com/facebook/folly/blob/main/folly/Range.h#L278-L333)


### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):
none
- Breaking backward compatibility(向后兼容性): 
none
---
