### PR TITLE
Support bthread_usleep to wait for Singleton on bthread

### DIFF
--- a/src/butil/memory/singleton.h
+++ b/src/butil/memory/singleton.h
@@ -33,9 +33,6 @@ namespace internal {
 // kBeingCreatedMarker means the spinlock is being held for creation.
 static const subtle::AtomicWord kBeingCreatedMarker = 1;
 
-// Yield the current thread/bthread so another thread/bthread can be scheduled.
-void yield();
-
 // We pull out some of the functionality into a non-templated function, so that
 // we can implement the more complicated pieces out of line in the .cc file.
 BUTIL_EXPORT subtle::AtomicWord WaitForInstance(subtle::AtomicWord* instance);

--- a/src/butil/memory/singleton.h
+++ b/src/butil/memory/singleton.h
@@ -33,6 +33,9 @@ namespace internal {
 // kBeingCreatedMarker means the spinlock is being held for creation.
 static const subtle::AtomicWord kBeingCreatedMarker = 1;
 
+// Yield the current thread/bthread so another thread/bthread can be scheduled.
+void yield();
+
 // We pull out some of the functionality into a non-templated function, so that
 // we can implement the more complicated pieces out of line in the .cc file.
 BUTIL_EXPORT subtle::AtomicWord WaitForInstance(subtle::AtomicWord* instance);

--- a/test/singleton_unittest.cc
+++ b/test/singleton_unittest.cc
@@ -296,8 +296,12 @@ extern TaskControl* g_task_control;
 
 class BthreadSingleton {
 public:
+    static BthreadSingleton* GetInstance() {
+        return Singleton<BthreadSingleton>::get();
+    }
+private:
     BthreadSingleton() {
-        bthread_usleep(5 * 1000 * 1000);
+        bthread_usleep(1000 * 1000);
     }
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

对于`::Singleton<T>`，在T构造的时候，并发调用`get`函数，只有一个线程会调用T的构造函数，其他线程会在`WaitForInstance`函数中等待（自旋+`sched_yield`）T完成构造。如果T构造函数中有挂起bthrea的操作，并发大的情况下，有可能会导致“死锁”问题：所有worker线程都在`WaitForInstance`函数中等待T完成构造，而此时已经没有worker可以调度执行T构造函数的bthread了，即T已经无法完成构造。

PR中的UT可以复现该问题。

### What is changed and the side effects?

Changed:

在链接了bthread时，使用`bthread_usleep`，这样在bthread上使用的`:Singleton<T>`就不会阻塞所有worker线程了。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
