### PR TITLE
Fix duplicate content type

### DIFF
--- a/src/brpc/http_header.cpp
+++ b/src/brpc/http_header.cpp
@@ -29,6 +29,14 @@ HttpHeader::HttpHeader()
     // NOTE: don't forget to clear the field in Clear() as well.
 }
 
+void HttpHeader::RemoveHeader(const char* key) {
+    if (IsContentType(key)) {
+        _content_type.clear();
+    } else {
+        _headers.erase(key);
+    }
+}
+
 void HttpHeader::AppendHeader(const std::string& key,
                               const butil::StringPiece& value) {
     std::string& slot = GetOrAddHeader(key);
@@ -67,6 +75,17 @@ const char* HttpHeader::reason_phrase() const {
     
 void HttpHeader::set_status_code(int status_code) {
     _status_code = status_code;
+}
+
+std::string& HttpHeader::GetOrAddHeader(const std::string& key) {
+    if (IsContentType(key)) {
+        return _content_type;
+    }
+
+    if (!_headers.initialized()) {
+        _headers.init(29);
+    }
+    return _headers[key];
 }
 
 const HttpHeader& DefaultHttpHeader() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

https://github.com/apache/brpc/blob/2729272ae5ee69e4c4142d14b7fafbf800944316/src/brpc/details/http_message.cpp#L576-L583

如果一次http请求中，同时调用了`set_content_type`和`SetHeader("Content-Type")`，那么`MakeRawHttpRequest`后的http包中会有两个`Content-Type` header。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
