### PR TITLE
fix compiler optimize thread local variable access on x86_64

### DIFF
--- a/src/butil/thread_local.h
+++ b/src/butil/thread_local.h
@@ -46,7 +46,7 @@
     var_name = v;                                                              \
   }
 
-#if defined(__clang__) && (defined(__aarch64__) || defined(__arm64__))
+#if defined(__clang__)
 // Clang compiler is incorrectly caching the address of thread_local variables
 // across a suspend-point. The following macros used to disable the volatile
 // thread local access optimization.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #845

Problem Summary:

使用Clang-16去编译BRPC，在x86_64平台上也会出现"sched_to itself"的问题。在Linux x86_64以及macOS x86_64上均能复现。

### What is changed and the side effects?

Changed: 在x86_64平台上用Clang编译器的时候禁用thread local变量的优化。

Side effects:
- Performance effects(性能影响): 使用Clang编译器的时候不采用thread local变量优化。

- Breaking backward compatibility(向后兼容性): 无

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
