### PR TITLE
add #include <memory> in brpc/details/http_message.h for compilation in CentOS8

### DIFF
--- a/src/brpc/details/http_message.h
+++ b/src/brpc/details/http_message.h
@@ -19,6 +19,7 @@
 #ifndef BRPC_HTTP_MESSAGE_H
 #define BRPC_HTTP_MESSAGE_H
 
+#include <memory>
 #include <string>                      // std::string
 #include "butil/macros.h"
 #include "butil/iobuf.h"               // butil::IOBuf


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: 2473

Problem Summary:

### What is changed and the side effects?

Changed: add #include <memory> in brpc/details/http_message.h

Side effects:
- Performance effects(性能影响):
None
- Breaking backward compatibility(向后兼容性): 
None
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
