### PR TITLE
Fix using butex in return keytable

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -329,7 +329,8 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
             m->local_storage.keytable = NULL; // optional
         }
 
-        // Group is probably changed
+        // During running the function in TaskMeta and deleting the KeyTable in
+        // return_KeyTable, the group is probably changed.
         g =  BAIDU_GET_VOLATILE_THREAD_LOCAL(tls_task_group);
 
         // Increase the version and wake up all joiners, if resulting version

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -307,9 +307,6 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
             thread_return = e.value();
         }
 
-        // Group is probably changed
-        g =  BAIDU_GET_VOLATILE_THREAD_LOCAL(tls_task_group);
-
         // TODO: Save thread_return
         (void)thread_return;
 
@@ -331,6 +328,9 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
             tls_bls.keytable = NULL;
             m->local_storage.keytable = NULL; // optional
         }
+
+        // Group is probably changed
+        g =  BAIDU_GET_VOLATILE_THREAD_LOCAL(tls_task_group);
 
         // Increase the version and wake up all joiners, if resulting version
         // is 0, change it to 1 to make bthread_t never be 0. Any access


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:
#2554
Problem Summary:
当一个bthread（taskmeta中的attr.keytable_pool = null）的生命周期结束，且其拥有keytable实例时。在销毁keytable时会调用由用户创建bthread_key_create(bthread_key_t* key, void (destructor)(void data))中传入的destructor析构函数，如果destructor内部使用了bthread-mutex并挂起的话，bthread恢复后所在的task_group会发生变化。在现有的task_runner实现中，如果在return_keytable后不重新指定task_group的话，调用ending_sched(&g)会出现错误。
### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
