### PR TITLE
Fix stream write in background not work

### DIFF
--- a/src/brpc/stream.cpp
+++ b/src/brpc/stream.cpp
@@ -689,7 +689,7 @@ int StreamWrite(StreamId stream_id, const butil::IOBuf &message,
         return EINVAL;
     }
     Stream* s = (Stream*)ptr->conn();
-    const int rc = s->AppendIfNotFull(message);
+    const int rc = s->AppendIfNotFull(message, options);
     if (rc == 0) {
         return 0;
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

#2280 中Socket::StartWrite的write_in_background并未生效。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
