### PR TITLE
Support hint size of formatted string for string_printf 

### DIFF
--- a/src/butil/string_printf.cpp
+++ b/src/butil/string_printf.cpp
@@ -67,24 +67,49 @@ inline int string_printf_impl(std::string& output, const char* format,
     }
     return 0;
 }
+
+inline int string_printf_impl(std::string& output,  size_t hint,
+                              const char* format, va_list args) {
+    if (hint > output.capacity()) {
+        output.reserve(hint);
+    }
+    return string_printf_impl(output,  format, args);
+}
 }  // end anonymous namespace
 
 std::string string_printf(const char* format, ...) {
     // snprintf will tell us how large the output buffer should be, but
-    // we then have to call it a second time, which is costly.  By
+    // we then have to call it a second time, which is costly. By
     // guestimating the final size, we avoid the double snprintf in many
-    // cases, resulting in a performance win.  We use this constructor
+    // cases, resulting in a performance win. We use this constructor
     // of std::string to avoid a double allocation, though it does pad
-    // the resulting string with nul bytes.  Our guestimation is twice
+    // the resulting string with nul bytes. Our guestimation is twice
     // the format string size, or 32 bytes, whichever is larger.  This
     // is a heuristic that doesn't affect correctness but attempts to be
     // reasonably fast for the most common cases.
     std::string ret;
-    ret.reserve(std::max(32UL, strlen(format) * 2));
-
     va_list ap;
     va_start(ap, format);
-    if (string_printf_impl(ret, format, ap) != 0) {
+    if (string_printf_impl(ret, std::max(32UL, strlen(format) * 2),
+                           format, ap) != 0) {
+        ret.clear();
+    }
+    va_end(ap);
+    return ret;
+}
+
+std::string string_printf(size_t hint_size, const char* format, ...) {
+    // snprintf will tell us how large the output buffer should be, but
+    // we then have to call it a second time, which is costly. By
+    // passing the hint size of formatted string, we avoid the double
+    // snprintf in many cases, resulting in a performance win. We use
+    // this constructor  of std::string to avoid a double allocation,
+    // though it does pad the resulting string with nul bytes.
+    std::string ret;
+    va_list ap;
+    va_start(ap, format);
+    if (string_printf_impl(ret, std::max(hint_size,strlen(format) * 2),
+                           format, ap) != 0) {
         ret.clear();
     }
     va_end(ap);
@@ -96,11 +121,7 @@ std::string string_printf(const char* format, ...) {
 int string_appendf(std::string* output, const char* format, ...) {
     va_list ap;
     va_start(ap, format);
-    const size_t old_size = output->size();
-    const int rc = string_printf_impl(*output, format, ap);
-    if (rc != 0) {
-        output->resize(old_size);
-    }
+    const int rc = string_vappendf(output, format, ap);
     va_end(ap);
     return rc;
 }
@@ -117,11 +138,7 @@ int string_vappendf(std::string* output, const char* format, va_list args) {
 int string_printf(std::string* output, const char* format, ...) {
     va_list ap;
     va_start(ap, format);
-    output->clear();
-    const int rc = string_printf_impl(*output, format, ap);
-    if (rc != 0) {
-        output->clear();
-    }
+    const int rc = string_vprintf(output, format, ap);
     va_end(ap);
     return rc;
 };

--- a/src/butil/string_printf.cpp
+++ b/src/butil/string_printf.cpp
@@ -108,7 +108,7 @@ std::string string_printf(size_t hint_size, const char* format, ...) {
     std::string ret;
     va_list ap;
     va_start(ap, format);
-    if (string_printf_impl(ret, std::max(hint_size,strlen(format) * 2),
+    if (string_printf_impl(ret, std::max(hint_size, strlen(format) * 2),
                            format, ap) != 0) {
         ret.clear();
     }

--- a/src/butil/string_printf.h
+++ b/src/butil/string_printf.h
@@ -27,9 +27,13 @@ namespace butil {
 std::string string_printf(const char* format, ...)
     __attribute__ ((format (printf, 1, 2)));
 
+// Hint size of formatted string.
+std::string string_printf(size_t hint_size, const char* format, ...)
+    __attribute__ ((format (printf, 2, 3)));
+
 // Write |format| and associated arguments into |output|
 // Returns 0 on success, -1 otherwise.
-int string_printf(std::string* output, const char* fmt, ...)
+int string_printf(std::string* output, const char* format, ...)
     __attribute__ ((format (printf, 2, 3)));
 
 // Write |format| and associated arguments in form of va_list into |output|.

--- a/test/string_printf_unittest.cpp
+++ b/test/string_printf_unittest.cpp
@@ -32,13 +32,23 @@ protected:
 };
 
 TEST_F(BaiduStringPrintfTest, sanity) {
-    ASSERT_EQ("hello 1 124 world", butil::string_printf("hello %d 124 %s", 1, "world"));
-    std::string sth;
-    ASSERT_EQ(0, butil::string_printf(&sth, "boolean %d", 1));
-    ASSERT_EQ("boolean 1", sth);
-    
-    ASSERT_EQ(0, butil::string_appendf(&sth, "too simple"));
-    ASSERT_EQ("boolean 1too simple", sth);
+
+    {
+        std::string sth = butil::string_printf("hello %d 124 %s", 1, "world");
+        ASSERT_EQ("hello 1 124 world", sth);
+
+        ASSERT_EQ("hello 1 124 world", butil::string_printf(sth.size(), "hello %d 124 %s", 1, "world"));
+        ASSERT_EQ("hello 1 124 world", butil::string_printf(sth.size() - 1, "hello %d 124 %s", 1, "world"));
+        ASSERT_EQ("hello 1 124 world", butil::string_printf(sth.size() + 1, "hello %d 124 %s", 1, "world"));
+
+    }
+    {
+        std::string sth;
+        ASSERT_EQ(0, butil::string_printf(&sth, "boolean %d", 1));
+        ASSERT_EQ("boolean 1", sth);
+        ASSERT_EQ(0, butil::string_appendf(&sth, "too simple"));
+        ASSERT_EQ("boolean 1too simple", sth);
+    }
 }
 
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

增加一个string_printf重载函数，支持用户传入格式化字符串的长度，避免调用两次vsnprintf。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
