### PR TITLE
Support 100-continue of server and remove expect header of request

### DIFF
--- a/src/brpc/details/http_message.cpp
+++ b/src/brpc/details/http_message.cpp
@@ -559,6 +559,11 @@ void MakeRawHttpRequest(butil::IOBuf* request,
         os << "Content-Length: " << (content ? content->length() : 0)
            << BRPC_CRLF;
     }
+    // `Expect: 100-continue' is not supported, remove it.
+    const std::string* expect = h->GetHeader("Expect");
+    if (expect && *expect == "100-continue") {
+        h->RemoveHeader("Expect");
+    }
     //rfc 7230#section-5.4:
     //A client MUST send a Host header field in all HTTP/1.1 request
     //messages. If the authority component is missing or undefined for

--- a/src/brpc/policy/http_rpc_protocol.h
+++ b/src/brpc/policy/http_rpc_protocol.h
@@ -43,6 +43,8 @@ struct CommonStrings {
     std::string ACCEPT_ENCODING;
     std::string CONTENT_ENCODING;
     std::string CONTENT_LENGTH;
+    std::string EXPECT;
+    std::string CONTINUE_100;
     std::string GZIP;
     std::string CONNECTION;
     std::string KEEP_ALIVE;

--- a/test/echo.proto
+++ b/test/echo.proto
@@ -90,6 +90,7 @@ service NacosNamingService {
 
 service HttpService {
     rpc Head(HttpRequest) returns (HttpResponse);
+    rpc Expect(HttpRequest) returns (HttpResponse);
 }
 
 enum State0 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
客户端使用libcurl请求brpc http服务端，偶现耗时超过1秒。经排查，发现是libcurl当使用Post或者Put方法，请求体超过一定大小(一般是 1024 字节)时，libcurl 自动添加”Expect: 100-continue”请求头，先发送header，等到服务端确认能接收body，收到服务端的100 continue response或者超过1秒，才发送body部分数据给服务端。

详细见[libcurl Expect 100-continue](https://everything.curl.dev/http/post/expect100) 和[rfc7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1)。



### What is changed and the side effects?

Changed:

1. 客户端组包的时候移除expect: 100-continue header。请求带上expect: 100-continue后，服务端可能会在收完header后先回100 continue response，等到收完body处理完再回200 ok response。brpc客户端不支持一个请求对应两个回包的场景。
2. 服务端解包时之解析出header，未收到body，先回100 continue response，等到收完body处理完再回200 ok response。


Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
