### PR TITLE
fix DirReaderPosix close same fd twice

### DIFF
--- a/src/butil/files/dir_reader_unix.h
+++ b/src/butil/files/dir_reader_unix.h
@@ -19,6 +19,7 @@
 #ifndef BUTIL_FILES_DIR_READER_UNIX_H_
 #define BUTIL_FILES_DIR_READER_UNIX_H_
 
+#include <cstddef>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
@@ -42,18 +43,14 @@ class DirReaderUnix {
   }
 
   ~DirReaderUnix() {
-    if (fd_ >= 0) {
-      if (IGNORE_EINTR(close(fd_)))
+    if (NULL != dir_) {
+      if (IGNORE_EINTR(closedir(dir_))) { // note this implicitly closes fd_
         RAW_LOG(ERROR, "Failed to close directory handle");
-    }
-    if(NULL != dir_){
-        closedir(dir_);
-    }
+      }
+    };
   }
 
-  bool IsValid() const {
-    return fd_ >= 0;
-  }
+  bool IsValid() const { return dir_ == NULL; }
 
   // Move to the next entry returning false if the iteration is complete.
   bool Next() {

--- a/src/butil/files/dir_reader_unix.h
+++ b/src/butil/files/dir_reader_unix.h
@@ -48,10 +48,10 @@ class DirReaderUnix {
       } else {
         RAW_LOG(ERROR, "Failed to close directory.");
       }
-    };
+    }
   }
 
-  bool IsValid() const { 
+  bool IsValid() const {
     return dir_ != NULL;
   }
 

--- a/src/butil/files/dir_reader_unix.h
+++ b/src/butil/files/dir_reader_unix.h
@@ -19,7 +19,6 @@
 #ifndef BUTIL_FILES_DIR_READER_UNIX_H_
 #define BUTIL_FILES_DIR_READER_UNIX_H_
 
-#include <cstddef>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
@@ -44,13 +43,17 @@ class DirReaderUnix {
 
   ~DirReaderUnix() {
     if (NULL != dir_) {
-      if (IGNORE_EINTR(closedir(dir_))) { // note this implicitly closes fd_
-        RAW_LOG(ERROR, "Failed to close directory handle");
+      if (IGNORE_EINTR(closedir(dir_)) == 0) { // this implicitly closes fd_
+        dir_ = NULL;
+      } else {
+        RAW_LOG(ERROR, "Failed to close directory.");
       }
     };
   }
 
-  bool IsValid() const { return dir_ == NULL; }
+  bool IsValid() const { 
+    return dir_ != NULL;
+  }
 
   // Move to the next entry returning false if the iteration is complete.
   bool Next() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
`DirReaderPosix` 析构时关闭只应调用 `closedir(dir_)` ， 不应同时调用 `close(fd_)`, 否则会导致同一个 `fd` 被close 两次。

> Upon	calling	closedir() the file descriptor is closed. 

https://man.freebsd.org/cgi/man.cgi?query=fdopendir&sektion=3
https://pubs.opengroup.org/onlinepubs/9699919799/functions/fdopendir.html

PoC : 
如果在 `close(fd_)` 和 `closedir(dir_)` 之间有新的 `open` 操作，`fd_` 可能会被复用，则 `closedir(dir_)` 导致该新 open 的 `fd_` 失效，后续对 `fd_` 的操作将会导致 `errno = 9 (Bad File Descriptor)` 错误。

ps: 实际情况可能是在多个线程中触发，这里以单线程代码说明：

``` c++
#include <stdio.h>
#include <dirent.h>
#include <fcntl.h>
#include <stdint.h>
#include <stdlib.h>
#include <errno.h>
#include <unistd.h>
#include <assert.h>
#include <string.h>


int main(int argc, char *argv[])
{
    DIR *d;
    struct dirent *dp;
    int dfd = 0;

    if ((d = fdopendir((dfd = open("./tmp", O_RDONLY)))) == NULL) {
        fprintf(stderr, "Cannot open ./tmp directory\n");
       exit(1);
    }

    // close dfd first,  dfd = 3.
    close(dfd); 

    // then open a new file, ffd maybe be reused, ffd = 3.
    int ffd = open("./tmp/testfile", O_RDONLY); 
    assert(ffd > 0);

    closedir(d); // note this implicitly closes dfd = 3, so ffd is invalid. 
    
    // read ffd would be failed.
    int rc = read(ffd, 0, 2);
    if(rc < 0) {
        printf("Read failed, error %d (%s)\n", errno, strerror(errno)); // errno = 9.
    }
    return 0;
}
```

### What is changed and the side effects?

Changed:
 ~DirReaderUnix()  中只需调用 `closedir(dir_)` 即可.

Side effects:
- Performance effects(性能影响):
No
- Breaking backward compatibility(向后兼容性): 
No
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
