### PR TITLE
Fix stack buffer overflow issue when calling copy_to_cstr

### DIFF
--- a/src/brpc/input_messenger.cpp
+++ b/src/brpc/input_messenger.cpp
@@ -101,7 +101,8 @@ ParseResult InputMessenger::CutInputMessage(
                 return result;
             } else {
                 if (m->_read_buf.size() >= 4) {
-                    char data[PROTO_DUMMY_LEN];
+                    // The length of `data' must be PROTO_DUMMY_LEN + 1 to store extra ending char '\0'
+                    char data[PROTO_DUMMY_LEN + 1];
                     m->_read_buf.copy_to_cstr(data, PROTO_DUMMY_LEN);
                     if (strncmp(data, "RDMA", PROTO_DUMMY_LEN) == 0 &&
                         m->_rdma_state == Socket::RDMA_OFF) {


### PR DESCRIPTION
线上升级到brpc-1.3后偶现一些随机的coredump，最后定位到bthread栈上数据被踩了
![image](https://github.com/apache/brpc/assets/4698734/e49d0ab1-3d04-4110-83dd-73b6bdcb5b30)

