### PR TITLE
Disallow copy and assign of Channel

### DIFF
--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -153,7 +153,9 @@ friend class Controller;
 friend class SelectiveChannel;
 public:
     Channel(ProfilerLinker = ProfilerLinker());
-    ~Channel();
+    virtual ~Channel();
+
+    DISALLOW_COPY_AND_ASSIGN(Channel);
 
     // Connect this channel to a single server whose address is given by the
     // first parameter. Use default options if `options' is NULL.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

禁用Channel拷贝和赋值操作：
1. 拷贝得到Channel并一定能使用（不知道是否Init）
2. 拷贝后，未再次执行SocketMapInsert令_server_id的引用计数加一。这样，只要有一个Channel析构了，就会将_server_id从SocketMap里删除，其他Channel副本的RPC调用都会失败。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
