### PR TITLE
Fix FlatMap assign operator bug

### DIFF
--- a/src/butil/containers/flat_map.h
+++ b/src/butil/containers/flat_map.h
@@ -151,12 +151,12 @@ public:
         key_type key;
     };
     
-    FlatMap(const hasher& hashfn = hasher(), 
-            const key_equal& eql = key_equal(),
-            const allocator_type& alloc = allocator_type());
+    explicit FlatMap(const hasher& hashfn = hasher(),
+                     const key_equal& eql = key_equal(),
+                     const allocator_type& alloc = allocator_type());
     ~FlatMap();
-    FlatMap(const FlatMap& rhs);    
-    void operator=(const FlatMap& rhs);
+    FlatMap(const FlatMap& rhs);
+    FlatMap& operator=(const FlatMap& rhs);
     void swap(FlatMap & rhs);
 
     // Must be called to initialize this map, otherwise insert/operator[]
@@ -307,9 +307,9 @@ public:
     typedef typename Map::key_equal key_equal;
     typedef typename Map::allocator_type allocator_type;
     
-    FlatSet(const hasher& hashfn = hasher(), 
-            const key_equal& eql = key_equal(),
-            const allocator_type& alloc = allocator_type())
+    explicit FlatSet(const hasher& hashfn = hasher(),
+                     const key_equal& eql = key_equal(),
+                     const allocator_type& alloc = allocator_type())
         : _map(hashfn, eql, alloc) {}
     void swap(FlatSet & rhs) { _map.swap(rhs._map); }
 

--- a/test/flat_map_unittest.cpp
+++ b/test/flat_map_unittest.cpp
@@ -1332,6 +1332,21 @@ TEST_F(FlatMapTest, copy) {
     m2 = m1;
     ASSERT_FALSE(m1.is_too_crowded(m1.size()));
     ASSERT_FALSE(m2.is_too_crowded(m1.size()));
+
+    butil::FlatMap<int, int> m3;
+    ASSERT_FALSE(m3.initialized());
+    m1 = m3;
+    ASSERT_TRUE(m1.empty());
+    ASSERT_TRUE(m1.initialized());
+
+    m3 = m2;
+    ASSERT_TRUE(m3.initialized());
+    m3.clear();
+    ASSERT_TRUE(m3.initialized());
+    ASSERT_TRUE(m3.empty());
+    butil::FlatMap<int, int> m4 = m3;
+    ASSERT_TRUE(m4.initialized());
+    ASSERT_TRUE(m4.empty());
 }
 
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

```
butil::FlatMap<int, int> m1;
if (m1.init(32) != 0) {}
butil::FlatMap<int, int> m2 = m1;
```
`FLatMap::operator=`的逻辑有问题，即使m1已经初始化了，但是因为m1是空的，所以将m1赋值给m2后，m2仍然是未初始化的，一旦被使用，基本上就会出core。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
