### PR TITLE
Fix comment of http parser and some typos

### DIFF
--- a/src/brpc/details/http_parser.h
+++ b/src/brpc/details/http_parser.h
@@ -208,7 +208,9 @@ struct http_parser {
   unsigned int index : 8;        /* index into current matcher */
 
   uint32_t nread;          /* # bytes read in various scenarios */
-  uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */
+  uint64_t content_length; /* # bytes in body. `(uint64_t) -1` (all bits one)
+                            * if no Content-Length header.
+                            */
 
   /** READ-ONLY **/
   unsigned short http_major;

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -236,7 +236,7 @@ void SendRpcResponse(int64_t correlation_id,
         span->set_response_size(res_buf.size());
     }
     // Send rpc response over stream even if server side failed to create
-    // stream for some reasons.
+    // stream for some reason.
     if(cntl->has_remote_stream()){
         // Send the response over stream to notify that this stream connection
         // is successfully built.
@@ -255,7 +255,7 @@ void SendRpcResponse(int64_t correlation_id,
         }
 
         if(stream_ptr) {
-            // Now it's ok the mark this server-side stream as connectted as all the
+            // Now it's ok the mark this server-side stream as connected as all the
             // written user data would follower the RPC response.
             ((Stream*)stream_ptr->conn())->SetConnected();
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

http_parser.content_length有误，应该修改为以下：
https://github.com/nodejs/http-parser/blob/ec8b5ee63f0e51191ea43bb0c6eac7bfbff3141d/http_parser.h#L311-L313

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
