### PR TITLE
Don't delete when the file is /dev/null

### DIFF
--- a/test/iobuf_unittest.cpp
+++ b/test/iobuf_unittest.cpp
@@ -1027,7 +1027,9 @@ TEST_F(IOBufTest, append_store_append_cut) {
         if (!write_to_dev_null) {
             ASSERT_EQ(0, system(cmd));
         }
-        remove(name);
+	if (!write_to_dev_null) {
+           remove(name);
+	}
     }
 
     for (size_t i = 0; i < ARRAY_SIZE(w); ++i) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2345

Problem Summary:
由于iobuf_unittest.cpp文件中append_store_append_cut测试用例删除/dev/null，导致在for循环中在执行open时重新创建了一个文件类型的/dev/null，从而引发系统问题

### What is changed and the side effects?

Changed: 当检测到是/dev/null, 不对其进行删除

Side effects:
- Performance effects(性能影响):
  无

- Breaking backward compatibility(向后兼容性): 
无

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
