### PR TITLE
Update workflows to skip builds for markdown-file-only changes

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -3,8 +3,12 @@ name: Build and Test on Linux
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
 
 env:
   proc_num: $(nproc)

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -3,8 +3,12 @@ name: Build on Macos
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
 
 env:
   proc_num: $(sysctl -n hw.logicalcpu)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary: 
- The entire GitHub workflow is run, even for changes that do not require a build, such as for markdown file changes. This [PR](https://github.com/apache/brpc/pull/2153) is an example of the entire workflow being run for an update to the `oncall.md` file. It takes approximately 30 minutes for the entire Github CI workflow to run and developers commit a standalone markdown file change at least 2 times per month.

### What is changed and the side effects?

Changed:
- Update GitHub workflow files to skip the `ci-linux` and `ci-macos` workflows for pushes and pull requests when the only changes are to markdown files. The result is less time spent waiting for builds to pass on both pushes and pull requests for Markdown file changes, which currently takes 30 minutes. Now, only the license check should run, which takes under 2 minutes.

Side effects:
- Performance effects(性能影响): N/A

- Breaking backward compatibility(向后兼容性): No

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
