### PR TITLE
[Fuzzing] add cifuzz workflow

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,38 @@
+name: CIFuzz
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+permissions: {}
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'brpc'
+        language: c++
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'brpc'
+        language: c++
+        fuzz-seconds: 300
+        output-sarif: true
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts
+    - name: Upload Sarif
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+      # Path to SARIF file relative to the root of the repository
+        sarif_file: cifuzz-sarif/results.sarif
+        checkout_path: cifuzz-sarif
+        category: CIFuzz


### PR DESCRIPTION
Integration of [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration) into the brpc repository.

I've scheduled CIFuzz to run every Sunday at 00:00, instead of on every pull request.
I made this change based on my previous CIFuzz integration experience https://github.com/apache/trafficserver/pull/10462.


If you prefer, I can change it to `on: [pull_request]`.
