### PR TITLE
[FIX] fix compile on ubuntu18.04 + use anonymous namespace for hardco…

### DIFF
--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -15,14 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <limits>
 
 #include "butil/logging.h"
 #include "brpc/log.h"
 #include "brpc/redis_command.h"
 
-namespace brpc {
+namespace {
 
 const size_t CTX_WIDTH = 5;
+
+} // namespace
+
+namespace brpc {
 
 // Much faster than snprintf(..., "%lu", d);
 inline size_t AppendDecimal(char* outbuf, unsigned long d) {


### PR DESCRIPTION
### Problem Summary:

1. comile error on ubuntu18.04, `BRPC/src/brpc/redis_command.cpp:411:29: error: ‘numeric_limits’ is not a member of ‘std’`
2. CTX_WIDTH should in anonymous namespace, only used in this cpp file.

### Changed:

1. compile on ubuntu18.04, redis_commands.cpp use numeric_limits<>, while missing <limits> header, cause compile error
2. use anonymous namespace for hardcode var, dont emit this to brpc namespace

Side effects:

+ no side effect

