### PR TITLE
将 GOOGLE_CHECK_NE 替换成 CHECK_NE

### DIFF
--- a/src/brpc/esp_message.cpp
+++ b/src/brpc/esp_message.cpp
@@ -20,6 +20,8 @@
 #include <google/protobuf/reflection_ops.h>     // ReflectionOps::Merge
 #include <google/protobuf/wire_format.h>        // WireFormatLite::GetTagWireType
 
+#include "butil/logging.h"
+
 namespace brpc {
 
 EspMessage::EspMessage()
@@ -92,7 +94,7 @@ int EspMessage::ByteSize() const {
 }
 
 void EspMessage::MergeFrom(const ::google::protobuf::Message& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     const EspMessage* source = dynamic_cast<const EspMessage*>(&from);
     if (source == NULL) {
         ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -102,7 +104,7 @@ void EspMessage::MergeFrom(const ::google::protobuf::Message& from) {
 }
 
 void EspMessage::MergeFrom(const EspMessage& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     head = from.head;
     body = from.body;
 }

--- a/src/brpc/memcache.cpp
+++ b/src/brpc/memcache.cpp
@@ -134,7 +134,7 @@ int MemcacheRequest::ByteSize() const {
 }
 
 void MemcacheRequest::MergeFrom(const ::google::protobuf::Message& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     const MemcacheRequest* source = dynamic_cast<const MemcacheRequest*>(&from);
     if (source == NULL) {
         ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -144,7 +144,7 @@ void MemcacheRequest::MergeFrom(const ::google::protobuf::Message& from) {
 }
 
 void MemcacheRequest::MergeFrom(const MemcacheRequest& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     _buf.append(from._buf);
     _pipelined_count += from._pipelined_count;
 }
@@ -262,7 +262,7 @@ int MemcacheResponse::ByteSize() const {
 }
 
 void MemcacheResponse::MergeFrom(const ::google::protobuf::Message& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     const MemcacheResponse* source = dynamic_cast<const MemcacheResponse*>(&from);
     if (source == NULL) {
         ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -272,7 +272,7 @@ void MemcacheResponse::MergeFrom(const ::google::protobuf::Message& from) {
 }
 
 void MemcacheResponse::MergeFrom(const MemcacheResponse& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     _err = from._err;
     // responses of memcached according to their binary layout, should be
     // directly concatenatible.

--- a/src/brpc/nshead_message.cpp
+++ b/src/brpc/nshead_message.cpp
@@ -93,7 +93,7 @@ int NsheadMessage::ByteSize() const {
 }
 
 void NsheadMessage::MergeFrom(const ::google::protobuf::Message& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     const NsheadMessage* source = dynamic_cast<const NsheadMessage*>(&from);
     if (source == NULL) {
         LOG(ERROR) << "Can only merge from NsheadMessage";
@@ -104,7 +104,7 @@ void NsheadMessage::MergeFrom(const ::google::protobuf::Message& from) {
 }
 
 void NsheadMessage::MergeFrom(const NsheadMessage& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     // No way to merge two nshead messages, just overwrite.
     head = from.head;
     body = from.body;

--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -94,7 +94,7 @@ int RedisRequest::ByteSize() const {
 }
 
 void RedisRequest::MergeFrom(const ::google::protobuf::Message& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     const RedisRequest* source = dynamic_cast<const RedisRequest*>(&from);
     if (source == NULL) {
         ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -104,7 +104,7 @@ void RedisRequest::MergeFrom(const ::google::protobuf::Message& from) {
 }
 
 void RedisRequest::MergeFrom(const RedisRequest& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     _has_error = _has_error || from._has_error;
     _buf.append(from._buf);
     _ncommand += from._ncommand;
@@ -312,7 +312,7 @@ int RedisResponse::ByteSize() const {
 }
 
 void RedisResponse::MergeFrom(const ::google::protobuf::Message& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     const RedisResponse* source = dynamic_cast<const RedisResponse*>(&from);
     if (source == NULL) {
         ::google::protobuf::internal::ReflectionOps::Merge(from, this);
@@ -322,7 +322,7 @@ void RedisResponse::MergeFrom(const ::google::protobuf::Message& from) {
 }
 
 void RedisResponse::MergeFrom(const RedisResponse& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     if (from._nreply == 0) {
         return;
     }

--- a/src/brpc/thrift_message.cpp
+++ b/src/brpc/thrift_message.cpp
@@ -107,12 +107,12 @@ int ThriftFramedMessage::ByteSize() const {
 }
 
 void ThriftFramedMessage::MergeFrom(const ::google::protobuf::Message& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     LOG(ERROR) << "ThriftFramedMessage does not support MergeFrom";
 }
 
 void ThriftFramedMessage::MergeFrom(const ThriftFramedMessage& from) {
-    GOOGLE_CHECK_NE(&from, this);
+    CHECK_NE(&from, this);
     LOG(ERROR) << "ThriftFramedMessage does not support MergeFrom";
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

GOOGLE_CHECK_NE 源自 protobuf，但是最新版本的 protobuf 去掉了这个宏定义，因此会导致编译出错。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

无影响

- Breaking backward compatibility(向后兼容性): 

无影响

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
