### PR TITLE
Opt HttpResponseSender move constructor

### DIFF
--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -705,16 +705,19 @@ class HttpResponseSender {
 friend class HttpResponseSenderAsDone;
 public:
     HttpResponseSender()
-        : _method_status(NULL), _received_us(0), _h2_stream_id(-1) {}
-    HttpResponseSender(Controller* cntl/*own*/)
+        : HttpResponseSender(NULL) {}
+    explicit HttpResponseSender(Controller* cntl/*own*/)
         : _cntl(cntl), _method_status(NULL), _received_us(0), _h2_stream_id(-1) {}
-    HttpResponseSender(HttpResponseSender&& s)
+    HttpResponseSender(HttpResponseSender&& s) noexcept
         : _cntl(std::move(s._cntl))
         , _req(std::move(s._req))
         , _res(std::move(s._res))
-        , _method_status(std::move(s._method_status))
+        , _method_status(s._method_status)
         , _received_us(s._received_us)
         , _h2_stream_id(s._h2_stream_id) {
+        s._method_status = NULL;
+        s._received_us = 0;
+        s._h2_stream_id = -1;
     }
     ~HttpResponseSender();
 
@@ -735,7 +738,7 @@ private:
 
 class HttpResponseSenderAsDone : public google::protobuf::Closure {
 public:
-    HttpResponseSenderAsDone(HttpResponseSender* s) : _sender(std::move(*s)) {}
+    explicit HttpResponseSenderAsDone(HttpResponseSender* s) : _sender(std::move(*s)) {}
     void Run() override {
         _sender._cntl->CallAfterRpcResp(_sender._req.get(), _sender._res.get());
         delete this;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

HttpResponseSender移动后，重置成员变量，合理一些。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
