### PR TITLE
Opt ssl read log

### DIFF
--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -2066,8 +2066,10 @@ ssize_t Socket::DoRead(size_t size_hint) {
                          << ": " << SSLError(e);
             errno = ESSL;
         } else {
-            // System error with corresponding errno set
-            PLOG(WARNING) << "Fail to read from ssl_fd=" << fd();
+            // System error with corresponding errno set.
+            PLOG_IF(WARNING, ssl_error != SSL_ERROR_ZERO_RETURN &&
+                             ssl_error != SSL_ERROR_SYSCALL)
+                << "Fail to read from ssl_fd=" << fd();
         }
         break;
     }

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -17,6 +17,7 @@
 
 
 #include "butil/compat.h"                        // OS_MACOSX
+#include "butil/ssl_compat.h"                    // BIO_fd_non_fatal_error
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #ifdef USE_MESALINK
@@ -2067,9 +2068,11 @@ ssize_t Socket::DoRead(size_t size_hint) {
             errno = ESSL;
         } else {
             // System error with corresponding errno set.
-            PLOG_IF(WARNING, ssl_error != SSL_ERROR_ZERO_RETURN &&
-                             ssl_error != SSL_ERROR_SYSCALL)
-                << "Fail to read from ssl_fd=" << fd();
+            bool is_fatal_error = (ssl_error != SSL_ERROR_ZERO_RETURN &&
+                                   ssl_error != SSL_ERROR_SYSCALL) ||
+                                   BIO_fd_non_fatal_error(errno) != 0 ||
+                                  nr < 0;
+            PLOG_IF(WARNING, is_fatal_error) << "Fail to read from ssl_fd=" << fd();
         }
         break;
     }

--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -19,6 +19,7 @@
 
 // Date: Thu Nov 22 13:57:56 CST 2012
 
+#include "butil/ssl_compat.h"               // BIO_fd_non_fatal_error
 #include <openssl/err.h>
 #include <openssl/ssl.h>                   // SSL_*
 #ifdef USE_MESALINK
@@ -37,10 +38,6 @@
 #include "butil/logging.h"                  // CHECK, LOG
 #include "butil/fd_guard.h"                 // butil::fd_guard
 #include "butil/iobuf.h"
-
-#if defined (OPENSSL_IS_BORINGSSL)
-#include "butil/ssl_compat.h"               // BIO_fd_non_fatal_error
-#endif
 
 namespace butil {
 namespace iobuf {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #977

Problem Summary:

对端发送完数据后关闭连接或者shutdown ssl，就有可能出现ssl_error=SSL_ERROR_SYSCALL/SSL_ERROR_ZERO_RETURN、nr>0、e=0，这应该是正常情况，没有必要打印WARNING日志。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
