### PR TITLE
send response之后，request/response对象析构之前执行一些自定义逻辑

### DIFF
--- a/example/asynchronous_echo_c++/server.cpp
+++ b/example/asynchronous_echo_c++/server.cpp
@@ -46,7 +46,7 @@ public:
         // optional: set a callback function which is called after response is sent
         // and before cntl/req/res is destructed.
         cntl->SetAfterRpcRespFn(std::bind(&EchoServiceImpl::CallAfterRpc,
-            std::placeholders::_1, std::placeholders::_1, std::placeholders::_1));
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
         // The purpose of following logs is to help you to understand
         // how clients interact with servers more intuitively. You should 

--- a/example/asynchronous_echo_c++/server.cpp
+++ b/example/asynchronous_echo_c++/server.cpp
@@ -45,7 +45,7 @@ public:
 
         // optional: set a callback function which is called after response is sent
         // and before cntl/req/res is destructed.
-        cntl->SetAfterRpcRespFn(std::bind(&EchoServiceImpl::CallAfterRpc,
+        cntl->set_after_rpc_resp_fn(std::bind(&EchoServiceImpl::CallAfterRpc,
             std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
         // The purpose of following logs is to help you to understand

--- a/example/echo_c++/server.cpp
+++ b/example/echo_c++/server.cpp
@@ -20,6 +20,7 @@
 #include <gflags/gflags.h>
 #include <butil/logging.h>
 #include <brpc/server.h>
+#include <json2pb/pb_to_json.h>
 #include "echo.pb.h"
 
 DEFINE_bool(echo_attachment, true, "Echo attachment as well");
@@ -48,6 +49,11 @@ public:
         brpc::Controller* cntl =
             static_cast<brpc::Controller*>(cntl_base);
 
+        // optional: set a callback function which is called after response is sent
+        // and before cntl/req/res is destructed.
+        cntl->SetAfterRpcRespFn(std::bind(&EchoServiceImpl::CallAfterRpc,
+            std::placeholders::_1, std::placeholders::_1, std::placeholders::_1));
+
         // The purpose of following logs is to help you to understand
         // how clients interact with servers more intuitively. You should 
         // remove these logs in performance-sensitive servers.
@@ -69,6 +75,19 @@ public:
             // being serialized into protobuf messages.
             cntl->response_attachment().append(cntl->request_attachment());
         }
+    }
+
+    // optional
+    static void CallAfterRpc(brpc::Controller* cntl,
+                        const google::protobuf::Message* req,
+                        const google::protobuf::Message* res) {
+        // at this time res is send to client, but cntl/req/res is not destructed
+        std::string req_str;
+        std::string res_str;
+        json2pb::ProtoMessageToJson(*req, &req_str, NULL);
+        json2pb::ProtoMessageToJson(*res, &res_str, NULL);
+        LOG(INFO) << "req:" << req_str
+                    << " res:" << res_str;
     }
 };
 }  // namespace example

--- a/example/echo_c++/server.cpp
+++ b/example/echo_c++/server.cpp
@@ -51,7 +51,7 @@ public:
 
         // optional: set a callback function which is called after response is sent
         // and before cntl/req/res is destructed.
