### PR TITLE
Opt Content-Length in response to HEAD request

### DIFF
--- a/src/brpc/details/http_message.cpp
+++ b/src/brpc/details/http_message.cpp
@@ -135,12 +135,6 @@ int HttpMessage::on_header_value(http_parser *parser,
 int HttpMessage::on_headers_complete(http_parser *parser) {
     HttpMessage *http_message = (HttpMessage *)parser->data;
     http_message->_stage = HTTP_ON_HEADERS_COMPLETE;
-    // Move content-type into the member field.
-    const std::string* content_type = http_message->header().GetHeader("content-type");
-    if (content_type) {
-        http_message->header().set_content_type(*content_type);
-        http_message->header().RemoveHeader("content-type");
-    }
     if (parser->http_major > 1) {
         // NOTE: this checking is a MUST because ProcessHttpResponse relies
         // on it to cast InputMessageBase* into different types.
@@ -177,7 +171,6 @@ int HttpMessage::on_headers_complete(http_parser *parser) {
             uri.SetHostAndPort(*host_header);
         }
     }
-
 
     // If server receives a response to a HEAD request, returns 1 and then
     // the parser will interpret that as saying that this message has no body.
@@ -628,7 +621,8 @@ void MakeRawHttpResponse(butil::IOBuf* response,
        << h->minor_version() << ' ' << h->status_code()
        << ' ' << h->reason_phrase() << BRPC_CRLF;
     bool is_invalid_content = h->status_code() < HTTP_STATUS_OK ||
-                      h->status_code() == HTTP_STATUS_NO_CONTENT;
+                              h->status_code() == HTTP_STATUS_NO_CONTENT;
+    bool is_head_req = h->method() == HTTP_METHOD_HEAD;
     if (is_invalid_content) {
         // https://www.rfc-editor.org/rfc/rfc7230#section-3.3.1
         // A server MUST NOT send a Transfer-Encoding header field in any
@@ -640,11 +634,22 @@ void MakeRawHttpResponse(butil::IOBuf* response,
         // with a status code of 1xx (Informational) or 204 (No Content).
         h->RemoveHeader("Content-Length");
     } else if (content) {
-        h->RemoveHeader("Content-Length");
-        // Never use "Content-Length" set by user.
-        // Always set Content-Length since lighttpd requires the header to be
-        // set to 0 for empty content.
-        os << "Content-Length: " << content->length() << BRPC_CRLF;
+        const std::string* content_length = h->GetHeader("Content-Length");
+        if (is_head_req) {
+            // Prioritize "Content-Length" set by user.
+            // If "Content-Length" is not set, set it to the length of content.
+            if (!content_length) {
+                os << "Content-Length: " << content->length() << BRPC_CRLF;
+            }
+        } else {
+            if (content_length) {
+                h->RemoveHeader("Content-Length");
+            }
+            // Never use "Content-Length" set by user.
+            // Always set Content-Length since lighttpd requires the header to be
+            // set to 0 for empty content.
+            os << "Content-Length: " << content->length() << BRPC_CRLF;
+        }
     }
     if (!h->content_type().empty()) {
         os << "Content-Type: " << h->content_type()
@@ -656,7 +661,12 @@ void MakeRawHttpResponse(butil::IOBuf* response,
     }
     os << BRPC_CRLF;  // CRLF before content
     os.move_to(*response);
-    if (!is_invalid_content && content) {
+
+    // https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.2
+    // The HEAD method is identical to GET except that the server MUST NOT
+    // send a message body in the response (i.e., the response terminates at
+    // the end of the header section).
+    if (!is_invalid_content && !is_head_req && content) {
         response->append(butil::IOBuf::Movable(*content));
     }
 }

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -942,14 +942,10 @@ HttpResponseSender::~HttpResponseSender() {
         }
     } else {
         butil::IOBuf* content = NULL;
-        if ((cntl->Failed() || !cntl->has_progressive_writer()) &&
-            // https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.2
-            // The HEAD method is identical to GET except that the server MUST NOT
-            // send a message body in the response (i.e., the response terminates at
-            // the end of the header section).
-            req_header->method() != HTTP_METHOD_HEAD) {
+        if (cntl->Failed() || !cntl->has_progressive_writer()) {
             content = &cntl->response_attachment();
         }
+        res_header->set_method(req_header->method());
         butil::IOBuf res_buf;
         MakeRawHttpResponse(&res_buf, res_header, content);
         if (FLAGS_http_verbose) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
1. #2366 修复了HEAD请求的问题，但是一般情况下http service不会设置Content-Length，响应就不会包括Content-Length，没有达到HEAD请求的预期。
2. #2319 保证了Content-Type在HttpHeader是唯一的，那么在解包的时候，就不需要设置两次Content-Type了。https://github.com/apache/brpc/blob/dc9e786fbb5fd79f08b49fa8d55ec4e1a35f2125/src/brpc/details/http_message.cpp#L139-L143

### What is changed and the side effects?

Changed:
1. 当响应HEAD请求时，优先使用用户设置的Content-Length。如果用户没有设置Content-Length，则使用content的长度作为Content-Length的值。
2. 删除HttpMessage::on_headers_complete中重复设置Content-Type的重复逻辑。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
