### PR TITLE
fix compiler optimize thread local variable access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(WITH_RDMA "With RDMA" OFF)
 option(BUILD_UNIT_TESTS "Whether to build unit tests" OFF)
 option(BUILD_BRPC_TOOLS "Whether to build brpc tools" ON)
 option(DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." ON)
+option(NOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS "Whether to disable compiler optimize thread local variable access." OFF)
 
 # Enable MACOSX_RPATH. Run "cmake --help-policy CMP0042" for policy details.
 if(POLICY CMP0042)
@@ -110,6 +111,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         set(DEFINE_CLOCK_GETTIME "-DNO_CLOCK_GETTIME_IN_MAC")
     endif()
     set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -Wno-deprecated-declarations -Wno-inconsistent-missing-override")
+endif()
+
+if(NOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS)
+    set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DNOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS")
 endif()
 
 set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DBRPC_WITH_RDMA=${WITH_RDMA_VAL} -DGFLAGS_NS=${GFLAGS_NS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ option(WITH_RDMA "With RDMA" OFF)
 option(BUILD_UNIT_TESTS "Whether to build unit tests" OFF)
 option(BUILD_BRPC_TOOLS "Whether to build brpc tools" ON)
 option(DOWNLOAD_GTEST "Download and build a fresh copy of googletest. Requires Internet access." ON)
-option(NOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS "Whether to disable compiler optimize thread local variable access." OFF)
 
 # Enable MACOSX_RPATH. Run "cmake --help-policy CMP0042" for policy details.
 if(POLICY CMP0042)
@@ -113,10 +112,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -Wno-deprecated-declarations -Wno-inconsistent-missing-override")
 endif()
 
-if(NOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS)
-    set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DNOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS")
-endif()
-
 set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DBRPC_WITH_RDMA=${WITH_RDMA_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
 if(WITH_MESALINK)
     set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DUSE_MESALINK")
@@ -153,6 +148,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0))
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-aligned-new")
     endif()
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(AppleClang)|(Clang)" AND CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64)|(arm64)")
+    # disable thread local access optimization.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS")
 endif()
 
 find_package(Protobuf REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,11 +150,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "(AppleClang)|(Clang)" AND CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64)|(arm64)")
-    # disable thread local access optimization.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS")
-endif()
-
 find_package(Protobuf REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/src/butil/thread_local.h
+++ b/src/butil/thread_local.h
@@ -30,6 +30,32 @@
 #define BAIDU_THREAD_LOCAL __thread
 #endif  // _MSC_VER
 
+#define BAIDU_VOLATILE_THREAD_LOCAL(type, var_name, default_value)             \
+  __thread type var_name = default_value;                                      \
+  static __attribute__((noinline, unused)) type get_##var_name(void) {         \
+    asm volatile("");                                                          \
+    return var_name;                                                           \
+  }                                                                            \
+  static __attribute__((noinline, unused)) type *get_ptr_##var_name(void) {    \
+    type *ptr = &var_name;                                                     \
+    asm volatile("" : "+rm"(ptr));                                             \
+    return ptr;                                                                \
+  }                                                                            \
+  static __attribute__((noinline, unused)) void set_##var_name(type v) {       \
+    asm volatile("");                                                          \
+    var_name = v;                                                              \
+  }
+
+#if defined(NOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS)
+#define BAIDU_GET_VOLATILE_THREAD_LOCAL(var_name) get_##var_name()
+#define BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(var_name) get_ptr_##var_name()
+#define BAIDU_SET_VOLATILE_THREAD_LOCAL(var_name, value) set_##var_name(value)
+#else
+#define BAIDU_GET_VOLATILE_THREAD_LOCAL(var_name) var_name
+#define BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(var_name) &##var_name
+#define BAIDU_SET_VOLATILE_THREAD_LOCAL(var_name, value) var_name = value
+#endif
+
 namespace butil {
 
 // Get a thread-local object typed T. The object will be default-constructed

--- a/src/butil/thread_local.h
+++ b/src/butil/thread_local.h
@@ -31,7 +31,7 @@
 #endif  // _MSC_VER
 
 #define BAIDU_VOLATILE_THREAD_LOCAL(type, var_name, default_value)             \
-  __thread type var_name = default_value;                                      \
+  BAIDU_THREAD_LOCAL type var_name = default_value;                                      \
   static __attribute__((noinline, unused)) type get_##var_name(void) {         \
     asm volatile("");                                                          \
     return var_name;                                                           \

--- a/src/butil/thread_local.h
+++ b/src/butil/thread_local.h
@@ -46,7 +46,10 @@
     var_name = v;                                                              \
   }
 
