### PR TITLE
add HTTP server-sent-events(SSE) example in brpc http server

### DIFF
--- a/docs/cn/http_service.md
+++ b/docs/cn/http_service.md
@@ -347,6 +347,8 @@ brpc server支持发送超大或无限长的body。方法如下:
 
 3. 发送完毕后确保所有的`butil::intrusive_ptr<brpc::ProgressiveAttachment>`都析构以释放资源。
 
+另外，利用该特性可以轻松实现Server-Sent Events(SSE)服务，从而使客户端能够通过 HTTP 连接从服务器自动接收更新。非常适合构建诸如chatGPT这类实时应用程序，应用例子详见[http_server.cpp](https://github.com/apache/brpc/blob/master/example/http_c++/http_server.cpp)中的HttpSSEServiceImpl。
+
 # 持续接收
 
 目前brpc server不支持在收齐http请求的header部分后就调用服务回调，即brpc server不适合接收超长或无限长的body。

--- a/docs/en/http_service.md
+++ b/docs/en/http_service.md
@@ -348,6 +348,8 @@ brpc server is capable of sending large or infinite sized body, in following ste
 
 3. After usage, destruct all `butil::intrusive_ptr<brpc::ProgressiveAttachment>` to release related resources.
 
+In addition, we can easily implement Server-Sent Events(SSE) with this feature, which enables a client to receive automatic updates from a server via a HTTP connection. SSE could be used to build real-time applications such as chatGPT. Please refer to HttpSSEServiceImpl in [http_server.cpp](https://github.com/apache/brpc/blob/master/example/http_c++/http_server.cpp) for more details.
+
 # Progressive receiving
 
 Currently brpc server doesn't support calling the service callback once header part in the http request is parsed. In other words, brpc server is not suitable for receiving large or infinite sized body.

--- a/example/http_c++/http.proto
+++ b/example/http_c++/http.proto
@@ -37,3 +37,7 @@ service QueueService {
   rpc stop(HttpRequest) returns (HttpResponse);
   rpc getstats(HttpRequest) returns (HttpResponse);
 };
+
+service HttpSSEService {
+  rpc stream(HttpRequest) returns (HttpResponse);
+};


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:
NA

Problem Summary:
添加了使用brpc 实现HTTP SSE功能的例子，可以用于brpc支持如大语言模型推理服务化等功能

### What is changed and the side effects?

Changed:
在example/http_c++中添加了一个HttpSSEServiceImpl实现。
具体而言，server端依次发送以下内容

1. 发送包含如下头部信息的HTTP response
```
Content-Type: text/event-stream
Cache-Control: no-cache
Connection: keep-alive
```
2. 后续HTTP server基于`ProgressiveAttachment`向客户段发送SSE的消息，格式：
```
[field]: value\n
```
其中， field可以取四个值，它们分别是：data、event、id、retry
Side effects:
- Performance effects(性能影响):
NO impact
- Breaking backward compatibility(向后兼容性): 
NO compatibiltiy issue
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
