### PR TITLE
Fix random value of CachedReader at first time

### DIFF
--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -127,7 +127,7 @@ static bool read_proc_status(ProcStat &stat) {
 template <typename T>
 class CachedReader {
 public:
-    CachedReader() : _mtime_us(0) {
+    CachedReader() : _mtime_us(0), _cached{} {
         CHECK_EQ(0, pthread_mutex_init(&_mutex, NULL));
     }
     ~CachedReader() {
@@ -150,7 +150,7 @@ public:
                 pthread_mutex_unlock(&p->_mutex);
                 // don't run fn inside lock otherwise a slow fn may
                 // block all concurrent bvar dumppers. (e.g. /vars)
-                T result;
+                T result{};
                 if (fn(&result)) {
                     pthread_mutex_lock(&p->_mutex);
                     p->_cached = result;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

CachedReader::get_value中fn没有在锁内执行，第一次执行get_value的时候，可能会读到_cache的初始值。由于_cache没有显式初始化，而且实际的类型（如ProcMemory、ProcStat）没有实现默认构造函数，所以成员变量的值是随机值。相对于随机值，值为0，让人更好理解一些。

https://github.com/apache/brpc/blob/24fc31eaa56d8b522975ca41ed012faf6cf77438/src/bvar/default_variables.cpp#L147-L163

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
