### PR TITLE
Fix compile with protobuf 22-25.

### DIFF
--- a/src/brpc/protocol.cpp
+++ b/src/brpc/protocol.cpp
@@ -18,6 +18,8 @@
 
 // Since kDefaultTotalBytesLimit is private, we need some hacks to get the limit.
 // Works for pb 2.4, 2.6, 3.0
+#include "google/protobuf/stubs/common.h"
+#if GOOGLE_PROTOBUF_VERSION < 4022000
 #define private public
 #include <google/protobuf/io/coded_stream.h>
 const int PB_TOTAL_BYETS_LIMITS_RAW =
@@ -25,6 +27,12 @@ const int PB_TOTAL_BYETS_LIMITS_RAW =
 const uint64_t PB_TOTAL_BYETS_LIMITS =
     PB_TOTAL_BYETS_LIMITS_RAW < 0 ? (uint64_t)-1LL : PB_TOTAL_BYETS_LIMITS_RAW;
 #undef private
+#else
+#include <google/protobuf/io/coded_stream.h>
+const int PB_TOTAL_BYETS_LIMITS_RAW = INT_MAX;
+const uint64_t PB_TOTAL_BYETS_LIMITS =
+    PB_TOTAL_BYETS_LIMITS_RAW < 0 ? (uint64_t)-1LL : PB_TOTAL_BYETS_LIMITS_RAW;
+#endif
 
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <google/protobuf/text_format.h>

--- a/src/json2pb/json_to_pb.cpp
+++ b/src/json2pb/json_to_pb.cpp
@@ -534,7 +534,7 @@ bool JsonValueToProtoMessage(const BUTIL_RAPIDJSON_NAMESPACE::Value& json_value,
     for (int i = 0; i < descriptor->extension_range_count(); ++i) {
         const google::protobuf::Descriptor::ExtensionRange*
             ext_range = descriptor->extension_range(i);
-#if GOOGLE_PROTOBUF_VERSION < 4022000
+#if GOOGLE_PROTOBUF_VERSION < 4025000
         for (int tag_number = ext_range->start; tag_number < ext_range->end; ++tag_number)
 #else
         for (int tag_number = ext_range->start_number(); tag_number < ext_range->end_number(); ++tag_number)

--- a/src/json2pb/pb_to_json.cpp
+++ b/src/json2pb/pb_to_json.cpp
@@ -75,7 +75,7 @@ bool PbToJsonConverter::Convert(const google::protobuf::Message& message, Handle
     for (int i = 0; i < ext_range_count; ++i) {
         const google::protobuf::Descriptor::ExtensionRange*
             ext_range = descriptor->extension_range(i);
-#if GOOGLE_PROTOBUF_VERSION < 4022000
+#if GOOGLE_PROTOBUF_VERSION < 4025000
         for (int tag_number = ext_range->start; tag_number < ext_range->end; ++tag_number)
 #else
         for (int tag_number = ext_range->start_number(); tag_number < ext_range->end_number(); ++tag_number)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:  PR #2546 在Protobuf 22-24这几个版本上的编译有一些问题，在25版本上可以编译通过。同时在Rocky 8.9的GCC 13上编译发现，原有的 #define private public的方式已经不被编译器接受，也会导致编译失败。

### What is changed and the side effects?

Changed:  修复在Protobuf 22-24这3个版本上编译失败的问题。对于private的问题，对于高版本增加一个特殊处理解决编译问题。

Side effects:
- Performance effects(性能影响): 无影响

- Breaking backward compatibility(向后兼容性): 无影响

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
