### PR TITLE
Fix : ELEMENTS_PER_BLOCK may be incorrect

### DIFF
--- a/src/butil/containers/doubly_buffered_data.h
+++ b/src/butil/containers/doubly_buffered_data.h
@@ -253,7 +253,7 @@ template <typename T, typename TLS, bool AllowBthreadSuspended>
 class DoublyBufferedData<T, TLS, AllowBthreadSuspended>::WrapperTLSGroup {
 public:
     const static size_t RAW_BLOCK_SIZE = 4096;
-    const static size_t ELEMENTS_PER_BLOCK = (RAW_BLOCK_SIZE + sizeof(DoublyBufferedData::Wrapper) - 1) / sizeof(DoublyBufferedData::Wrapper);
+    const static size_t ELEMENTS_PER_BLOCK = std::max(RAW_BLOCK_SIZE / sizeof(DoublyBufferedData::Wrapper), 1lU);
 
     struct BAIDU_CACHELINE_ALIGNMENT ThreadBlock {
         inline DoublyBufferedData::Wrapper* at(size_t offset) {

--- a/src/butil/containers/doubly_buffered_data.h
+++ b/src/butil/containers/doubly_buffered_data.h
@@ -253,7 +253,7 @@ template <typename T, typename TLS, bool AllowBthreadSuspended>
 class DoublyBufferedData<T, TLS, AllowBthreadSuspended>::WrapperTLSGroup {
 public:
     const static size_t RAW_BLOCK_SIZE = 4096;
-    const static size_t ELEMENTS_PER_BLOCK = std::max(RAW_BLOCK_SIZE / sizeof(DoublyBufferedData::Wrapper), 1lU);
+    const static size_t ELEMENTS_PER_BLOCK = RAW_BLOCK_SIZE / sizeof(Wrapper) > 0 ? RAW_BLOCK_SIZE / sizeof(Wrapper) : 1;
 
     struct BAIDU_CACHELINE_ALIGNMENT ThreadBlock {
         inline DoublyBufferedData::Wrapper* at(size_t offset) {

--- a/src/butil/containers/doubly_buffered_data.h
+++ b/src/butil/containers/doubly_buffered_data.h
@@ -253,7 +253,7 @@ template <typename T, typename TLS, bool AllowBthreadSuspended>
 class DoublyBufferedData<T, TLS, AllowBthreadSuspended>::WrapperTLSGroup {
 public:
     const static size_t RAW_BLOCK_SIZE = 4096;
-    const static size_t ELEMENTS_PER_BLOCK = (RAW_BLOCK_SIZE + sizeof(T) - 1) / sizeof(T);
+    const static size_t ELEMENTS_PER_BLOCK = (RAW_BLOCK_SIZE + sizeof(DoublyBufferedData::Wrapper) - 1) / sizeof(DoublyBufferedData::Wrapper);
 
     struct BAIDU_CACHELINE_ALIGNMENT ThreadBlock {
         inline DoublyBufferedData::Wrapper* at(size_t offset) {
@@ -359,7 +359,7 @@ __thread std::vector<typename DoublyBufferedData<T, TLS, AllowBthreadSuspended>:
         DoublyBufferedData<T, TLS, AllowBthreadSuspended>::WrapperTLSGroup::_s_tls_blocks = NULL;
 
 template <typename T, typename TLS, bool AllowBthreadSuspended>
-class DoublyBufferedData<T, TLS, AllowBthreadSuspended>::Wrapper
+class BAIDU_CACHELINE_ALIGNMENT DoublyBufferedData<T, TLS, AllowBthreadSuspended>::Wrapper
     : public DoublyBufferedDataWrapperBase<T, TLS> {
 friend class DoublyBufferedData;
 public:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:#2561

Problem Summary:

推测常量ELEMENTS_PER_BLOCK本意是一页可以容纳DoublyBufferedData::Wrapper的个数，误写成了sizeof(T)
DoublyBufferedData::Wrapper增加BAIDU_CACHELINE_ALIGNMENT修饰，避免伪共享

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