-#if defined(NOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS)
+#if defined(__clang__) && (defined(__aarch64__) || defined(__arm64__))
+// Clang compiler is incorrectly caching the address of thread_local variables
+// across a suspend-point. The following macros used to disable the volatile
+// thread local access optimization.
 #define BAIDU_GET_VOLATILE_THREAD_LOCAL(var_name) get_##var_name()
 #define BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(var_name) get_ptr_##var_name()
 #define BAIDU_SET_VOLATILE_THREAD_LOCAL(var_name, value) set_##var_name(value)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:https://github.com/apache/brpc/issues/1776, https://github.com/apache/brpc/issues/1407, https://github.com/apache/brpc/issues/845,https://github.com/apache/brpc/issues/1860, https://github.com/apache/brpc/issues/1860, https://github.com/apache/doris/pull/13270 

Problem Summary:
一些编译器会优化 thread_local 的变量的读写，在同一个函数中间如果再次获取相同变量的值时，会直接从缓存的地址里面进行加载。但是如果在函数过程中间，线程发生切换（ bthread 切换到另一个线程执行)，那么 thread_local 变量需要重新获当前运行线程的，而不应该使用之前的旧值。

经测试，Apple M1 Apple clang version 14.0.0, 编译依然存在该问题：
task_runner 函数的部分汇编代码：
```
 1923 00000000000017cc <__ZN7bthread9TaskGroup11task_runnerEl>:
 1924 ; void TaskGroup::task_runner(intptr_t skip_remained) {
 1925     17cc: ff c3 03 d1   sub     sp, sp, #240
 1926     17d0: fd 7b 0e a9   stp     x29, x30, [sp, #224]
 1927     17d4: fd 83 03 91   add     x29, sp, #224
 1928     17d8: e8 03 00 aa   mov     x8, x0
 1929     17dc: 00 00 00 90   adrp    x0, 0x1000 <__ZN7bthread9TaskGroup11task_runnerEl+0x10>
 1930     17e0: 00 00 40 f9   ldr     x0, [x0]
 1931     17e4: 09 00 40 f9   ldr     x9, [x0]
 1932     17e8: 20 01 3f d6   blr     x9
 1933     17ec: e0 33 00 f9   str     x0, [sp, #96]
 1934     17f0: 00 00 00 90   adrp    x0, 0x1000 <__ZN7bthread9TaskGroup11task_runnerEl+0x24>
 1935     17f4: 00 00 40 f9   ldr     x0, [x0]
 1936     17f8: 09 00 40 f9   ldr     x9, [x0]
 1937     17fc: 20 01 3f d6   blr     x9
 1938     1800: e9 03 00 aa   mov     x9, x0
 1939     1804: e0 33 40 f9   ldr     x0, [sp, #96]
 1940     1808: e9 37 00 f9   str     x9, [sp, #104]
 1941     180c: a8 83 1f f8   stur    x8, [x29, #-8]
 1942 ;     TaskGroup* g = tls_task_group; // first load tls_task_group
 1943     1810: 08 00 40 f9   ldr     x8, [x0]
 1944     1814: a8 03 1f f8   stur    x8, [x29, #-16]
 ....
 2039     1934: 00 00 00 94   bl      0x1934 <__ZN7bthread9TaskGroup11task_runnerEl+0x168>
 2040     1938: 01 00 00 14   b       0x193c <__ZN7bthread9TaskGroup11task_runnerEl+0x170>
 2041     193c: e8 33 40 f9   ldr     x8, [sp, #96]
 2042 ;         g =  tls_task_group; // thread maybe changed, but load tls_task_group form [x8]
 2043     1940: 08 01 40 f9   ldr     x8, [x8]
 2044     1944: a8 03 1f f8   stur    x8, [x29, #-16]
 2045 ;         if (m->attr.flags & BTHREAD_LOG_START_AND_FINISH) {
```

1933 处首次读取了 tls_task_group，并放入了 `[sp, #96]` 位置，2043 行时，线程可能已经切换，但是依然从 `[sp, #96]`处中加载 tls_task_group ，导致读取到了上一个旧值。导致错误发生。

gcc 通过开启 fno-gcse 选项禁止该优化，clang 未能找到对应控制选项。

参考： 
1. [how-to-disable-clang-expression-elimination-for-thread-local-variable](https://stackoverflow.com/questions/75592038/how-to-disable-clang-expression-elimination-for-thread-local-variable/75622732#75622732)
2. [qemu QEMU_DEFINE_STATIC_CO_TLS](https://github.com/qemu/qemu/blob/d7e2fe4aac8b74bbfe82b2309536528b4dbe0d34/include/qemu/coroutine-tls.h#L153-L163)
3. https://bugs.llvm.org/show_bug.cgi?id=19177
4. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26461 
5. https://github.com/llvm/llvm-project/issues/47179
### What is changed and the side effects?

Changed:
1. 新增 `NOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS` 用于控制是否允许编译器优化，如果为 true 是，对应的  thread local 变量必须通过 noinline 的函数调用方式来获取最新值，绕开编译器的优化。
Side effects:
- Performance effects(性能影响):
如果开启 `NOT_ALLOW_OPTIMIZE_THREAD_LOCAL_ACCESS` , 会造成多一次的函数调用开销。
- Breaking backward compatibility(向后兼容性): 
无
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
