### PR TITLE
Fix incorrect core file in run_tests.sh

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -15,11 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# turn on coredumps
+ulimit -c unlimited
+rm core.*
+
 test_num=0
 failed_test=""
 rc=0
 test_bins="test_butil test_bvar bthread*unittest brpc*unittest"
-ulimit -c unlimited # turn on coredumps
 for test_bin in $test_bins; do
     test_num=$((test_num + 1))
     >&2 echo "[runtest] $test_bin"
@@ -34,6 +37,7 @@ if [ $test_num -eq 0 ]; then
     >&2 echo "[runtest] Cannot find any tests"
     exit 1
 fi
+
 print_bt () {
     # find newest core file
     COREFILE=$(find . -name "core*" -type f -printf "%T@ %p\n" | sort -k 1 -n | cut -d' ' -f 2- | tail -n 1)
@@ -42,6 +46,7 @@ print_bt () {
         gdb -c "$COREFILE" $1 -ex "thread apply all bt" -ex "set pagination 0" -batch;
     fi
 }
+
 if [ -z "$failed_test" ]; then
     >&2 echo "[runtest] $test_num succeeded"
 elif [ $test_num -gt 1 ]; then


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

https://github.com/apache/brpc/blob/6a335aa8bc713768aaa4dfcc5b1b2b66fe64e7a8/test/run_tests.sh#L37-L44

`run_tests.sh`中有问题，认为最新的core文件一定是失败的ut生成的，但是[ci](https://github.com/apache/brpc/actions/runs/8832477501/job/24249875410)中出现了对不上的情况：

>  1 FAILED TEST
corefile=./core.test_butil.8086 prog=brpc_grpc_protocol_unittest

Problem Summary:

### What is changed and the side effects?

Changed:

先将旧的core文件删除。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
