### PR TITLE
fix LoadBalancerWithNaming memory leak when ssl init failed

### DIFF
--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -19,6 +19,7 @@
 #include <inttypes.h>
 #include <google/protobuf/descriptor.h>
 #include <gflags/gflags.h>
+#include <memory>
 #include "butil/time.h"                              // milliseconds_from_now
 #include "butil/logging.h"
 #include "butil/third_party/murmurhash3/murmurhash3.h"
@@ -372,7 +373,8 @@ int Channel::Init(const char* ns_url,
             _options.mutable_ssl_options()->sni_name = _service_name;
         }
     }
-    LoadBalancerWithNaming* lb = new (std::nothrow) LoadBalancerWithNaming;
+    std::unique_ptr<LoadBalancerWithNaming> lb(new (std::nothrow)
+                                                   LoadBalancerWithNaming);
     if (NULL == lb) {
         LOG(FATAL) << "Fail to new LoadBalancerWithNaming";
         return -1;        
@@ -387,10 +389,9 @@ int Channel::Init(const char* ns_url,
     }
     if (lb->Init(ns_url, lb_name, _options.ns_filter, &ns_opt) != 0) {
         LOG(ERROR) << "Fail to initialize LoadBalancerWithNaming";
-        delete lb;
         return -1;
     }
-    _lb.reset(lb);
+    _lb.reset(lb.release());
     return 0;
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
lb (`LoadBalancerWithNaming`) 可能内存泄漏当 `CreateSocketSSLContext` 失败时。

### What is changed and the side effects? 

Changed:
使用 `unique_ptr` 包裹 `lb` 临时对象，并在成功完成初始化后，将其生命周期转移给 `_lb`.

Side effects:
- Performance effects(性能影响):
无
- Breaking backward compatibility(向后兼容性): 
无
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
