### PR TITLE
Fix domain naming service host name buffer length

### DIFF
--- a/src/brpc/policy/domain_naming_service.cpp
+++ b/src/brpc/policy/domain_naming_service.cpp
@@ -23,6 +23,7 @@
 #include "bthread/bthread.h"
 #include "brpc/log.h"
 #include "brpc/policy/domain_naming_service.h"
+#include "butil/logging.h"
 
 DEFINE_bool(dns_support_ipv6, false, "Resolve DNS by IPV6 address first");
 
@@ -42,7 +43,7 @@ int DomainNamingService::GetServers(const char* dns_name,
     }
 
     // Should be enough to hold host name
-    char buf[128];
+    char buf[256];
     size_t i = 0;
     for (; i < sizeof(buf) - 1 && dns_name[i] != '\0'
              && dns_name[i] != ':' && dns_name[i] != '/'; ++i) {

--- a/src/brpc/policy/domain_naming_service.cpp
+++ b/src/brpc/policy/domain_naming_service.cpp
@@ -23,7 +23,6 @@
 #include "bthread/bthread.h"
 #include "brpc/log.h"
 #include "brpc/policy/domain_naming_service.h"
-#include "butil/logging.h"
 
 DEFINE_bool(dns_support_ipv6, false, "Resolve DNS by IPV6 address first");
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:https://github.com/apache/brpc/issues/1911

Problem Summary:
hostname maybe exceed to 128 bytes according to [RFC 1035 section 2.3.4](http://www.freesoft.org/CIE/RFC/1035/9.htm).

https://github.com/apache/brpc/pull/1965 has fixed this problem, but missing `src/brpc/policy/domain_naming_service.cpp` .
### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
