### PR TITLE
Fix unit test running error under arch64

### DIFF
--- a/src/butil/thread_local.h
+++ b/src/butil/thread_local.h
@@ -31,7 +31,7 @@
 #endif  // _MSC_VER
 
 #define BAIDU_VOLATILE_THREAD_LOCAL(type, var_name, default_value)             \
-  BAIDU_THREAD_LOCAL type var_name = default_value;                                      \
+  BAIDU_THREAD_LOCAL type var_name = default_value;                            \
   static __attribute__((noinline, unused)) type get_##var_name(void) {         \
     asm volatile("");                                                          \
     return var_name;                                                           \
@@ -46,10 +46,10 @@
     var_name = v;                                                              \
   }
 
-#if defined(__clang__)
-// Clang compiler is incorrectly caching the address of thread_local variables
-// across a suspend-point. The following macros used to disable the volatile
-// thread local access optimization.
+#if (defined (__aarch64__) && defined (__GNUC__)) || defined(__clang__)
+// GNU compiler under aarch and Clang compiler is incorrectly caching the 
+// address of thread_local variables across a suspend-point. The following
+// macros used to disable the volatile thread local access optimization.
 #define BAIDU_GET_VOLATILE_THREAD_LOCAL(var_name) get_##var_name()
 #define BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(var_name) get_ptr_##var_name()
 #define BAIDU_SET_VOLATILE_THREAD_LOCAL(var_name, value) set_##var_name(value)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/apache/brpc/issues/2318

Problem Summary: 在arch64下使用gcc编译，运行单测会报错。

### What is changed and the side effects?

Changed: 在arch64 + gcc的环境中禁止thread_local访问优化。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性):  是

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
