### PR TITLE
fix some codes that violates the C++ One Definition Rule [-Wodr]

### DIFF
--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -275,6 +275,7 @@ void SendRpcResponse(int64_t correlation_id,
     }
 }
 
+namespace {
 struct CallMethodInBackupThreadArgs {
     ::google::protobuf::Service* service;
     const ::google::protobuf::MethodDescriptor* method;
@@ -283,6 +284,7 @@ struct CallMethodInBackupThreadArgs {
     ::google::protobuf::Message* response;
     ::google::protobuf::Closure* done;
 };
+}
 
 static void CallMethodInBackupThread(void* void_args) {
     CallMethodInBackupThreadArgs* args = (CallMethodInBackupThreadArgs*)void_args;

--- a/src/brpc/policy/nshead_protocol.cpp
+++ b/src/brpc/policy/nshead_protocol.cpp
@@ -169,6 +169,7 @@ ParseResult ParseNsheadMessage(butil::IOBuf* source,
     return MakeMessage(msg);
 }
 
+namespace {
 struct CallMethodInBackupThreadArgs {
     NsheadService* service;
     const Server* server;
@@ -177,6 +178,7 @@ struct CallMethodInBackupThreadArgs {
     NsheadMessage* response;
     NsheadClosure* done;
 };
+}
 
 static void CallMethodInBackupThread(void* void_args) {
     CallMethodInBackupThreadArgs* args = (CallMethodInBackupThreadArgs*)void_args;

--- a/src/brpc/policy/thrift_protocol.cpp
+++ b/src/brpc/policy/thrift_protocol.cpp
@@ -414,6 +414,7 @@ inline void ProcessThriftFramedRequestNoExcept(ThriftService* service,
     done->ResumeRunning();
 }
 
+namespace {
 struct CallMethodInBackupThreadArgs {
     ThriftService* service;
     Controller* controller;
@@ -421,6 +422,7 @@ struct CallMethodInBackupThreadArgs {
     ThriftFramedMessage* response;
     ThriftClosure* done;
 };
+}
 
 static void CallMethodInBackupThread(void* void_args) {
     CallMethodInBackupThreadArgs* args = (CallMethodInBackupThreadArgs*)void_args;

--- a/src/butil/popen.cpp
+++ b/src/butil/popen.cpp
@@ -29,7 +29,7 @@
 #include <sys/wait.h>
 
 extern "C" {
-uint64_t BAIDU_WEAK bthread_usleep(uint64_t microseconds);
+int BAIDU_WEAK bthread_usleep(uint64_t microseconds);
 }
 #endif
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Fix some codes that violates the C++ One Definition Rule, which stop us to enable [LTO](https://gcc.gnu.org/wiki/LinkTimeOptimization) feature

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):
none
- Breaking backward compatibility(向后兼容性): 
none
---

