### PR TITLE
remove old rpcz directory even if program crash

### DIFF
--- a/docs/cn/rpcz.md
+++ b/docs/cn/rpcz.md
@@ -13,6 +13,7 @@
 | rpcz_database_dir          | ./rpc_data/rpcz      | For storing requests/contexts collected by rpcz. | src/baidu/rpc/span.cpp                 |
 | rpcz_keep_span_db          | false                | Don't remove DB of rpcz at program's exit | src/baidu/rpc/span.cpp                 |
 | rpcz_keep_span_seconds (R) | 3600                 | Keep spans for at most so many seconds   | src/baidu/rpc/span.cpp                 |
+| rpcz_save_span_min_latency_us (R) | 0 (default:0) | The minimum latency microseconds of span saved | src/baidu/rpc/span.cpp |
 
 若启动时未加-enable_rpcz，则可在启动后访问SERVER_URL/rpcz/enable动态开启rpcz，访问SERVER_URL/rpcz/disable则关闭，这两个链接等价于访问SERVER_URL/flags/enable_rpcz?setvalue=true和SERVER_URL/flags/enable_rpcz?setvalue=false。在r31010之后，rpc在html版本中增加了一个按钮可视化地开启和关闭。
 

--- a/src/brpc/span.cpp
+++ b/src/brpc/span.cpp
@@ -506,6 +506,12 @@ inline uint64_t ToLittleEndian(const uint32_t* buf) {
 }
 
 SpanDB* SpanDB::Open() {
+    // Remove old rpcz directory even if crash occurs.
+    if (!FLAGS_rpcz_keep_span_db) {
+        std::string cmd = butil::string_printf("rm -rf %s", FLAGS_rpcz_database_dir.c_str());
+        butil::ignore_result(system(cmd.c_str()));
+    }
+
     SpanDB local;
     leveldb::Status st;
     char prefix[64];


### PR DESCRIPTION
### What problem does this PR solve?

rpcz目录在正常运行过程会周期性的删除旧的数据，但是如果在程序运行一段时间crash掉或者被kill掉，原来的rpcz目录不会释放掉，日积月累会占用很多空间。
这个PR会在rpcz启动的时候并且rpcz_keep_span_db为false的情况下，清理旧的数据。

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
