### PR TITLE
Fix HTTP HEAD method

### DIFF
--- a/src/brpc/details/http_message.h
+++ b/src/brpc/details/http_message.h
@@ -46,7 +46,8 @@ class HttpMessage {
 public:
     // If read_body_progressively is true, the body will be read progressively
     // by using SetBodyReader().
-    HttpMessage(bool read_body_progressively = false);
+    explicit HttpMessage(bool read_body_progressively = false,
+                         HttpMethod request_method = HTTP_METHOD_GET);
     ~HttpMessage();
 
     const butil::IOBuf &body() const { return _body; }
@@ -64,6 +65,8 @@ public:
     bool Completed() const { return _stage == HTTP_ON_MESSAGE_COMPLETE; }
     HttpParserStage stage() const { return _stage; }
 
+    HttpMethod request_method() const { return _request_method; }
+
     HttpHeader &header() { return _header; }
     const HttpHeader &header() const { return _header; }
     size_t parsed_length() const { return _parsed_length; }
@@ -74,6 +77,7 @@ public:
     static int on_status(http_parser*, const char *, const size_t);
     static int on_header_field(http_parser *, const char *, const size_t);
     static int on_header_value(http_parser *, const char *, const size_t);
+    // Returns -1 on error, 0 on success, 1 on success and skip body.
     static int on_headers_complete(http_parser *);
     static int on_body_cb(http_parser*, const char *, const size_t);
     static int on_message_complete_cb(http_parser *);
@@ -102,6 +106,7 @@ private:
 
     HttpParserStage _stage;
     std::string _url;
+    HttpMethod _request_method;
     HttpHeader _header;
     bool _read_body_progressively;
     // For mutual exclusion between on_body and SetBodyReader.

--- a/src/brpc/policy/http_rpc_protocol.h
+++ b/src/brpc/policy/http_rpc_protocol.h
@@ -85,9 +85,10 @@ class HttpContext : public ReadableProgressiveAttachment
                   , public InputMessageBase
                   , public HttpMessage {
 public:
-    HttpContext(bool read_body_progressively)
+    explicit HttpContext(bool read_body_progressively,
+                         HttpMethod request_method = HTTP_METHOD_GET)
         : InputMessageBase()
-        , HttpMessage(read_body_progressively)
+        , HttpMessage(read_body_progressively, request_method)
         , _is_stage2(false) {
         // add one ref for Destroy
         butil::intrusive_ptr<HttpContext>(this).detach();
@@ -106,12 +107,12 @@ public:
     bool is_stage2() const { return _is_stage2; }
 
     // @InputMessageBase
-    void DestroyImpl() {
+    void DestroyImpl() override {
         RemoveOneRefForStage2();
     }
 
     // @ReadableProgressiveAttachment
-    void ReadProgressiveAttachmentBy(ProgressiveReader* r) {
+    void ReadProgressiveAttachmentBy(ProgressiveReader* r) override {
         return SetBodyReader(r);
     }
 

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -465,6 +465,7 @@ Socket::Socket(Forbidden)
     , _stream_set(NULL)
     , _total_streams_unconsumed_size(0)
     , _ninflight_app_health_check(0)
+    , _http_request_method(HTTP_METHOD_GET)
 {
     CreateVarsOnce();
     pthread_mutex_init(&_id_wait_list_mutex, NULL);

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -38,6 +38,7 @@
 #include "brpc/socket_id.h"               // SocketId
 #include "brpc/socket_message.h"          // SocketMessagePtr
 #include "bvar/bvar.h"
+#include "http_method.h"
 
 namespace brpc {
 namespace policy {
@@ -577,6 +578,9 @@ public:
 
     bthread_keytable_pool_t* keytable_pool() const { return _keytable_pool; }
 
+    void set_http_request_method(const HttpMethod& method) { _http_request_method = method; }
+    HttpMethod http_request_method() const { return _http_request_method; }
+
 private:
     DISALLOW_COPY_AND_ASSIGN(Socket);
 
@@ -915,6 +919,8 @@ private:
     // Refer to `SocketKeepaliveOptions' for details.
     // non-NULL means that keepalive is on.
     std::shared_ptr<SocketKeepaliveOptions> _keepalive_options;
+
+    HttpMethod _http_request_method;
 };
 
 } // namespace brpc

--- a/test/brpc_http_message_unittest.cpp
+++ b/test/brpc_http_message_unittest.cpp
@@ -226,6 +226,39 @@ TEST(HttpMessageTest, parse_from_iobuf) {
     ASSERT_EQ("text/plain", http_message.header().content_type());
 }
 
+
+TEST(HttpMessageTest, parse_http_head_response) {
+    char response1[1024] = "HTTP/1.1 200 OK\r\n"
+                          "Content-Type: text/plain\r\n"
+                          "Content-Length: 1024\r\n"
+                          "\r\n";
+    butil::IOBuf request;
+    request.append(response1);
+
+    brpc::HttpMessage http_message(false, brpc::HTTP_METHOD_HEAD);
+    ASSERT_TRUE(http_message.ParseFromIOBuf(request) >= 0);
+    ASSERT_TRUE(http_message.Completed()) << http_message.stage();
+    ASSERT_EQ("text/plain", http_message.header().content_type());
+    const std::string* content_length = http_message.header().GetHeader("Content-Length");
+    ASSERT_NE(nullptr, content_length);
+    ASSERT_EQ("1024", *content_length);
+
+
+    char response2[1024] = "HTTP/1.1 200 OK\r\n"
+                           "Content-Type: text/plain\r\n"
+                           "Transfer-Encoding: chunked\r\n"
+                           "\r\n";
+    butil::IOBuf request2;
+    request2.append(response2);
+    brpc::HttpMessage http_message2(false, brpc::HTTP_METHOD_HEAD);
+    ASSERT_TRUE(http_message2.ParseFromIOBuf(request2) >= 0);
+    ASSERT_TRUE(http_message2.Completed()) << http_message2.stage();
+    ASSERT_EQ("text/plain", http_message2.header().content_type());
+    const std::string* transfer_encoding = http_message2.header().GetHeader("Transfer-Encoding");
+    ASSERT_NE(nullptr, transfer_encoding);
+    ASSERT_EQ("chunked", *transfer_encoding);
+}
+
 TEST(HttpMessageTest, find_method_property_by_uri) {
     brpc::Server server;
     ASSERT_EQ(0, server.AddService(new test::EchoService(),
@@ -393,15 +426,15 @@ TEST(HttpMessageTest, serialize_http_response) {
     // content is cleared.
     CHECK(content.empty());
 
+    // null content
+    header.SetHeader("Content-Length", "100");
+    MakeRawHttpResponse(&response, &header, NULL);
+    ASSERT_EQ("HTTP/1.1 200 OK\r\nContent-Length: 100\r\nFoo: Bar\r\n\r\n", response) << butil::ToPrintable(response);
+
     // user-set content-length is ignored.
     content.append("data2");
-    header.SetHeader("Content-Length", "100");
     MakeRawHttpResponse(&response, &header, &content);
     ASSERT_EQ("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nFoo: Bar\r\n\r\ndata2", response);
-
-    // null content
-    MakeRawHttpResponse(&response, &header, NULL);
-    ASSERT_EQ("HTTP/1.1 200 OK\r\nFoo: Bar\r\n\r\n", response);
 }
 
 } //namespace

--- a/test/echo.proto
+++ b/test/echo.proto
@@ -88,6 +88,10 @@ service NacosNamingService {
     rpc List(HttpRequest) returns (HttpResponse);
 };
 
+service HttpService {
+    rpc Head(HttpRequest) returns (HttpResponse);
+}
+
 enum State0 {
     STATE0_NUM_0 = 0;
     STATE0_NUM_1 = 1;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: fix #764

Problem Summary:
解析HTTP HEAD请求的回包时，如果回包header中content-length不为0或者transfer-encoding为shunked，on_headers_complete未返回1，则parser会继续解析body。但是HTTP回包是不包含body部分的，就导致会parser一直等到rpc超时。
https://github.com/apache/brpc/blob/4fa4bcda3cf9ae28a3036a564bd1085581c0263c/src/brpc/details/http_parser.cpp#L1744-L1752

https://github.com/apache/brpc/blob/4fa4bcda3cf9ae28a3036a564bd1085581c0263c/src/brpc/details/http_parser.cpp#L1753-L1766

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
