### PR TITLE
修复rpc_channel_connection_count

### DIFF
--- a/src/brpc/details/health_check.cpp
+++ b/src/brpc/details/health_check.cpp
@@ -206,9 +206,6 @@ bool HealthCheckTask::OnTriggeringTask(timespec* next_abstime) {
         hc = ptr->CheckHealth();
     }
     if (hc == 0) {
-        if (ptr->CreatedByConnect()) {
-            g_vars->channel_conn << -1;
-        }
         if (!FLAGS_health_check_path.empty()) {
             ptr->_ninflight_app_health_check.fetch_add(
                     1, butil::memory_order_relaxed);

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -1369,9 +1369,6 @@ int Socket::CheckConnected(int sockfd) {
             << "Connected to " << remote_side()
             << " via fd=" << (int)sockfd << " SocketId=" << id()
             << " local_side=" << local_point;
-    if (CreatedByConnect()) {
-        g_vars->channel_conn << 1;
-    }
     // Doing SSL handshake after TCP connected
     return SSLHandshake(sockfd, false);
 }
@@ -1526,6 +1523,9 @@ void Socket::CheckConnectedAndKeepWrite(int fd, int err, void* data) {
     CHECK_GE(sockfd, 0);
     if (err == 0 && s->CheckConnected(sockfd) == 0
         && s->ResetFileDescriptor(sockfd) == 0) {
+        if (s->CreatedByConnect()) {
+            g_vars->channel_conn << 1;
+        }
         if (s->_app_connect) {
             s->_app_connect->StartConnect(req->socket, AfterAppConnected, req);
         } else {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
在tcp连接成功，ssl握手失败的情况下，rpc_channel_connection_count会自增。随后fd被close，但是计数却没有减

### What is changed and the side effects?

Changed:
只有在Socket::ResetFileDescriptor被成功调用后再自增计数，以使close fd时减计数的逻辑生效
Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
