### PR TITLE
fix gtest build cmd in doc

### DIFF
--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -38,7 +38,7 @@ sudo apt-get install -y libgoogle-perftools-dev
 
 如果你要运行测试，那么要安装并编译libgtest-dev（它没有被默认编译）：
 ```shell
-sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
+sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv lib/libgtest* /usr/lib/ && cd -
 ```
 gtest源码目录可能变动，如果`/usr/src/gtest`不存在，请尝试`/usr/src/googletest/googletest`。
 

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -38,7 +38,7 @@ sudo apt-get install -y libgoogle-perftools-dev
 
 If you need to run tests, install and compile libgtest-dev (which is not compiled yet):
 ```shell
-sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -
+sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv lib/libgtest* /usr/lib/ && cd -
 ```
 The directory of gtest source code may be changed, try `/usr/src/googletest/googletest` if `/usr/src/gtest` is not there.
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

Original cmd `sudo apt-get install -y cmake libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libgtest* /usr/lib/ && cd -` does not work:

```
➜  /usr/src/gtest $ sudo make && sudo mv libgtest* /usr/lib
[ 25%] Building CXX object CMakeFiles/gtest.dir/src/gtest-all.cc.o
[ 50%] Linking CXX static library lib/libgtest.a
[ 50%] Built target gtest
[ 75%] Building CXX object CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
[100%] Linking CXX static library lib/libgtest_main.a
[100%] Built target gtest_main
zsh: no matches found: libgtest*
```

### What is changed and the side effects?

Changed:
Fix the gtest library path to `sudo mv lib/libgtest* /usr/lib` from `sudo mv libgtest* /usr/lib`.

Side effects:
- Performance effects(性能影响): N/A

- Breaking backward compatibility(向后兼容性): N/A

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
