### PR TITLE
avoid rdma::GlobalRelease before event dispatcher is stopped

### DIFF
--- a/src/brpc/rdma/rdma_helper.cpp
+++ b/src/brpc/rdma/rdma_helper.cpp
@@ -510,6 +510,8 @@ static void GlobalRdmaInitializeOrDieImpl() {
         ExitWithError();
     }
 
+    atexit(GlobalRelease);
+
     SocketOptions opt;
     opt.fd = g_context->async_fd;
     butil::make_close_on_exec(opt.fd);
@@ -522,8 +524,6 @@ static void GlobalRdmaInitializeOrDieImpl() {
         LOG(WARNING) << "Fail to create socket to get async event of RDMA";
         ExitWithError();
     }
-
-    atexit(GlobalRelease);
 
     g_mem_alloc = butil::iobuf::blockmem_allocate;
     g_mem_dealloc = butil::iobuf::blockmem_deallocate;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/apache/brpc/issues/2213

Problem Summary: rdma::GlobalRelease runs before event dispatcher is stopped. It may incur coredump during program exit.

### What is changed and the side effects?

Changed: the order of atexit on rdma::GlobalRelease

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
