### PR TITLE
Fix macOS bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -251,6 +251,7 @@ objc_library(
         "src/butil/mac/scoped_cftyperef.h",
         "src/butil/mac/scoped_typeref.h",
         "src/butil/macros.h",
+        "src/butil/string_printf.h",
         "src/butil/memory/aligned_memory.h",
         "src/butil/memory/scoped_policy.h",
         "src/butil/memory/scoped_ptr.h",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

#2306 introduced a new include in butil/macros.h, this dependency is missing in bazel macos_lib rule.

### What is changed and the side effects?

Changed:
- Added butil/string_printf.h to macos_lib header list.

Side effects:
- Performance effects(性能影响):
  n/a
- Breaking backward compatibility(向后兼容性): 
  n/a
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
