### PR TITLE
selective_channle支持返回response_attachment

### DIFF
--- a/src/brpc/selective_channel.cpp
+++ b/src/brpc/selective_channel.cpp
@@ -354,6 +354,7 @@ void SubDone::Run() {
     main_cntl->_remote_side = _cntl._remote_side;
     // connection_type may be changed during CallMethod. 
     main_cntl->set_connection_type(_cntl.connection_type());
+    main_cntl->response_attachment().swap(_cntl.response_attachment());
     Resource r;
     r.response = _cntl._response;
     r.sub_done = this;


### PR DESCRIPTION
### What problem does this PR solve?

测试发现，channel类型是selective_channel时client收不到server填充的response_attachment。