### PR TITLE
fix redis server example handler memory leak

### DIFF
--- a/example/redis_c++/redis_server.cpp
+++ b/example/redis_c++/redis_server.cpp
@@ -24,6 +24,7 @@
 #include <butil/crc32c.h>
 #include <butil/strings/string_split.h>
 #include <gflags/gflags.h>
+#include <memory>
 #include <unordered_map>
 
 #include <butil/time.h>
@@ -110,9 +111,11 @@ private:
 
 int main(int argc, char* argv[]) {
     google::ParseCommandLineFlags(&argc, &argv, true);
-    RedisServiceImpl* rsimpl = new RedisServiceImpl;
-    rsimpl->AddCommandHandler("get", new GetCommandHandler(rsimpl));
-    rsimpl->AddCommandHandler("set", new SetCommandHandler(rsimpl));
+    RedisServiceImpl *rsimpl = new RedisServiceImpl;
+    auto get_handler =std::unique_ptr<GetCommandHandler>(new GetCommandHandler(rsimpl));
+    auto set_handler =std::unique_ptr<SetCommandHandler>( new SetCommandHandler(rsimpl));
+    rsimpl->AddCommandHandler("get", get_handler.get());
+    rsimpl->AddCommandHandler("set", set_handler.get());
 
     brpc::Server server;
     brpc::ServerOptions server_options;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:


Redis service handler should be released after server stopped.

### What is changed and the side effects?

Changed:

Using `unique_ptr` wrap `GetCommandHandler` and `SetCommandHandler` pointer.

Side effects:
- Performance effects(性能影响):
No
- Breaking backward compatibility(向后兼容性): 
No
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
