### PR TITLE
Fix GetProgramName not contains absolute path from cmdline

### DIFF
--- a/src/brpc/builtin/common.cpp
+++ b/src/brpc/builtin/common.cpp
@@ -339,17 +339,35 @@ static void CreateProgramName() {
         s_program_name = s_cmdline;
     }
 }
+
 const char* GetProgramName() {
     pthread_once(&create_program_name_once, CreateProgramName);
     return s_program_name;
 }
+
+static pthread_once_t create_program_path_once = PTHREAD_ONCE_INIT;
+static const char* s_program_path = "unknown";
+static char s_program_exec_path[PATH_MAX];
+static void CreateProgramPath() {
+    const ssize_t nr = butil::GetProcessAbsolutePath(s_program_exec_path, sizeof(s_program_exec_path) - 1);
+    if (nr > 0) {
+        s_program_exec_path[nr] = '\0';
+        s_program_path = s_program_exec_path;
+    }
+}
+
+const char* GetProgramPath() {
+    pthread_once(&create_program_path_once, CreateProgramPath);
+    return s_program_path;
+}
+
 
 static pthread_once_t compute_program_checksum_once = PTHREAD_ONCE_INIT;
 static char s_program_checksum[33];
 static const char s_alphabet[] = "0123456789abcdef";
 static void ComputeProgramCHECKSUM() {
     unsigned char checksum[16];
-    FileChecksum(GetProgramName(), checksum);
+    FileChecksum(GetProgramPath(), checksum);
     for (size_t i = 0, j = 0; i < 16; ++i, j+=2) {
         s_program_checksum[j] = s_alphabet[checksum[i] >> 4];
         s_program_checksum[j+1] = s_alphabet[checksum[i] & 0xF];

--- a/src/brpc/builtin/common.h
+++ b/src/brpc/builtin/common.h
@@ -112,6 +112,9 @@ int FileChecksum(const char* file_path, unsigned char* checksum);
 // Get name of current program.
 const char* GetProgramName();
 
+// Get absolute path of current program.
+const char* GetProgramPath();
+
 // Get checksum of current program image.
 const char* GetProgramChecksum();
 

--- a/src/brpc/builtin/hotspots_service.cpp
+++ b/src/brpc/builtin/hotspots_service.cpp
@@ -493,7 +493,7 @@ static void DisplayResult(Controller* cntl,
         cmd_builder << "--base " << *base_name << ' ';
     }
 
-    cmd_builder << GetProgramName() << " " << prof_name;
+    cmd_builder << GetProgramPath() << " " << prof_name;
 
     if (display_type == DisplayType::kFlameGraph) {
         // For flamegraph, we don't care about pprof error msg, 
@@ -509,7 +509,7 @@ static void DisplayResult(Controller* cntl,
     if (base_name) {
         cmd_builder << "-base " << *base_name << ' ';
     }
-    cmd_builder << GetProgramName() << " " << prof_name << " 2>&1 ";
+    cmd_builder << GetProgramPath() << " " << prof_name << " 2>&1 ";
 #endif
 
     const std::string cmd = cmd_builder.str();

--- a/src/butil/process_util.cc
+++ b/src/butil/process_util.cc
@@ -19,8 +19,6 @@
 
 // Date: Wed Apr 11 14:35:56 CST 2018
 
-#include <cstddef>
-#include <cstring>
 #include <fcntl.h>                      // open
 #include <stdio.h>                      // snprintf
 #include <sys/types.h>  
@@ -90,9 +88,6 @@ ssize_t ReadCommandLine(char* buf, size_t len, bool with_args) {
     }
 }
 
-// Get absolute path of this program.
-// Returns length of the absolute path on sucess, -1 otherwise.
-// NOTE: `buf' does not end with zero.
 ssize_t GetProcessAbsolutePath(char *buf, size_t len) {
 #if defined(OS_LINUX)
     memset(buf, 0, len);

--- a/src/butil/process_util.h
+++ b/src/butil/process_util.h
@@ -32,6 +32,11 @@ namespace butil {
 // NOTE: `buf' does not end with zero.
 ssize_t ReadCommandLine(char* buf, size_t len, bool with_args);
 
+// Get absolute path of this program.
+// Returns length of the absolute path on sucess, -1 otherwise.
+// NOTE: `buf' does not end with zero.
+ssize_t GetProcessAbsolutePath(char* buf, size_t len);
+
 } // namespace butil
 
 #endif // BUTIL_PROCESS_UTIL_H


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

从 cmdline 中获取程序名称时不包含程序的完整路径。因为程序的启动路径可能已经包含在了 $PATH 中，所以 cmdline 中只有程序的名称而没有路径信息，导致在使用 `ProgramCHECKSUM` 以及使用 `heap profile` 解析符号时找不到程序的具体位置而导致失败。

#### 复现：
```
export PATH=$PATH:/path/to/echo_server
```
启动server
```
echo_server
```
获取程序的校验码会报错：
```
E20240515 10:57:13.508802 39562 common.cpp:318] Fail to open `echo_server': No such file or directory [2]
```

使用 Heap Profiler 会解析不了.
```
[20240515.110220.heap]
Using remote profile at echo_server.
Using local file ./rpc_data/profiling/000000000000000000000000ce010000/20240515.110220.heap.
The first profile should be a remote form to use /pprof/symbol
```
### What is changed and the side effects?

Changed:
- Linux 系统使用 readlink(/proc/self/exe) 获取程序绝对路径
- MacOSX 系统使用 proc_pidpath 获取当前进程的绝对路径

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
