### PR TITLE
fix thrift version gt 0.13.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,10 @@ endif()
 
 if(WITH_THRIFT)
     set(THRIFT_CPP_FLAG "-DENABLE_THRIFT_FRAMED_PROTOCOL")
-    set(THRIFT_LIB "thrift")
+    find_library(THRIFT_LIB NAMES thrift)
+    if (NOT THRIFT_LIB)
+        message(FATAL_ERROR "Fail to find Thrift")
+    endif()
 endif()
 
 set(WITH_RDMA_VAL "0")

--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -353,15 +353,14 @@ if [ $WITH_THRIFT != 0 ]; then
         append_to_output "STATIC_LINKINGS+=-lthriftnb"
     fi
     # get thrift version
-    thrift_version=$(thrift --version|awk '{print $3}')
-    IFS='.' read -ra version_parts <<< "$thrift_version"
-    major=${version_parts[0]}
-    minor=${version_parts[1]}
+    thrift_version=$(thrift --version | awk '{print $3}')
+    major=$(echo "$thrift_version" | awk -F '.' '{print $1}')
+    minor=$(echo "$thrift_version" | awk -F '.' '{print $2}')
     if [ $((major)) -eq 0 -a $((minor)) -lt 11 ]; then
-        echo "Thrift version is less than 0.11.0"
         CPPFLAGS="${CPPFLAGS} -D_THRIFT_VERSION_LOWER_THAN_0_11_0_"
+        echo "less"
     else
-        echo "Thrift version is equal to or greater than 0.11.0"
+        echo "greater"
     fi
 fi
 

--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -352,6 +352,17 @@ if [ $WITH_THRIFT != 0 ]; then
     else
         append_to_output "STATIC_LINKINGS+=-lthriftnb"
     fi
+    # get thrift version
+    thrift_version=$(thrift --version|awk '{print $3}')
+    IFS='.' read -ra version_parts <<< "$thrift_version"
+    major=${version_parts[0]}
+    minor=${version_parts[1]}
+    if [ $((major)) -eq 0 -a $((minor)) -lt 11 ]; then
+        echo "Thrift version is less than 0.11.0"
+        CPPFLAGS="${CPPFLAGS} -D_THRIFT_VERSION_LOWER_THAN_0_11_0_"
+    else
+        echo "Thrift version is equal to or greater than 0.11.0"
+    fi
 fi
 
 if [ $WITH_RDMA != 0 ]; then

--- a/example/thrift_extension_c++/native_client.cpp
+++ b/example/thrift_extension_c++/native_client.cpp
@@ -27,12 +27,15 @@
 #include <butil/logging.h>
 
 // _THRIFT_STDCXX_H_ is defined by thrift/stdcxx.h which was added since thrift 0.11.0
+// but deprecated after 0.13.0
 #ifndef THRIFT_STDCXX
  #if defined(_THRIFT_STDCXX_H_)
  # define THRIFT_STDCXX apache::thrift::stdcxx
- #else
+ #elif defined(_THRIFT_VERSION_LOWER_THAN_0_11_0_)
  # define THRIFT_STDCXX boost
  # include <boost/make_shared.hpp>
+ #else
+ # define THRIFT_STDCXX std
  #endif
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,8 +35,33 @@ add_library(brpc-static STATIC $<TARGET_OBJECTS:BUTIL_LIB>
                                $<TARGET_OBJECTS:SOURCES_LIB>
                                $<TARGET_OBJECTS:PROTO_LIB>)
 
