### PR TITLE
Use sync log for crash fatal log

### DIFF
--- a/src/butil/logging.cc
+++ b/src/butil/logging.cc
@@ -938,7 +938,7 @@ void PrintLog(std::ostream& os, int severity, const char* file, int line,
         OutputLog(os, content);
         if (pair_quote) {
             os << '"';
-        } else if (!content.empty() && content[content.size()-1] != '"') {
+        } else if (!content.empty() && content[content.size() -1 ] != '"') {
             // Controller may write `"M":"...` which misses the last quote
             os << '"';
         }
@@ -1268,10 +1268,11 @@ public:
 
         // write to log file
         if ((logging_destination & LOG_TO_FILE) != 0) {
-            if (FLAGS_async_log) {
-                AsyncLogger::GetInstance()->Log(std::move(log));
-            } else {
+            if ((FLAGS_crash_on_fatal_log && severity == BLOG_FATAL) ||
+                !FLAGS_async_log) {
                 Log2File(log);
+            } else {
+                AsyncLogger::GetInstance()->Log(std::move(log));
             }
         }
         return true;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

对于crash fatal log，使用同步日志，保证在crash之前落盘fatal日志。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
