### PR TITLE
Restrict BRPC_VALIDATE_GFLAG to global scope and namespace scope only

### DIFF
--- a/src/brpc/reloadable_flags.h
+++ b/src/brpc/reloadable_flags.h
@@ -35,9 +35,10 @@
 // modify directly. To emphasize this, you have to write the validator by
 // yourself and use GFLAGS_NS::GetCommandLineOption() to acess the flag.
 #define BRPC_VALIDATE_GFLAG(flag, validate_fn)                     \
-    const int register_FLAGS_ ## flag ## _dummy                         \
-                 __attribute__((__unused__)) =                          \
-        ::brpc::RegisterFlagValidatorOrDie(                       \
+    namespace brpc_flags {}                                        \
+    const int register_FLAGS_ ## flag ## _dummy                    \
+                 __attribute__((__unused__)) =                     \
+        ::brpc::RegisterFlagValidatorOrDie(                        \
             &FLAGS_##flag, (validate_fn))
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

限制BRPC_VALIDATE_GFLAG只能在全局作用域或者namespace中使用，避免注册失败导致运行中的进程退出了。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
