### PR TITLE
change UserDataDeleter type from function ptr to std::function

### DIFF
--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -192,7 +192,7 @@ size_t IOBuf::new_bigview_count() {
 }
 
 const uint16_t IOBUF_BLOCK_FLAGS_USER_DATA = 0x1;
-typedef void (*UserDataDeleter)(void*);
+using UserDataDeleter = std::function<void(void*)>;
 
 struct UserDataExtension {
     UserDataDeleter deleter;
@@ -236,7 +236,8 @@ struct IOBuf::Block {
         , cap(data_size)
         , u({0})
         , data(data_in) {
-        get_user_data_extension()->deleter = deleter;
+        auto ext = new (get_user_data_extension()) UserDataExtension();
+        ext->deleter = std::move(deleter);
     }
 
     // Undefined behavior when (flags & IOBUF_BLOCK_FLAGS_USER_DATA) is 0.
@@ -270,7 +271,9 @@ struct IOBuf::Block {
                 this->~Block();
                 iobuf::blockmem_deallocate(this);
             } else if (flags & IOBUF_BLOCK_FLAGS_USER_DATA) {
-                get_user_data_extension()->deleter(data);
+                auto ext = get_user_data_extension();
+                ext->deleter(data);
+                ext->~UserDataExtension();
                 this->~Block();
                 free(this);
             }
@@ -398,7 +401,7 @@ IOBuf::Block* share_tls_block() {
 }
 
 // Return one block to TLS.
-inline void release_tls_block(IOBuf::Block *b) {
+inline void release_tls_block(IOBuf::Block* b) {
     if (!b) {
         return;
     }
@@ -1219,7 +1222,7 @@ int IOBuf::appendv(const const_iovec* vec, size_t n) {
 
 int IOBuf::append_user_data_with_meta(void* data,
                                       size_t size,
-                                      void (*deleter)(void*),
+                                      std::function<void(void*)> deleter,
                                       uint64_t meta) {
     if (size > 0xFFFFFFFFULL - 100) {
         LOG(FATAL) << "data_size=" << size << " is too large";
@@ -1236,7 +1239,7 @@ int IOBuf::append_user_data_with_meta(void* data,
     if (mem == NULL) {
         return -1;
     }
-    IOBuf::Block* b = new (mem) IOBuf::Block((char*)data, size, deleter);
+    IOBuf::Block* b = new (mem) IOBuf::Block((char*)data, size, std::move(deleter));
     b->u.data_meta = meta;
     const IOBuf::BlockRef r = { 0, b->cap, b };
     _move_back_ref(r);

--- a/src/butil/iobuf.h
+++ b/src/butil/iobuf.h
@@ -24,6 +24,7 @@
 
 #include <sys/uio.h>                             // iovec
 #include <stdint.h>                              // uint32_t
+#include <functional>
 #include <string>                                // std::string
 #include <ostream>                               // std::ostream
 #include <google/protobuf/io/zero_copy_stream.h> // ZeroCopyInputStream
@@ -246,11 +247,11 @@ public:
     // Append the user-data to back side WITHOUT copying.
     // The user-data can be split and shared by smaller IOBufs and will be
     // deleted using the deleter func when no IOBuf references it anymore.
-    int append_user_data(void* data, size_t size, void (*deleter)(void*));
+    int append_user_data(void* data, size_t size, std::function<void(void*)> deleter);
 
     // Append the user-data to back side WITHOUT copying.
     // The meta is associated with this piece of user-data.
-    int append_user_data_with_meta(void* data, size_t size, void (*deleter)(void*), uint64_t meta);
+    int append_user_data_with_meta(void* data, size_t size, std::function<void(void*)> deleter, uint64_t meta);
 
     // Get the data meta of the first byte in this IOBuf.
     // The meta is specified with append_user_data_with_meta before.

--- a/src/butil/iobuf_inl.h
+++ b/src/butil/iobuf_inl.h
@@ -37,8 +37,8 @@ inline ssize_t IOBuf::cut_multiple_into_file_descriptor(
     return pcut_multiple_into_file_descriptor(fd, -1, pieces, count);
 }
 
-inline int IOBuf::append_user_data(void* data, size_t size, void (*deleter)(void*)) {
-    return append_user_data_with_meta(data, size, deleter, 0);
+inline int IOBuf::append_user_data(void* data, size_t size, std::function<void(void*)> deleter) {
+    return append_user_data_with_meta(data, size, std::move(deleter), 0);
 }
 
 inline ssize_t IOPortal::append_from_file_descriptor(int fd, size_t max_count) {

--- a/test/iobuf_unittest.cpp
+++ b/test/iobuf_unittest.cpp
@@ -20,6 +20,7 @@
 #include <sys/socket.h>                // socketpair
 #include <errno.h>                     // errno
 #include <fcntl.h>                     // O_RDONLY
+#include <stdlib.h>
 #include <memory>
 #include <butil/files/temp_file.h>      // TempFile
 #include <butil/containers/flat_map.h>
@@ -1632,6 +1633,9 @@ TEST_F(IOBufTest, append_stateful_user_data) {
     }
 
     struct Deleter {
+        Deleter(std::shared_ptr<char> partial) : partial(std::move(partial)) {}
+        Deleter(const Deleter&) { std::abort(); /*non copy*/ }
+        Deleter(Deleter&&) noexcept = default;
         void operator()(void*) {
             partial.reset();
         }


### PR DESCRIPTION
### What problem does this PR solve?

#### Issue Number:
#2430
#### Problem Summary:
`IOBuf` is brpc's buffer type, which is designed to be compatible with many forms of the underlying data. For example, the `append_user_data` can append a piece of user data into an `IOBuf` without making any copy.

But this interface still has a limitation. Because it accepts deleter of type `void(*)(void*)` only, so that the deleter is unable to save any state or context.

Assume that the user uses a custom memory resource, such as c++17's pmr or some implementations of arena. User requests a large chunk of memory at once, then allocates the memory block monotonically from this chunk. It won't releases any memory unless the chunk is exhausted and all the allocated blocks are marked as "deleted". The usage `std::pmr::monotonic_buffer_resource` could have such behaviour.

However, currently since the deleter cannot carry state or context. It's impossible to perceive whether such a memory resource can be released. Because we cannot notify the owner of the resource that the last reference on that memory resource has been freed and the memory can now be released.

IOBuf是brpc通用的buffer类型，它被设计为可以兼容多种可能的底层数据形式。比如append_user_data接口可以将用户的一段数据拼接到IOBuf中而不产生任何拷贝。

但是这个接口仍然存在局限性。因为它接受的delete仅为void(void*)类型，这导致deleter无法保存任何状态或者上下文。

设想用户使用了一种自定义的内存资源，比如c++17的pmr或者自己实现的arena。用户一次性申请了大块内存，然后将该内存块线性分配给不同的请求，当内存块耗尽且所有分配出去的内存都被标记为释放时时再一次性释放。std::pmr::monotonic_buffer_resource的使用就可能存在这样的行为。

然而由于deleter无法携带状态或者上下文，因此程序无法感知到何时内存资源可以被释放。因为我们无法在deleter中通知资源的持有者，最后一个在该内存资源上的引用已经被释放，现在可以回收内存了。

### What is changed and the side effects?

#### Changed:
把`UserDataDeleter `的类型替换为`std::function`.
#### Side effects:
- Performance effects(性能影响):
  `std::function`可以本地存储函数指针（small object optimization，取决于编译器，但是较新版本的gcc和clang都有实现）。对于已经存在的使用函数指针的代码的性能影响几乎可以忽略不计。overhead只存在于影响了编译器内联。
- Breaking backward compatibility(向后兼容性): 
不破坏任何已有功能。
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译). **checked**
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试). **checked**
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
