### PR TITLE
Fix bthread_usleep return unexpected error

### DIFF
--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -196,7 +196,7 @@ if [ "$SYSTEM" = "Darwin" ]; then
 	DYNAMIC_LINKINGS="$DYNAMIC_LINKINGS -Wl,-U,_MallocExtension_ReleaseFreeMemory"
 	DYNAMIC_LINKINGS="$DYNAMIC_LINKINGS -Wl,-U,_ProfilerStart"
 	DYNAMIC_LINKINGS="$DYNAMIC_LINKINGS -Wl,-U,_ProfilerStop"
-  DYNAMIC_LINKINGS="$DYNAMIC_LINKINGS -Wl,-U,__Z13GetStackTracePPvii"
+	DYNAMIC_LINKINGS="$DYNAMIC_LINKINGS -Wl,-U,__Z13GetStackTracePPvii"
 	DYNAMIC_LINKINGS="$DYNAMIC_LINKINGS -Wl,-U,_RegisterThriftProtocol"
 fi
 append_linking() {

--- a/src/bthread/task_meta.h
+++ b/src/bthread/task_meta.h
@@ -53,6 +53,9 @@ struct TaskMeta {
     butil::atomic<ButexWaiter*> current_waiter;
     uint64_t current_sleep;
 
+    // A flag to mark if the Timer scheduling failed.
+    bool sleep_failed;
+
     // A builtin flag to mark if the thread is stopping.
     bool stop;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

#2435 的改动可能会导致bthread_usleep实际上成功执行，但是返回ESTOP失败。

`_add_sleep_event`函数中，在定时器添加成功后，`e.meta->current_sleep = sleep_id`之前，定时器执行，唤醒了协程。
https://github.com/apache/brpc/blob/09141d4d87e2a68736144ebc6dad55eba449c6cc/src/bthread/task_group.cpp#L757-L775

协程被唤醒后，`current_sleep`为0、`interrupted`为false，返回了ESTOP错误。
https://github.com/apache/brpc/blob/09141d4d87e2a68736144ebc6dad55eba449c6cc/src/bthread/task_group.cpp#L804-L808 

### What is changed and the side effects?

Changed:

使用一个特定的成员变量代替`current_sleep==0`来表示定时器添加失败。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
