### PR TITLE
Update CI check in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before the PR:
 
 After the PR:
 
-* Make sure the [travis-ci](https://app.travis-ci.com/github/apache/brpc/pull_requests) passed.
+* Make sure the [GitHub Actions](https://github.com/apache/brpc/actions) passed.
 
 # Chinese version
 
@@ -26,4 +26,4 @@ After the PR:
 
 提交PR后请确认：
 
-* [travis-ci](https://app.travis-ci.com/github/apache/brpc/pull_requests)成功通过。
+* [GitHub Actions](https://github.com/apache/brpc/actions)成功通过。


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:
- A Travis CI build was last run 4 months ago, however, it is still mentioned in the contributing guidelines. The new process is to check that GitHub Actions pass.

### What is changed and the side effects?

Changed:
- Update `CONTRIBUTING.md` to specify checking GitHub Actions instead of checking Travis CI.

Side effects:
- Performance effects(性能影响): N/A

- Breaking backward compatibility(向后兼容性): N/A

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
