### PR TITLE
解决客户端收到Goaway的问题

### DIFF
--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -603,7 +603,7 @@ void Controller::OnVersionedRPCReturned(const CompletionInfo& info,
         _current_call.nretry >= _max_retry) {
         goto END_OF_RPC;
     }
-    if (_current_call.sending_sock->MarkedGoAway()) {
+    if (_current_call.sending_sock != NULL && _current_call.sending_sock->MarkedGoAway()) {
         CHECK_EQ(current_id(), info.id) << "error_code=" << _error_code;
         _current_call.OnComplete(this, 0, info.responded, false);
         if (_http_response) {

--- a/src/brpc/policy/http2_rpc_protocol.cpp
+++ b/src/brpc/policy/http2_rpc_protocol.cpp
@@ -977,6 +977,7 @@ H2ParseResult H2Context::OnGoAway(
     if (is_client_side()) {
         // The socket will not be selected for further requests.
         _socket->SetLogOff();
+        _socket->SetGoAway();
 
         std::vector<H2StreamContext*> goaway_streams;
         RemoveGoAwayStreams(last_stream_id, &goaway_streams);
@@ -1810,7 +1811,7 @@ void PackH2Request(butil::IOBuf*,
 
 static bool IsH2SocketValid(Socket* s) {
     H2Context* c = static_cast<H2Context*>(s->parsing_context());
-    return (c == NULL || !c->RunOutStreams());
+    return (c == NULL || !c->RunOutStreams()) && !s->MarkedGoAway();
 }
 
 StreamUserData* H2GlobalStreamCreator::OnCreatingStream(

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -433,6 +433,12 @@ public:
     // fd. Once set, this flag can only be cleared inside `WaitAndReset'.
     void SetLogOff();
 
+    // Set EGOAWAY flag to this tmp `Socket' will checkfn fail,
+    // ie. IsH2SocketValid will fail;
+    void SetGoAway();
+
+    bool MarkedGoAway();
+
     // Check Whether the socket is available for user requests.
     bool IsAvailable() const;
 
@@ -875,6 +881,9 @@ private:
 
     // Set by SetLogOff
     butil::atomic<bool> _logoff_flag;
+
+    //Set by SetGoAway
+    bool _goaway_flag;
 
     // Status flag used to mark that
     enum AdditionalRefStatus {

--- a/src/brpc/socket_inl.h
+++ b/src/brpc/socket_inl.h
@@ -247,6 +247,14 @@ inline void Socket::SetLogOff() {
     }
 }
 
+inline void Socket::SetGoAway() {
+    _goaway_flag = true;
+}
+
+inline bool Socket::MarkedGoAway() {
+    return _goaway_flag;
+}
+
 inline bool Socket::IsAvailable() const {
     return !_logoff_flag.load(butil::memory_order_relaxed) &&
         (_ninflight_app_health_check.load(butil::memory_order_relaxed) == 0);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:
#2510
Problem Summary:
客户端收到goawaay应该抛弃原来的tmp_socket, 选择新的socket重试, 并且也不需要做健康检查
### What is changed and the side effects?
none
Changed:

Side effects:
- Performance effects(性能影响):
none
- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
