### PR TITLE
Fix Content-Length and Transfer-Encoding problems

### DIFF
--- a/src/brpc/details/http_parser.cpp
+++ b/src/brpc/details/http_parser.cpp
@@ -410,7 +410,10 @@ enum header_states
   , h_transfer_encoding
   , h_upgrade
 
+  , h_matching_transfer_encoding_token_start
   , h_matching_transfer_encoding_chunked
+  , h_matching_transfer_encoding_token
+
   , h_matching_connection_keep_alive
   , h_matching_connection_close
 
@@ -499,6 +502,12 @@ bool is_url_char(char c) { return IS_URL_CHAR(c); }
 
 #define start_state (parser->type == HTTP_REQUEST ? s_start_req : s_start_res)
 
+/**
+ * Verify that a char is a valid visible (printable) US-ASCII
+ * character or %x80-FF
+ **/
+#define IS_HEADER_CHAR(ch)                                                     \
+  (ch == CR || ch == LF || ch == 9 || ((unsigned char)ch > 31 && ch != 127))
 
 #if BRPC_HTTP_PARSER_STRICT
 # define STRICT_CHECK(cond)                                          \
@@ -691,6 +700,8 @@ size_t http_parser_execute (http_parser *parser,
   const char *url_mark = 0;
   const char *body_mark = 0;
   const char *status_mark = 0;
+  const unsigned int lenient = parser->lenient_http_headers;
+  const unsigned int allow_chunked_length = parser->allow_chunked_length;
 
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
@@ -782,6 +793,7 @@ size_t http_parser_execute (http_parser *parser,
         if (ch == CR || ch == LF)
           break;
         parser->flags = 0;
+        parser->uses_transfer_encoding = 0;
         parser->content_length = ULLONG_MAX;
 
         if (ch == 'H') {
@@ -817,6 +829,7 @@ size_t http_parser_execute (http_parser *parser,
       case s_start_res:
       {
         parser->flags = 0;
+        parser->uses_transfer_encoding = 0;
         parser->content_length = ULLONG_MAX;
 
         switch (ch) {
@@ -1015,6 +1028,7 @@ size_t http_parser_execute (http_parser *parser,
         if (ch == CR || ch == LF)
           break;
         parser->flags = 0;
+        parser->uses_transfer_encoding = 0;
         parser->content_length = ULLONG_MAX;
 
         if (!IS_ALPHA(ch)) {
@@ -1470,6 +1484,7 @@ size_t http_parser_execute (http_parser *parser,
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(TRANSFER_ENCODING)-2) {
                 parser->header_state = h_transfer_encoding;
+                parser->uses_transfer_encoding = 1;
               }
               break;
 
@@ -1544,8 +1559,12 @@ size_t http_parser_execute (http_parser *parser,
             if ('c' == c) {
               parser->header_state = h_matching_transfer_encoding_chunked;
             } else {
-              parser->header_state = h_general;
+              parser->header_state = h_matching_transfer_encoding_token;
             }
+            break;
+
+          /* Multi-value `Transfer-Encoding` header */
+          case h_matching_transfer_encoding_token_start:
             break;
 
           case h_content_length:
@@ -1554,6 +1573,12 @@ size_t http_parser_execute (http_parser *parser,
               goto error;
             }
 
+            if (parser->flags & F_CONTENTLENGTH) {
+              SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
+              goto error;
+            }
+
+            parser->flags |= F_CONTENTLENGTH;
             parser->content_length = ch - '0';
             break;
 
@@ -1589,6 +1614,11 @@ size_t http_parser_execute (http_parser *parser,
           parser->state = s_header_almost_done;
           CALLBACK_DATA_NOADVANCE(header_value);
           goto reexecute_byte;
+        }
+
+        if (!lenient && !IS_HEADER_CHAR(ch)) {
+          SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
+          goto error;
         }
 
         c = LOWER(ch);
@@ -1628,13 +1658,43 @@ size_t http_parser_execute (http_parser *parser,
           }
 
           /* Transfer-Encoding: chunked */
+          case h_matching_transfer_encoding_token_start:
+            /* looking for 'Transfer-Encoding: chunked' */
+            if ('c' == c) {
+              parser->header_state = h_matching_transfer_encoding_chunked;
+            } else if (TOKEN(c)) {
+              /* NOTE(gejun): Not use strict mode for these macros since the additional
+               * characeters seem to be OK.
+               */
+
+              /* TODO(indutny): similar code below does this, but why?
+               * At the very least it seems to be inconsistent given that
+               * h_matching_transfer_encoding_token does not check for
+               * `STRICT_TOKEN`
+               */
+              parser->header_state = h_matching_transfer_encoding_token;
+            } else if (c == ' ' || c == '\t') {
+              /* Skip lws */
+            } else {
+              parser->header_state = h_general;
+            }
+            break;
+
+          /* Transfer-Encoding: chunked */
           case h_matching_transfer_encoding_chunked:
             parser->index++;
             if (parser->index > sizeof(CHUNKED)-1
                 || c != CHUNKED[parser->index]) {
-              parser->header_state = h_general;
+              parser->header_state = h_matching_transfer_encoding_token;
             } else if (parser->index == sizeof(CHUNKED)-2) {
               parser->header_state = h_transfer_encoding_chunked;
+            }
+            break;
+
+          case h_matching_transfer_encoding_token:
+            if (ch == ',') {
+              parser->header_state = h_matching_transfer_encoding_token_start;
+              parser->index = 0;
             }
             break;
 
@@ -1660,6 +1720,9 @@ size_t http_parser_execute (http_parser *parser,
             break;
 
           case h_transfer_encoding_chunked:
+            if (ch != ' ') parser->header_state = h_matching_transfer_encoding_token;
+            break;
+
           case h_connection_keep_alive:
           case h_connection_close:
             if (ch != ' ') parser->header_state = h_general;
@@ -1739,6 +1802,24 @@ size_t http_parser_execute (http_parser *parser,
           break;
         }
 
+        /* Cannot use transfer-encoding and a content-length header together
+           per the HTTP specification. (RFC 7230 Section 3.3.3) */
+        if ((parser->uses_transfer_encoding == 1) &&
+             (parser->flags & F_CONTENTLENGTH)) {
+          /* Allow it for lenient parsing as long as `Transfer-Encoding` is
+           * not `chunked` or allow_length_with_encoding is set
+           */
+          if (parser->flags & F_CHUNKED) {
+            if (!allow_chunked_length) {
+              SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
+              goto error;
+            }
+          } else if (!lenient) {
+            SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
+            goto error;
+          }
+        }
+
         parser->state = s_headers_done;
 
         /* Here we call the headers_complete callback. This is somewhat
@@ -1791,6 +1872,26 @@ size_t http_parser_execute (http_parser *parser,
         } else if (parser->flags & F_CHUNKED) {
           /* chunked encoding - ignore Content-Length header */
           parser->state = s_chunk_size_start;
+        } else if (parser->uses_transfer_encoding == 1) {
+          if (parser->type == HTTP_REQUEST && !lenient) {
+            /* RFC 7230 3.3.3 */
+            /* If a Transfer-Encoding header field
+            * is present in a request and the chunked transfer coding is not
+            * the final encoding, the message body length cannot be determined
+            * reliably; the server MUST respond with the 400 (Bad Request)
+            * status code and then close the connection.
+            */
+            SET_ERRNO(HPE_INVALID_TRANSFER_ENCODING);
+            return (p - data); /* Error */
+          } else {
+            /* RFC 7230 3.3.3 */
+            /* If a Transfer-Encoding header field is present in a response and
+            * the chunked transfer coding is not the final encoding, the
+            * message body length is determined by reading the connection until
+            * it is closed by the server.
+            */
+              parser->state = s_body_identity_eof;
+          }
         } else {
           if (parser->content_length == 0) {
             /* Content-Length header given but zero: Content-Length: 0\r\n */
@@ -2035,6 +2136,12 @@ http_message_needs_eof (const http_parser *parser)
       parser->status_code == 304 ||     /* Not Modified */
       parser->flags & F_SKIPBODY) {     /* response to a HEAD request */
     return 0;
+  }
+
+  /* RFC 7230 3.3.3, see `s_headers_almost_done` */
+  if ((parser->uses_transfer_encoding == 1) &&
+      (parser->flags & F_CHUNKED) == 0) {
+    return 1;
   }
 
   if ((parser->flags & F_CHUNKED) || parser->content_length != ULLONG_MAX) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

1. [RFC 7230 3.3.3](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3)规范：Content-Length和Transfer-Encoding: chunked不能一起使用，或者忽略Content-Length。目前brpc使用的http-parser版本比较旧，允许Content-Length和Transfer-Encoding: chunked一起使用，存在请求走私（Request Smuggling）和响应拆分（response splitting）的风险。

2. [RFC 7233 3.3.2](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2)规范：有Transfer-Encoding的时候，发送者不能发送Content-Length。

### What is changed and the side effects?

Changed:

1. 引入最新[http-parser](https://github.com/nodejs/http-parser/blob/main/http_parser.c#L1808)中Content-Length和Transfer-Encoding相关的代码。解析http包时，默认拒绝同时存在Content-Length和Transfer-Encoding的http包。如果打开开关且Transfer-Encoding的最后一个编码是chunked时，则移除Content-Length，接受该http包。
2. 组http包时，有Transfer-Encoding，则移除且不添加Content-Length。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
