### PR TITLE
Do not link abseil interface targets

### DIFF
--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -266,7 +266,7 @@ PROTOBUF_VERSION=$(grep '#define GOOGLE_PROTOBUF_VERSION [0-9]\+' $PROTOBUF_HDR/
 if [ "$PROTOBUF_VERSION" -ge 4022000 ]; then
     ABSL_HDR=$(find_dir_of_header_or_die absl/base/config.h)
     ABSL_LIB=$(find_dir_of_lib_or_die absl_strings)
-    ABSL_LIB_NAMES="
+    ABSL_TARGET_NAMES="
         absl_bad_optional_access
         absl_bad_variant_access
         absl_base
@@ -333,8 +333,11 @@ if [ "$PROTOBUF_VERSION" -ge 4022000 ]; then
         absl_time
         absl_time_zone
     "
-    for i in $ABSL_LIB_NAMES; do
-         append_linking "$ABSL_LIB" "$i"
+    for i in $ABSL_TARGET_NAMES; do
+        # ignore interface targets
+        if [ -n "$(find_dir_of_lib $i)" ]; then
+            append_linking "$ABSL_LIB" "$i"
+        fi
     done
     CXXFLAGS="-std=c++17"
 else


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2591

Problem Summary:

abseil targets required by protobuf may be an interface only target, which should not be linked.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
