### PR TITLE
usleep returns ESTOP when schedule timer failed

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -796,6 +796,11 @@ int TaskGroup::usleep(TaskGroup** pg, uint64_t timeout_us) {
     g->set_remained(_add_sleep_event, &e);
     sched(pg);
     g = *pg;
+    if (e.meta->current_sleep == 0 && !e.meta->interrupted) {
+        // Fail to `_add_sleep_event'.
+        errno = ESTOP;
+        return -1;
+    }
     e.meta->current_sleep = 0;
     if (e.meta->interrupted) {
         // Race with set and may consume multiple interruptions, which are OK.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

_add_sleep_event失败后，bthread_usleep并没有真正sleep，只是重新调度了，这时候应该返回错误。一些场景下会有死循环风险，例如：
https://github.com/apache/brpc/blob/13a07174eab6ce4ae898ecf2bdb5e1144f7df313/src/brpc/periodic_naming_service.cpp#L64-L71

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
