### PR TITLE
Update work_stealing_queue.h

### DIFF
--- a/src/bthread/work_stealing_queue.h
+++ b/src/bthread/work_stealing_queue.h
@@ -124,6 +124,10 @@ public:
         do {
             butil::atomic_thread_fence(butil::memory_order_seq_cst);
             b = _bottom.load(butil::memory_order_acquire);
+            
+            // If not get t again and another steal() happens
+            // after the first getting, it might stuck in a dead circle
+            t = _top.load(butil::memory_order_acquire);
             if (t >= b) {
                 return false;
             }


### PR DESCRIPTION
### What problem does this PR solve?
Steal() method might stuck into a dead circle without setting t = _top in the circle.
And there are some unnecessary memory order or fence in some methods.

Issue Number: #2147

Problem Summary:

### What is changed and the side effects?

Better performance.

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
