### PR TITLE
Fix compilation errors reported by clang-14 (#2242)

### DIFF
--- a/src/brpc/details/hpack.cpp
+++ b/src/brpc/details/hpack.cpp
@@ -489,8 +489,7 @@ inline void EncodeInteger(butil::IOBufAppender* out, uint8_t msb,
     value -= max_prefix_value;
     msb |= max_prefix_value;
     out->push_back(msb);
-    size_t out_bytes = 1;
-    for (; value >= 128; ++out_bytes) {
+    for (; value >= 128; ) {
         const uint8_t c = (value & 0x7f) | 0x80;
         value >>= 7;
         out->push_back(c);

--- a/src/brpc/span.cpp
+++ b/src/brpc/span.cpp
@@ -749,7 +749,7 @@ void ListSpans(int64_t starting_realtime, size_t max_scan,
     }
     BriefSpan brief;
     size_t nscan = 0;
-    for (size_t i = 0; nscan < max_scan && it->Valid(); ++i, it->Prev()) {
+    for (; nscan < max_scan && it->Valid(); it->Prev()) {
         const int64_t key_tm = ToLittleEndian((const uint32_t*)it->key().data());
         // May have some bigger time at the beginning, because leveldb returns
         // keys >= starting_realtime.

--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -160,8 +160,6 @@ void SamplerCollector::run() {
         if (s) {
             s->InsertBeforeAsList(&root);
         }
-        int nremoved = 0;
-        int nsampled = 0;
         for (butil::LinkNode<Sampler>* p = root.next(); p != &root;) {
             // We may remove p from the list, save next first.
             butil::LinkNode<Sampler>* saved_next = p->next();
@@ -171,11 +169,9 @@ void SamplerCollector::run() {
                 s->_mutex.unlock();
                 p->RemoveFromList();
                 delete s;
-                ++nremoved;
             } else {
                 s->take_sample();
                 s->_mutex.unlock();
-                ++nsampled;
             }
             p = saved_next;
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:
#2242 

Problem Summary:
(warning: variable 'nremoved' set but not used [-Wunused-but-set-var)

### What is changed and the side effects?
remove not used variable to fix the compile warnnings

Changed:

Side effects:
- Performance effects(性能影响):
No impact

- Breaking backward compatibility(向后兼容性): 
No compatibility issue

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
