### PR TITLE
test/iobuf: fix mismatch deallocation

### DIFF
--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -164,8 +164,13 @@ inline void* cp(void *__restrict dest, const void *__restrict src, size_t n) {
 void* (*blockmem_allocate)(size_t) = ::malloc;
 void  (*blockmem_deallocate)(void*) = ::free;
 
+void remove_tls_block_chain();
+
 // Use default function pointers
 void reset_blockmem_allocate_and_deallocate() {
+    // There maybe block allocated by previous hooks, it's wrong to free them using
+    // mismatched hook.
+    remove_tls_block_chain();
     blockmem_allocate = ::malloc;
     blockmem_deallocate = ::free;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

In tests there are some places that don't clear previous allocated block before resetting allocation hooks and lead to asan error.

### What is changed and the side effects?

Changed:

Release lts blocks in `reset_blockmem_allocate_and_deallocate`.

Side effects:
- Performance effects(性能影响):
  None

- Breaking backward compatibility(向后兼容性):
  None
