### PR TITLE
remove unnecessary libthriftnb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,6 @@ set(DYNAMIC_LIB
     ${PROTOC_LIB}
     ${CMAKE_THREAD_LIBS_INIT}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     ${OPENSSL_CRYPTO_LIBRARY}
     dl
     z)

--- a/example/asynchronous_echo_c++/CMakeLists.txt
+++ b/example/asynchronous_echo_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -119,7 +115,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/auto_concurrency_limiter/CMakeLists.txt
+++ b/example/auto_concurrency_limiter/CMakeLists.txt
@@ -108,7 +108,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/backup_request_c++/CMakeLists.txt
+++ b/example/backup_request_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -119,7 +115,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/cancel_c++/CMakeLists.txt
+++ b/example/cancel_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -119,7 +115,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/cascade_echo_c++/CMakeLists.txt
+++ b/example/cascade_echo_c++/CMakeLists.txt
@@ -38,10 +38,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -118,7 +114,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/dynamic_partition_echo_c++/CMakeLists.txt
+++ b/example/dynamic_partition_echo_c++/CMakeLists.txt
@@ -43,10 +43,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -125,7 +121,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/echo_c++/CMakeLists.txt
+++ b/example/echo_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -119,7 +115,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/grpc_c++/CMakeLists.txt
+++ b/example/grpc_c++/CMakeLists.txt
@@ -114,7 +114,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/http_c++/CMakeLists.txt
+++ b/example/http_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
@@ -126,7 +122,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/memcache_c++/CMakeLists.txt
+++ b/example/memcache_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -119,7 +115,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/multi_threaded_echo_c++/CMakeLists.txt
+++ b/example/multi_threaded_echo_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
@@ -125,7 +121,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/multi_threaded_echo_fns_c++/CMakeLists.txt
+++ b/example/multi_threaded_echo_fns_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
@@ -125,7 +121,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/nshead_extension_c++/CMakeLists.txt
+++ b/example/nshead_extension_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -119,7 +115,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/nshead_pb_extension_c++/CMakeLists.txt
+++ b/example/nshead_pb_extension_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -119,7 +115,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/parallel_echo_c++/CMakeLists.txt
+++ b/example/parallel_echo_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
@@ -125,7 +121,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/partition_echo_c++/CMakeLists.txt
+++ b/example/partition_echo_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
@@ -125,7 +121,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/rdma_performance/CMakeLists.txt
+++ b/example/rdma_performance/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -125,7 +121,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/redis_c++/CMakeLists.txt
+++ b/example/redis_c++/CMakeLists.txt
@@ -48,10 +48,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -128,7 +124,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     ${GPERFTOOLS_LIBRARIES}
     dl
     )

--- a/example/selective_echo_c++/CMakeLists.txt
+++ b/example/selective_echo_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
@@ -125,7 +121,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/session_data_and_thread_local/CMakeLists.txt
+++ b/example/session_data_and_thread_local/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
@@ -126,7 +122,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/example/streaming_echo_c++/CMakeLists.txt
+++ b/example/streaming_echo_c++/CMakeLists.txt
@@ -39,10 +39,6 @@ find_library(THRIFT_LIB NAMES thrift)
 if (NOT THRIFT_LIB)
     set(THRIFT_LIB "")
 endif()
-find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
-    set(THRIFTNB_LIB "")
-endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
 if(LINK_SO)
@@ -119,7 +115,6 @@ set(DYNAMIC_LIB
     ${OPENSSL_CRYPTO_LIBRARY}
     ${OPENSSL_SSL_LIBRARY}
     ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
     dl
     )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,8 +35,8 @@ add_library(brpc-static STATIC $<TARGET_OBJECTS:BUTIL_LIB>
                                $<TARGET_OBJECTS:SOURCES_LIB>
                                $<TARGET_OBJECTS:PROTO_LIB>)
 
-if(BRPC_WITH_THRIFT)
-   target_link_libraries(brpc-static thrift)
+if(WITH_THRIFT)
+   target_link_libraries(brpc-static ${THRIFT_LIB})
 endif()
 
 SET_TARGET_PROPERTIES(brpc-static PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
@@ -55,11 +55,11 @@ if(BUILD_SHARED_LIBS)
                                    $<TARGET_OBJECTS:SOURCES_LIB>
                                    $<TARGET_OBJECTS:PROTO_LIB>)
     target_link_libraries(brpc-shared ${DYNAMIC_LIB})
-    if(BRPC_WITH_GLOG)
+    if(WITH_GLOG)
         target_link_libraries(brpc-shared ${GLOG_LIB})
     endif()
-    if(BRPC_WITH_THRIFT)
-        target_link_libraries(brpc-shared thrift)
+    if(WITH_THRIFT)
+        target_link_libraries(brpc-shared ${THRIFT_LIB})
     endif()
     SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: fix typo of 
 
THRIFTNB_LIB was removed in #888 
BRPC_WITH_THRIFT BRPC_WITH_GLOG was renamed to WITH_THRIFT WITH_GLOG in #383

Contribute previous [modifications](https://github.com/microsoft/vcpkg/pull/32705/files) to upstream

Problem Summary: remove unnecessary libthriftnb

### What is changed and the side effects?

Changed:None

Side effects:
- Performance effects(性能影响):None

- Breaking backward compatibility(向后兼容性): None

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