-        cntl->SetAfterRpcRespFn(std::bind(&EchoServiceImpl::CallAfterRpc,
+        cntl->set_after_rpc_resp_fn(std::bind(&EchoServiceImpl::CallAfterRpc,
             std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
         // The purpose of following logs is to help you to understand

--- a/example/echo_c++/server.cpp
+++ b/example/echo_c++/server.cpp
@@ -52,7 +52,7 @@ public:
         // optional: set a callback function which is called after response is sent
         // and before cntl/req/res is destructed.
         cntl->SetAfterRpcRespFn(std::bind(&EchoServiceImpl::CallAfterRpc,
-            std::placeholders::_1, std::placeholders::_1, std::placeholders::_1));
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
         // The purpose of following logs is to help you to understand
         // how clients interact with servers more intuitively. You should 
@@ -81,7 +81,7 @@ public:
     static void CallAfterRpc(brpc::Controller* cntl,
                         const google::protobuf::Message* req,
                         const google::protobuf::Message* res) {
-        // at this time res is send to client, but cntl/req/res is not destructed
+        // at this time res is already sent to client, but cntl/req/res is not destructed
         std::string req_str;
         std::string res_str;
         json2pb::ProtoMessageToJson(*req, &req_str, NULL);

--- a/example/http_c++/http_server.cpp
+++ b/example/http_c++/http_server.cpp
@@ -52,7 +52,7 @@ public:
         // optional: set a callback function which is called after response is sent
         // and before cntl/req/res is destructed.
         cntl->SetAfterRpcRespFn(std::bind(&HttpServiceImpl::CallAfterRpc,
-            std::placeholders::_1, std::placeholders::_1, std::placeholders::_1));
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
         // Fill response.
         cntl->http_response().set_content_type("text/plain");

--- a/example/http_c++/http_server.cpp
+++ b/example/http_c++/http_server.cpp
@@ -51,7 +51,7 @@ public:
 
         // optional: set a callback function which is called after response is sent
         // and before cntl/req/res is destructed.
-        cntl->SetAfterRpcRespFn(std::bind(&HttpServiceImpl::CallAfterRpc,
+        cntl->set_after_rpc_resp_fn(std::bind(&HttpServiceImpl::CallAfterRpc,
             std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
         // Fill response.

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -228,6 +228,7 @@ void Controller::ResetNonPods() {
     }
     delete _remote_stream_settings;
     _thrift_method_name.clear();
+    _after_rpc_resp_fn = nullptr;
 
     CHECK(_unfinished_call == NULL);
 }
@@ -1474,6 +1475,13 @@ int Controller::GetSockOption(int level, int optname, void* optval, socklen_t* o
     } else {
         errno = EBADF;
         return -1;
+    }
+}
+
+void Controller::call_after_rpc_resp(const google::protobuf::Message* req, const google::protobuf::Message* res) {
+    if (_after_rpc_resp_fn) {
+        _after_rpc_resp_fn(this, req, res);
+        _after_rpc_resp_fn = nullptr;
     }
 }
 

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -1478,7 +1478,7 @@ int Controller::GetSockOption(int level, int optname, void* optval, socklen_t* o
     }
 }
 
-void Controller::call_after_rpc_resp(const google::protobuf::Message* req, const google::protobuf::Message* res) {
+void Controller::CallAfterRpcResp(const google::protobuf::Message* req, const google::protobuf::Message* res) {
     if (_after_rpc_resp_fn) {
         _after_rpc_resp_fn(this, req, res);
         _after_rpc_resp_fn = nullptr;

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -568,13 +568,13 @@ public:
     // -1 means no deadline.
     int64_t deadline_us() const { return _deadline_us; }
 
-    using after_rpc_resp_fn_t = std::function<void(Controller* cntl,
+    using AfterRpcRespFnType = std::function<void(Controller* cntl,
                                                const google::protobuf::Message* req,
                                                const google::protobuf::Message* res)>;
 
-    void set_after_rpc_resp_fn(after_rpc_resp_fn_t&& fn) { _after_rpc_resp_fn = fn; }
+    void SetAfterRpcRespFn(AfterRpcRespFnType&& fn) { _after_rpc_resp_fn = fn; }
 
-    void call_after_rpc_resp(const google::protobuf::Message* req, const google::protobuf::Message* res);
+    void CallAfterRpcResp(const google::protobuf::Message* req, const google::protobuf::Message* res);
 
 private:
     struct CompletionInfo {
@@ -832,7 +832,7 @@ private:
 
     uint32_t _auth_flags;
 
-    after_rpc_resp_fn_t _after_rpc_resp_fn;
+    AfterRpcRespFnType _after_rpc_resp_fn;
 };
 
 // Advises the RPC system that the caller desires that the RPC call be

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -22,6 +22,7 @@
 // To brpc developers: This is a header included by user, don't depend
 // on internal structures, use opaque pointers instead.
 
+#include <functional>                          // std::function
 #include <gflags/gflags.h>                     // Users often need gflags
 #include <string>
 #include "butil/intrusive_ptr.hpp"             // butil::intrusive_ptr
@@ -567,6 +568,14 @@ public:
     // -1 means no deadline.
     int64_t deadline_us() const { return _deadline_us; }
 
+    using after_rpc_resp_fn_t = std::function<void(Controller* cntl,
+                                               const google::protobuf::Message* req,
+                                               const google::protobuf::Message* res)>;
+
+    void set_after_rpc_resp_fn(after_rpc_resp_fn_t&& fn) { _after_rpc_resp_fn = fn; }
+
+    void call_after_rpc_resp(const google::protobuf::Message* req, const google::protobuf::Message* res);
+
 private:
     struct CompletionInfo {
         CallId id;           // call_id of the corresponding request
@@ -822,6 +831,8 @@ private:
     std::string _thrift_method_name;
 
     uint32_t _auth_flags;
+
+    after_rpc_resp_fn_t _after_rpc_resp_fn;
 };
 
 // Advises the RPC system that the caller desires that the RPC call be

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -572,7 +572,7 @@ public:
                                                const google::protobuf::Message* req,
                                                const google::protobuf::Message* res)>;
 
-    void SetAfterRpcRespFn(AfterRpcRespFnType&& fn) { _after_rpc_resp_fn = fn; }
+    void set_after_rpc_resp_fn(AfterRpcRespFnType&& fn) { _after_rpc_resp_fn = fn; }
 
     void CallAfterRpcResp(const google::protobuf::Message* req, const google::protobuf::Message* res);
 

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -149,10 +149,14 @@ void SendRpcResponse(int64_t correlation_id,
         span->set_start_send_us(butil::cpuwide_time_us());
     }
     Socket* sock = accessor.get_sending_socket();
-    std::unique_ptr<Controller, LogErrorTextAndDelete> recycle_cntl(cntl);
-    ConcurrencyRemover concurrency_remover(method_status, cntl, received_us);
+
     std::unique_ptr<const google::protobuf::Message> recycle_req(req);
     std::unique_ptr<const google::protobuf::Message> recycle_res(res);
+
+    std::unique_ptr<Controller, LogErrorTextAndDelete> recycle_cntl(cntl);
+    ConcurrencyRemover concurrency_remover(method_status, cntl, received_us);
+
+    ClosureGuard guard(brpc::NewCallback(cntl, &Controller::call_after_rpc_resp, req, res));
     
     StreamId response_stream_id = accessor.response_stream();
 

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -156,7 +156,7 @@ void SendRpcResponse(int64_t correlation_id,
     std::unique_ptr<Controller, LogErrorTextAndDelete> recycle_cntl(cntl);
     ConcurrencyRemover concurrency_remover(method_status, cntl, received_us);
 
-    ClosureGuard guard(brpc::NewCallback(cntl, &Controller::call_after_rpc_resp, req, res));
+    ClosureGuard guard(brpc::NewCallback(cntl, &Controller::CallAfterRpcResp, req, res));
     
     StreamId response_stream_id = accessor.response_stream();
 

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -732,7 +732,11 @@ private:
 class HttpResponseSenderAsDone : public google::protobuf::Closure {
 public:
     HttpResponseSenderAsDone(HttpResponseSender* s) : _sender(std::move(*s)) {}
-    void Run() override { delete this; }
+    void Run() override {
+        _sender._cntl->call_after_rpc_resp(_sender._req.get(), _sender._res.get());
+        delete this;
+    }
+
 private:
     HttpResponseSender _sender;
 };

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -733,7 +733,7 @@ class HttpResponseSenderAsDone : public google::protobuf::Closure {
 public:
     HttpResponseSenderAsDone(HttpResponseSender* s) : _sender(std::move(*s)) {}
     void Run() override {
-        _sender._cntl->call_after_rpc_resp(_sender._req.get(), _sender._res.get());
+        _sender._cntl->CallAfterRpcResp(_sender._req.get(), _sender._res.get());
         delete this;
     }
 

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -1604,7 +1604,7 @@ protected:
         brpc::Controller cntl;
         for (int i = 0; i < count; ++i) {
             std::string str;
-            cntl->SetAfterRpcRespFn(std::bind(&ChannelTest::CallAfterRpc, &str,
+            cntl.SetAfterRpcRespFn(std::bind(&ChannelTest::CallAfterRpc, &str,
                 std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
             test::EchoRequest req;
             test::EchoResponse res;

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -157,7 +157,7 @@ class MyEchoService : public ::test::EchoService {
         brpc::Controller* cntl =
             static_cast<brpc::Controller*>(cntl_base);
         std::shared_ptr<CallAfterRpcObject> str_test(new CallAfterRpcObject());
-        cntl->SetAfterRpcRespFn(std::bind(&MyEchoService::CallAfterRpc, str_test,
+        cntl->set_after_rpc_resp_fn(std::bind(&MyEchoService::CallAfterRpc, str_test,
             std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
         brpc::ClosureGuard done_guard(done);
         if (req->server_fail()) {

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -141,8 +141,8 @@ public:
         EXPECT_EQ(str, "CallAfterRpcRespTest");
     }
 
-    void Set(const std::string& s) {
-        str = s;
+    void Append(const std::string& s) {
+        str.append(s);
     }
 
 private:
@@ -186,7 +186,7 @@ class MyEchoService : public ::test::EchoService {
                         const google::protobuf::Message* res) {
         const test::EchoRequest* request = static_cast<const test::EchoRequest*>(req);
         const test::EchoResponse* response = static_cast<const test::EchoResponse*>(res);
-        str->Set("CallAfterRpcRespTest");
+        str->Append("CallAfterRpcRespTest");
         EXPECT_TRUE(nullptr != cntl);
         EXPECT_TRUE(nullptr != request);
         EXPECT_TRUE(nullptr != response);

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -40,7 +40,11 @@
 #include "brpc/selective_channel.h"
 #include "brpc/socket_map.h"
 #include "brpc/controller.h"
+#if BAZEL_TEST
+#include "test/echo.pb.h"
+#else
 #include "echo.pb.h"
+#endif   // BAZEL_TEST
 #include "brpc/options.pb.h"
 
 namespace brpc {
@@ -129,6 +133,22 @@ static bool VerifyMyRequest(const brpc::InputMessageBase* msg_base) {
     return true;
 }
 
+class CallAfterRpcObject {
+public:
+    explicit CallAfterRpcObject() {}
+
+    ~CallAfterRpcObject() {
+        EXPECT_EQ(str, "CallAfterRpcRespTest");
+    }
+
+    void Set(const std::string& s) {
+        str = s;
+    }
+
+private:
+    std::string str;
+};
+
 class MyEchoService : public ::test::EchoService {
     void Echo(google::protobuf::RpcController* cntl_base,
               const ::test::EchoRequest* req,
@@ -136,6 +156,9 @@ class MyEchoService : public ::test::EchoService {
               google::protobuf::Closure* done) {
         brpc::Controller* cntl =
             static_cast<brpc::Controller*>(cntl_base);
+        std::shared_ptr<CallAfterRpcObject> str_test(new CallAfterRpcObject());
+        cntl->SetAfterRpcRespFn(std::bind(&MyEchoService::CallAfterRpc, str_test,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
         brpc::ClosureGuard done_guard(done);
         if (req->server_fail()) {
             cntl->SetFailed(req->server_fail(), "Server fail1");
@@ -156,6 +179,17 @@ class MyEchoService : public ::test::EchoService {
             res->add_code_list(req->code());
         }
         res->set_receiving_socket_id(cntl->_current_call.sending_sock->id());
+    }
+    static void CallAfterRpc(std::shared_ptr<CallAfterRpcObject> str,
+                        brpc::Controller* cntl,
+                        const google::protobuf::Message* req,
+                        const google::protobuf::Message* res) {
+        const test::EchoRequest* request = static_cast<const test::EchoRequest*>(req);
+        const test::EchoResponse* response = static_cast<const test::EchoResponse*>(res);
+        str->Set("CallAfterRpcRespTest");
+        EXPECT_TRUE(nullptr != cntl);
+        EXPECT_TRUE(nullptr != request);
+        EXPECT_TRUE(nullptr != response);
     }
 };
 
@@ -247,7 +281,7 @@ protected:
             const brpc::Server*,
             brpc::MethodStatus*, int64_t>(
                 &brpc::policy::SendRpcResponse,
-                meta.correlation_id(), cntl, NULL, res,
+                meta.correlation_id(), cntl, req, res,
                 &ts->_dummy, NULL, -1);
         ts->_svc.CallMethod(method, cntl, req, res, done);
     }
@@ -1565,28 +1599,15 @@ protected:
         StopAndJoin();
     }
 
-    static void CallAfterRpc(std::string* str,
-                        brpc::Controller* cntl,
-                        const google::protobuf::Message* req,
-                        const google::protobuf::Message* res) {
-        const test::EchoRequest* request = static_cast<const test::EchoRequest*>(req);
-        const test::EchoResponse* response = static_cast<const test::EchoResponse*>(res);
-        *str = request->message() + response->message();
-    }
-
     void RPCThread(brpc::ChannelBase* channel, bool async) {
         brpc::Controller cntl;
         test::EchoRequest req;
         test::EchoResponse res;
-        std::string str;
-        cntl.SetAfterRpcRespFn(std::bind(&ChannelTest::CallAfterRpc, &str,
-            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
         req.set_message(__FUNCTION__);
         CallMethod(channel, &cntl, &req, &res, async);
 
         ASSERT_EQ(0, cntl.ErrorCode()) << cntl.ErrorText();
         EXPECT_EQ("received " + std::string(__FUNCTION__), res.message());
-        ASSERT_EQ(str, req.message() + res.message());
     }
 
     void RPCThread(brpc::ChannelBase* channel, bool async, int count) {
@@ -1594,15 +1615,11 @@ protected:
         for (int i = 0; i < count; ++i) {
             test::EchoRequest req;
             test::EchoResponse res;
-            std::string str;
-            cntl.SetAfterRpcRespFn(std::bind(&ChannelTest::CallAfterRpc, &str,
-                std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
             req.set_message(__FUNCTION__);
             CallMethod(channel, &cntl, &req, &res, async);
 
             ASSERT_EQ(0, cntl.ErrorCode()) << cntl.ErrorText();
             ASSERT_EQ("received " + std::string(__FUNCTION__), res.message());
-            ASSERT_EQ(str, req.message() + res.message());
             cntl.Reset();
         }
     }

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -1590,7 +1590,6 @@ protected:
         }
     }
 
-    // optional
     static void CallAfterRpc(std::string* str,
                         brpc::Controller* cntl,
                         const google::protobuf::Message* req,
@@ -1606,7 +1605,7 @@ protected:
         for (int i = 0; i < count; ++i) {
             std::string str;
             cntl->SetAfterRpcRespFn(std::bind(&ChannelTest::CallAfterRpc, &str,
-                std::placeholders::_1, std::placeholders::_1, std::placeholders::_1));
+                std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
             test::EchoRequest req;
             test::EchoResponse res;
             req.set_message(__FUNCTION__);

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -1594,7 +1594,9 @@ protected:
                         brpc::Controller* cntl,
                         const google::protobuf::Message* req,
                         const google::protobuf::Message* res) {
-        *str = req->message() + res->message();
+        const test::EchoRequest* request = static_cast<const test::EchoRequest*>(req);
+        const test::EchoResponse* response = static_cast<const test::EchoResponse*>(res);
+        *str = request->message() + response->message();
     }
 
     void RPCThread(bool single_server, bool async, bool short_connection,


### PR DESCRIPTION
### What problem does this PR solve?
1.我们的场景希望将响应时间减少到最小，所以希望将一些类似数据上报的耗时操作（是的，特别耗时）放在response返回之后、request/response析构之前做
2.本pr借鉴了 #1433 ，看这个pr一直没合入且测试发现有些问题&不太满足我们的需要，所以另提一个。 #1433  的问题主要是：
（1）太多无关topic的改动
（2）仅在SendRpcResponse成功时才调用call_after_rpc_resp函数，失败时没有调用（我们需要无论成功或失败都要调用）
（3）定义的after_resp_fn_t不包含controller指针，我们需要拿到controller对象（进而拿到session data指针，所以声明为非const指针）
3.同样在目前在常用的 baidu_std/http/http2 协议上支持。其他协议未开发。
4.将Controller与req、res的析构顺序进行了修改，依赖关系应该是controller依赖req、res，所以应该先析构controller，后析构req、res

麻烦maintainers看看有什么不妥之处~
