### PR TITLE
fix h2 protocol abnormal  case when SETTINGS_HEADER_TABLE_SIZE set to zero

### DIFF
--- a/src/brpc/policy/http2_rpc_protocol.cpp
+++ b/src/brpc/policy/http2_rpc_protocol.cpp
@@ -1569,6 +1569,10 @@ H2UnsentRequest::AppendAndDestroySelf(butil::IOBuf* out, Socket* socket) {
     HPackOptions options;
     options.encode_name = FLAGS_h2_hpack_encode_name;
     options.encode_value = FLAGS_h2_hpack_encode_value;
+    if (ctx->remote_settings().header_table_size == 0) {
+        options.index_policy = HPACK_NEVER_INDEX_HEADER;
+    }
+    
     for (size_t i = 0; i < _size; ++i) {
         hpacker.Encode(&appender, _list[i], options);
     }
@@ -1710,6 +1714,9 @@ H2UnsentResponse::AppendAndDestroySelf(butil::IOBuf* out, Socket* socket) {
     HPackOptions options;
     options.encode_name = FLAGS_h2_hpack_encode_name;
     options.encode_value = FLAGS_h2_hpack_encode_value;
+    if (ctx->remote_settings().header_table_size == 0) {
+        options.index_policy = HPACK_NEVER_INDEX_HEADER;
+    }
 
     for (size_t i = 0; i < _size; ++i) {
         hpacker.Encode(&appender, _list[i], options);


### PR DESCRIPTION
### What problem does this PR solve?

when use h2:grpc protocol pass nginx,  if nginx not support dynamic HPACK,  it will set SETTINGS_HEADER_TABLE_SIZE value to 0，now brpc not address this case.

https://trac.nginx.org/nginx/ticket/1538
rfc reference: https://datatracker.ietf.org/doc/html/rfc9113 4.3.1

Issue Number:

https://github.com/apache/brpc/issues/2286
https://github.com/apache/brpc/issues/2176

Problem Summary:
ignore a h2 protocol param set case

### What is changed and the side effects?

Changed:
add a if check when encode h2 header

Side effects:
- Performance effects(性能影响):
It hardly makes a difference

- Breaking backward compatibility(向后兼容性): 
completely compatible
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
