### PR TITLE
fix-redis-response-swap-mem-leak

### DIFF
--- a/src/brpc/redis_reply.h
+++ b/src/brpc/redis_reply.h
@@ -318,7 +318,8 @@ inline void RedisReply::Swap(RedisReply& other) {
     std::swap(_length, other._length);
     std::swap(_data.padding[0], other._data.padding[0]);
     std::swap(_data.padding[1], other._data.padding[1]);
-    std::swap(_arena, other._arena);
+    // reply _arena should not be swapped because _arena point to address in redisresponse.
+    // std::swap(_arena, other._arena);
 }
 
 inline void RedisReply::CopyFromSameArena(const RedisReply& other) {


### PR DESCRIPTION
### What problem does this PR solve?
redis response swap operation may cause memory leaks
Issue Number:

Problem Summary:
redis reply _arena address should be the same as respone, otherwise, there may be a memory leak.

> test code
```
    brpc::RedisResponse resp1;
    std::cout << "response 1 arena address:"<< &(resp1._arena) << std::endl;
    std::cout << "first reply arena address:" << (resp1._first_reply._arena) << std::endl;
    brpc::RedisResponse resp2;
    std::cout << "response 2 arena address:"<< &(resp2._arena) << std::endl;
    std::cout << "first reply arena address:" << (resp2._first_reply._arena) << std::endl;

    resp1.Swap(&resp2);
    std::cout << "========= swap ============" << std::endl;
    std::cout << "response 1 arena address:"<< &(resp1._arena) << std::endl;
    std::cout << "first reply arena address:" << (resp1._first_reply._arena) << std::endl;;
    std::cout << "response 2 arena address:"<< &(resp2._arena) << std::endl;
    std::cout << "first reply arena address:" << (resp2._first_reply._arena) << std::endl;
```
**bug version**
<img width="341" alt="image" src="https://github.com/apache/brpc/assets/26954625/0d1a5637-9cc8-4a9f-bd7f-70dc8d947118">

**fixed version**
<img width="335" alt="image" src="https://github.com/apache/brpc/assets/26954625/2b34eb1e-ef1f-4695-bd5a-68727914918c">

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):
no
- Breaking backward compatibility(向后兼容性): 
no
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
