### PR TITLE
Use Hedron's Compile Commands Extractor for Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -283,14 +283,13 @@ perl_register_toolchains()
 #
 # Tools Dependencies
 #
-
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
 http_archive(
-    name = "com_grail_bazel_compdb",
-    sha256 = "d32835b26dd35aad8fd0ba0d712265df6565a3ad860d39e4c01ad41059ea7eda",
-    strip_prefix = "bazel-compilation-database-0.5.2",
-    urls = ["https://github.com/grailbio/bazel-compilation-database/archive/0.5.2.tar.gz"],
+    name = "hedron_compile_commands",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/3dddf205a1f5cde20faf2444c1757abe0564ff4c.tar.gz",
+    strip_prefix = "bazel-compile-commands-extractor-3dddf205a1f5cde20faf2444c1757abe0564ff4c",
+    sha256 = "3cd0e49f0f4a6d406c1d74b53b7616f5e24f5fd319eafc1bf8eee6e14124d115",
 )
-
-load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
-
-bazel_compdb_deps()
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+hedron_compile_commands_setup()

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -13,18 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_grail_bazel_compdb//:defs.bzl", "compilation_database")
-load("@com_grail_bazel_output_base_util//:defs.bzl", "OUTPUT_BASE")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
-compilation_database(
+refresh_compile_commands(
     name = "brpc_compdb",
-    # OUTPUT_BASE is a dynamic value that will vary for each user workspace.
-    # If you would like your build outputs to be the same across users, then
-    # skip supplying this value, and substitute the default constant value
-    # "__OUTPUT_BASE__" through an external tool like `sed` or `jq` (see
-    # below shell commands for usage).
-    output_base = OUTPUT_BASE,
-    targets = [
-        "//:brpc",
-    ],
+    # Specify the targets of interest.
+    # For example, specify a dict of targets and their arguments:
+    targets = {
+        "//:brpc": "",
+    },
+    # For more details, feel free to look into refresh_compile_commands.bzl if you want.
 )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -15,8 +15,7 @@
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
-load("@com_grail_bazel_compdb//:defs.bzl", "compilation_database")
-load("@com_grail_bazel_output_base_util//:defs.bzl", "OUTPUT_BASE")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 COPTS = [
     "-D__STDC_FORMAT_MACROS",
@@ -236,20 +235,15 @@ cc_test(
     ],
 )
 
-compilation_database(
+refresh_compile_commands(
     name = "brpc_test_compdb",
-    # Use test profile
-    testonly = True,
-    # OUTPUT_BASE is a dynamic value that will vary for each user workspace.
-    # If you would like your build outputs to be the same across users, then
-    # skip supplying this value, and substitute the default constant value
-    # "__OUTPUT_BASE__" through an external tool like `sed` or `jq` (see
-    # below shell commands for usage).
-    output_base = OUTPUT_BASE,
-    targets = [
-        "//:brpc",
-        ":bvar_test",
-        ":bthread_test",
-        ":butil_test",
-    ],
+    # Specify the targets of interest.
+    # For example, specify a dict of targets and their arguments:
+    targets = {
+        "//:brpc": "",
+        ":bvar_test": "",
+        ":bthread_test": "",
+        ":butil_test": "",
+    },
+    # For more details, feel free to look into refresh_compile_commands.bzl if you want.
 )


### PR DESCRIPTION
### What problem does this PR solve?
Replace deprecated bazel compile commands extractor. We have been using [ Hedron's extractor](https://github.com/hedronvision/bazel-compile-commands-extractor) for years. Works perfectly for large projects. Also it's active maintained
> https://github.com/grailbio/bazel-compilation-database#status
This repository is now in maintenance mode. 

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
