### PR TITLE
fix ut MultiDimensionTest:mlatencyrecorder coredump

### DIFF
--- a/src/bvar/multi_dimension_inl.h
+++ b/src/bvar/multi_dimension_inl.h
@@ -64,8 +64,8 @@ MultiDimension<T>::MultiDimension(const butil::StringPiece& prefix,
 
 template <typename T>
 MultiDimension<T>::~MultiDimension() {
-    delete_stats();
     hide();
+    delete_stats();
 }
 
 template <typename T>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

I found a coredump in ut MultiDimensionTest:mlatencyrecorder and the asan prompt:

![image](https://github.com/apache/brpc/assets/12481610/4dab270d-fefc-4fd7-8369-fedbed9fe193)




### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
