### PR TITLE
Support FastPthreadMutex contention profiler && expose FastPthreadMutex to user

### DIFF
--- a/src/bthread/butex.cpp
+++ b/src/bthread/butex.cpp
@@ -121,7 +121,7 @@ struct BAIDU_CACHELINE_ALIGNMENT Butex {
 
     butil::atomic<int> value;
     ButexWaiterList waiters;
-    internal::FastPthreadMutex waiter_lock;
+    FastPthreadMutex waiter_lock;
 };
 
 BAIDU_CASSERT(offsetof(Butex, value) == 0, offsetof_value_must_0);
@@ -460,8 +460,8 @@ int butex_requeue(void* arg, void* arg2) {
 
     ButexWaiter* front = NULL;
     {
-        std::unique_lock<internal::FastPthreadMutex> lck1(b->waiter_lock, std::defer_lock);
-        std::unique_lock<internal::FastPthreadMutex> lck2(m->waiter_lock, std::defer_lock);
+        std::unique_lock<FastPthreadMutex> lck1(b->waiter_lock, std::defer_lock);
+        std::unique_lock<FastPthreadMutex> lck2(m->waiter_lock, std::defer_lock);
         butil::double_lock(lck1, lck2);
         if (b->waiters.empty()) {
             return 0;

--- a/src/bthread/id.cpp
+++ b/src/bthread/id.cpp
@@ -114,7 +114,7 @@ struct BAIDU_CACHELINE_ALIGNMENT Id {
     // contended_ver: locked and contended
     uint32_t first_ver;
     uint32_t locked_ver;
-    internal::FastPthreadMutex mutex;
+    FastPthreadMutex mutex;
     void* data;
     int (*on_error)(bthread_id_t, void*, int);
     int (*on_error2)(bthread_id_t, void*, int, const std::string&);

--- a/src/bthread/mutex.h
+++ b/src/bthread/mutex.h
@@ -72,7 +72,7 @@ namespace internal {
 class FastPthreadMutex {
 public:
     FastPthreadMutex() : _futex(0) {}
-    ~FastPthreadMutex() {}
+    ~FastPthreadMutex() = default;
     void lock();
     void unlock();
     bool try_lock();
@@ -85,6 +85,19 @@ private:
 typedef butil::Mutex FastPthreadMutex;
 #endif
 }
+
+class FastPthreadMutex {
+public:
+    FastPthreadMutex() = default;
+    ~FastPthreadMutex() = default;
+    DISALLOW_COPY_AND_ASSIGN(FastPthreadMutex);
+
+    void lock();
+    void unlock();
+    bool try_lock() { return _mutex.try_lock(); }
+private:
+    internal::FastPthreadMutex _mutex;
+};
 
 }  // namespace bthread
 

--- a/src/bthread/timer_thread.cpp
+++ b/src/bthread/timer_thread.cpp
@@ -92,7 +92,7 @@ public:
     Task* consume_tasks();
 
 private:
-    internal::FastPthreadMutex _mutex;
+    FastPthreadMutex _mutex;
     int64_t _nearest_run_time;
     Task* _task_head;
 };

--- a/src/bthread/timer_thread.h
+++ b/src/bthread/timer_thread.h
@@ -95,7 +95,7 @@ private:
 
     TimerThreadOptions _options;
     Bucket* _buckets;        // list of tasks to be run
-    internal::FastPthreadMutex _mutex;    // protect _nearest_run_time
+    FastPthreadMutex _mutex;    // protect _nearest_run_time
     int64_t _nearest_run_time;
     // the futex for wake up timer thread. can't use _nearest_run_time because
     // it's 64-bit.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #1354

Problem Summary:

### What is changed and the side effects?

Changed:

1. FastPthreadMutex支持contention profiler。
2. 暴露FastPthreadMutex给用户使用。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
