### PR TITLE
Fix possible segment fault in delete_stats() of MultiDimension. (#2237)

### DIFF
--- a/src/bvar/multi_dimension_inl.h
+++ b/src/bvar/multi_dimension_inl.h
@@ -118,6 +118,7 @@ void MultiDimension<T>::delete_stats() {
     // then traversal tmp_map and delete bvar object,
     // which can prevent the bvar object from being deleted twice.
     MetricMap tmp_map;
+    CHECK_EQ(0, tmp_map.init(8192, 80));
     auto clear_fn = [&tmp_map](MetricMap& map) {
         if (!tmp_map.empty()) {
             tmp_map.clear();

--- a/test/bvar_multi_dimension_unittest.cpp
+++ b/test/bvar_multi_dimension_unittest.cpp
@@ -355,6 +355,8 @@ TEST_F(MultiDimensionTest, stats) {
     ASSERT_FALSE(my_madder.has_stats(labels_value2));
     ASSERT_FALSE(my_madder.has_stats(labels_value3));
     ASSERT_FALSE(my_madder.has_stats(labels_value4));
+    bvar::Adder<int> *adder5 = my_madder.get_stats(labels_value1);
+    ASSERT_TRUE(adder5);
 }
 
 TEST_F(MultiDimensionTest, get_description) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:  #2237 

Problem Summary:

The delete_stats() function of MultiDimension may casue segment fault.

### What is changed and the side effects?

Changed:Fix bug of delete_stats() function of MulitDimension.

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
