### PR TITLE
fix ignore SIGPIPE signal concurrent issue with other library

### DIFF
--- a/src/brpc/global.cpp
+++ b/src/brpc/global.cpp
@@ -323,7 +323,7 @@ static void GlobalInitializeOrDieImpl() {
     struct sigaction oldact;
     if (sigaction(SIGPIPE, NULL, &oldact) != 0 ||
             (oldact.sa_handler == NULL && oldact.sa_sigaction == NULL)) {
-        CHECK(NULL == signal(SIGPIPE, SIG_IGN));
+        CHECK(SIG_ERR != signal(SIGPIPE, SIG_IGN));
     }
 
     // Make GOOGLE_LOG print to comlog device


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
There is a crash issue that at beginning many library concurrently ignore SIGPIPE to assert failed.

### What is changed and the side effects?
none
Changed:
none
Side effects:
- Performance effects(性能影响):
none
- Breaking backward compatibility(向后兼容性): 
none
