### PR TITLE
Fix resource leak when there are multiple HCAs

### DIFF
--- a/src/brpc/rdma/rdma_helper.cpp
+++ b/src/brpc/rdma/rdma_helper.cpp
@@ -385,12 +385,11 @@ static inline void ExitWithError() {
 }
 
 /**
- * @brief Open the RDMA device specified by `device_name` or the first available
- * device if `device_name` is empty. Also, number of available devices are
- * written to `*num_available_devices`
+ * @brief Open the RDMA device specified by FLAGS_rdma_device or the first
+ * available device if FLAGS_rdma_device is empty. Also, number of available
+ * devices are written to `*num_available_devices`
  *
  * @param num_total Total number returned by ibv_open_devices
- * @param device_name Empty if not specified
  * @param num_available_devices Location to write num available
  * @return ibv_context* nullptr if no device available or device_name not match
  */


### PR DESCRIPTION
### What problem does this PR solve?

When there are multiple HCAs, current implementation defaults to the last device. Previous opened device was not closed. 
Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
