### PR TITLE
Fix cancel callback may be called twice

### DIFF
--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -552,13 +552,13 @@ void Controller::NotifyOnCancel(google::protobuf::Closure* callback) {
         LOG(FATAL) << "NotifyCancel a single call more than once!";
         return;
     }
-    if (bthread_id_create(&_oncancel_id, callback, RunOnCancel) != 0) {
-        PLOG(FATAL) << "Fail to create bthread_id";
-        return;
-    }
     SocketUniquePtr sock;
     if (Socket::Address(_current_call.peer_id, &sock) != 0) {
         // Connection already broken
+        return;
+    }
+    if (bthread_id_create(&_oncancel_id, callback, RunOnCancel) != 0) {
+        PLOG(FATAL) << "Fail to create bthread_id";
         return;
     }
     sock->NotifyOnFailed(_oncancel_id);  // Always succeed


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

当bthread_id_create执行成功，Socket::Address执行失败是，callback会被执行。当Controller析构的时候，bthread_id_error会再次执行callback。如果callback执行完会被释放（brpc::NewCallback默认行为），那么这个场景下会出现double delete的问题。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