+function(check_thrift_version target_arg)
+    #use thrift command to get version
+    execute_process(
+        COMMAND thrift --version
+        OUTPUT_VARIABLE THRIFT_VERSION_OUTPUT
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" THRIFT_VERSION ${THRIFT_VERSION_OUTPUT})
+    string(REGEX REPLACE "\\." ";" THRIFT_VERSION_LIST ${THRIFT_VERSION})
+
+    list(GET THRIFT_VERSION_LIST 0 THRIFT_MAJOR_VERSION)
+    list(GET THRIFT_VERSION_LIST 1 THRIFT_MINOR_VERSION)
+
+    if (THRIFT_MAJOR_VERSION EQUAL 0 AND THRIFT_MINOR_VERSION LESS 11)
+        message(STATUS "Thrift version is less than 0.11.0")
+        target_compile_definitions($(target_arg) PRIVATE _THRIFT_VERSION_LOWER_THAN_0_11_0_)
+    else()
+        message(STATUS "Thrift version is equal to or greater than 0.11.0")
+    endif()
+endfunction()
+
+
 if(WITH_THRIFT)
    target_link_libraries(brpc-static ${THRIFT_LIB})
+   check_thrift_version(brpc-static)
 endif()
 
 SET_TARGET_PROPERTIES(brpc-static PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
@@ -47,33 +72,6 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
 set(protoc_gen_mcpack_SOURCES
     ${PROJECT_SOURCE_DIR}/src/mcpack2pb/generator.cpp
  )
-
-function(check_thrift_version)
-#use thrift command to get version
-execute_process(
-    COMMAND thrift --version
-    OUTPUT_VARIABLE THRIFT_VERSION_OUTPUT
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" THRIFT_VERSION ${THRIFT_VERSION_OUTPUT})
-string(REGEX REPLACE "\\." ";" THRIFT_VERSION_LIST ${THRIFT_VERSION})
-
-list(GET THRIFT_VERSION_LIST 0 THRIFT_MAJOR_VERSION)
-list(GET THRIFT_VERSION_LIST 1 THRIFT_MINOR_VERSION)
-
-if (THRIFT_MAJOR_VERSION EQUAL 0 AND THRIFT_MINOR_VERSION LESS 20)
-    message(STATUS "Thrift version is less than 0.11.0")
-else()
-    message(STATUS "Thrift version is equal to or greater than 0.11.0")
-endif()
-endfunction()
-
-if(WITH_THRIFT)
-    check_thrift_version()
-endif()
-
     
 add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
 
@@ -87,6 +85,7 @@ if(BUILD_SHARED_LIBS)
     endif()
     if(WITH_THRIFT)
         target_link_libraries(brpc-shared ${THRIFT_LIB})
+        check_thrift_version(brpc-shared)
     endif()
     SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,33 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/output/bin)
 set(protoc_gen_mcpack_SOURCES
     ${PROJECT_SOURCE_DIR}/src/mcpack2pb/generator.cpp
  )
+
+function(check_thrift_version)
+#use thrift command to get version
+execute_process(
+    COMMAND thrift --version
+    OUTPUT_VARIABLE THRIFT_VERSION_OUTPUT
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" THRIFT_VERSION ${THRIFT_VERSION_OUTPUT})
+string(REGEX REPLACE "\\." ";" THRIFT_VERSION_LIST ${THRIFT_VERSION})
+
+list(GET THRIFT_VERSION_LIST 0 THRIFT_MAJOR_VERSION)
+list(GET THRIFT_VERSION_LIST 1 THRIFT_MINOR_VERSION)
+
+if (THRIFT_MAJOR_VERSION EQUAL 0 AND THRIFT_MINOR_VERSION LESS 20)
+    message(STATUS "Thrift version is less than 0.11.0")
+else()
+    message(STATUS "Thrift version is equal to or greater than 0.11.0")
+endif()
+endfunction()
+
+if(WITH_THRIFT)
+    check_thrift_version()
+endif()
+
     
 add_executable(protoc-gen-mcpack ${protoc_gen_mcpack_SOURCES})
 

--- a/src/brpc/policy/thrift_protocol.cpp
+++ b/src/brpc/policy/thrift_protocol.cpp
@@ -40,13 +40,16 @@
 #include <thrift/TApplicationException.h>
 
 // _THRIFT_STDCXX_H_ is defined by thrift/stdcxx.h which was added since thrift 0.11.0
+// but deprecated after thrift 0.13.0
 #include <thrift/TProcessor.h> // to include stdcxx.h if present
 #ifndef THRIFT_STDCXX
  #if defined(_THRIFT_STDCXX_H_)
  # define THRIFT_STDCXX apache::thrift::stdcxx
- #else
+ #elif defined(_THRIFT_VERSION_LOWER_THAN_0_11_0_)
  # define THRIFT_STDCXX boost
  # include <boost/make_shared.hpp>
+ #else
+ # define THRIFT_STDCXX std
  #endif
 #endif
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #1328 

Problem Summary: 
When using thrift version greater than 0.13.0, brpc can't compile correctly due to deprecate of boost.


### What is changed and the side effects?

Changed:

Now compile logic works as follow:
For version < 0.11, set _THRIFT_VERSION_LOWER_THAN_0_11_0_ in cmake and using boost
For 0.11 <= version < 0.13, _THRIFT_STDCXX_H_ is set inside thrift/stdcxx.h and use apache::thrift::stdcxx
For later, just use std

Side effects:
- Performance effects(性能影响):
No
- Breaking backward compatibility(向后兼容性): 
No, later version of thrift use std as well.
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
