### PR TITLE
Fix not end wait when ns fails to start

### DIFF
--- a/src/brpc/details/naming_service_thread.h
+++ b/src/brpc/details/naming_service_thread.h
@@ -66,11 +66,11 @@ class NamingServiceThread : public SharedObject, public Describable {
     };
     class Actions : public NamingServiceActions {
     public:
-        Actions(NamingServiceThread* owner);
-        ~Actions();
-        void AddServers(const std::vector<ServerNode>& servers);
-        void RemoveServers(const std::vector<ServerNode>& servers);
-        void ResetServers(const std::vector<ServerNode>& servers);
+        explicit Actions(NamingServiceThread* owner);
+        ~Actions() override;
+        void AddServers(const std::vector<ServerNode>& servers) override;
+        void RemoveServers(const std::vector<ServerNode>& servers) override;
+        void ResetServers(const std::vector<ServerNode>& servers) override;
         int WaitForFirstBatchOfServers();
         void EndWait(int error_code);
 
@@ -90,19 +90,20 @@ class NamingServiceThread : public SharedObject, public Describable {
 
 public:    
     NamingServiceThread();
-    ~NamingServiceThread();
+    ~NamingServiceThread() override;
 
     int Start(NamingService* ns,
               const std::string& protocol,
               const std::string& service_name,
               const GetNamingServiceThreadOptions* options);
     int WaitForFirstBatchOfServers();
+    void EndWait(int error_code);
 
     int AddWatcher(NamingServiceWatcher* w, const NamingServiceFilter* f);
     int AddWatcher(NamingServiceWatcher* w) { return AddWatcher(w, NULL); }
     int RemoveWatcher(NamingServiceWatcher* w);
 
-    void Describe(std::ostream& os, const DescribeOptions&) const;
+    void Describe(std::ostream& os, const DescribeOptions&) const override;
 
 private:
     void Run();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

当channel并发Init的时候，其中一个线程负责Start ns，其他线程则WaitForFirstBatchOfServers。这时候如果Start失败了，并没有唤醒其他线程，其他线程则会一直在等。

### What is changed and the side effects?

Start失败则通过EndWait唤醒其他线程。


Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
