### PR TITLE
Fix scoped_refptr leave ptr_ uninit when move construct by nullptr

### DIFF
--- a/src/butil/memory/ref_counted.h
+++ b/src/butil/memory/ref_counted.h
@@ -285,17 +285,15 @@ class scoped_refptr {
       ptr_->AddRef();
   }
 
-  scoped_refptr(scoped_refptr<T>&& r) noexcept : ptr_(r.ptr_) {
-    if (r.ptr_){
-      r.ptr_ = nullptr;
-    }
+  scoped_refptr(scoped_refptr<T>&& r) noexcept {
+    ptr_ = r.ptr_;
+    r.ptr_ = nullptr;
   }
 
   template <typename U>
-  scoped_refptr(scoped_refptr<U>&& r) noexcept : ptr_(r.ptr_) {
-    if (r.ptr_){
-      r.ptr_ = nullptr;
-    }
+  scoped_refptr(scoped_refptr<U>&& r) noexcept {
+    ptr_ = r.ptr_;
+    r.ptr_ = nullptr;
   }
 
   ~scoped_refptr() {

--- a/src/butil/memory/ref_counted.h
+++ b/src/butil/memory/ref_counted.h
@@ -285,21 +285,19 @@ class scoped_refptr {
       ptr_->AddRef();
   }
 
-  scoped_refptr(scoped_refptr<T>&& r) noexcept {
+  scoped_refptr(scoped_refptr<T>&& r) noexcept : ptr_(r.get()) {
     if (r.ptr_){
-      ptr_ = r.ptr_;
       r.ptr_ = nullptr;
     }
   }
 
   template <typename U>
-  scoped_refptr(scoped_refptr<U>&& r) noexcept {
+  scoped_refptr(scoped_refptr<U>&& r) noexcept : ptr_(r.get()) {
     if (r.ptr_){
-      ptr_ = r.ptr_;
       r.ptr_ = nullptr;
     }
   }
- 
+
   ~scoped_refptr() {
     if (ptr_)
       ptr_->Release();

--- a/src/butil/memory/ref_counted.h
+++ b/src/butil/memory/ref_counted.h
@@ -285,14 +285,14 @@ class scoped_refptr {
       ptr_->AddRef();
   }
 
-  scoped_refptr(scoped_refptr<T>&& r) noexcept : ptr_(r.get()) {
+  scoped_refptr(scoped_refptr<T>&& r) noexcept : ptr_(r.ptr_) {
     if (r.ptr_){
       r.ptr_ = nullptr;
     }
   }
 
   template <typename U>
-  scoped_refptr(scoped_refptr<U>&& r) noexcept : ptr_(r.get()) {
+  scoped_refptr(scoped_refptr<U>&& r) noexcept : ptr_(r.ptr_) {
     if (r.ptr_){
       r.ptr_ = nullptr;
     }

--- a/test/ref_counted_unittest.cc
+++ b/test/ref_counted_unittest.cc
@@ -82,3 +82,16 @@ TEST(RefCountedUnitTest, ScopedRefPtrBooleanOperations) {
   EXPECT_NE(raw_p, p2);
   EXPECT_EQ(p1, p2);
 }
+
+TEST(RefCountedUnitTest, ScopedRefPtrMoveCtor)
+{
+  scoped_refptr<SelfAssign> p1 = new SelfAssign;
+  EXPECT_TRUE(p1);
+
+  scoped_refptr<SelfAssign> p2(std::move(p1));
+  EXPECT_TRUE(p2);
+  EXPECT_FALSE(p1);
+
+  scoped_refptr<SelfAssign> p3(std::move(p1));
+  EXPECT_FALSE(p3);
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
scoped_refptr 使用 nullptr 移动构造时会导致 ptr_ 未初始化，从而有可能导致内存问题

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响): 无

- Breaking backward compatibility(向后兼容性): 无

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
