### PR TITLE
Use butil::ThreadLocal to store keytable

### DIFF
--- a/src/bthread/key.cpp
+++ b/src/bthread/key.cpp
@@ -205,8 +205,7 @@ private:
     SubKeyTable* _subs[KEY_1STLEVEL_SIZE];
 };
 
-class KeyTableList {
-public:
+struct KeyTableList {
     KeyTableList() {
         keytable = NULL;
     }

--- a/src/bthread/key.cpp
+++ b/src/bthread/key.cpp
@@ -349,7 +349,7 @@ int bthread_keytable_pool_destroy(bthread_keytable_pool_t* pool) {
     // Cheat get/setspecific and destroy the keytables.
     bthread::TaskGroup* g = bthread::tls_task_group;
     bthread::KeyTable* old_kt = bthread::tls_bls.keytable;
-    while(saved_free_keytables) {
+    while (saved_free_keytables) {
         bthread::KeyTable* kt = saved_free_keytables;
         saved_free_keytables = kt->next;
         bthread::tls_bls.keytable = kt;
@@ -363,7 +363,6 @@ int bthread_keytable_pool_destroy(bthread_keytable_pool_t* pool) {
     if (g) {
         g->current_task()->local_storage.keytable = old_kt;
     }
-    return 0;
     // TODO: return_keytable may race with this function, we don't destroy
     // the mutex right now.
     // pthread_mutex_destroy(&pool->mutex);

--- a/src/bthread/key.cpp
+++ b/src/bthread/key.cpp
@@ -22,6 +22,7 @@
 #include <pthread.h>
 #include "butil/macros.h"
 #include "butil/atomicops.h"
+#include "butil/thread_key.h"
 #include "bvar/passive_status.h"
 #include "bthread/errno.h"                       // EAGAIN
 #include "bthread/task_group.h"                  // TaskGroup
@@ -204,13 +205,53 @@ private:
     SubKeyTable* _subs[KEY_1STLEVEL_SIZE];
 };
 
+class KeyTableList {
+public:
+    KeyTableList() {
+        keytable = NULL;
+    }
+    ~KeyTableList() {
+        bthread::TaskGroup* const g = bthread::tls_task_group;
+        bthread::KeyTable* old_kt = bthread::tls_bls.keytable;
+        while (keytable) {
+            bthread::KeyTable* kt = keytable;
+            keytable = kt->next;
+            bthread::tls_bls.keytable = kt;
+            if (g) {
+                g->current_task()->local_storage.keytable = kt;
+            }
+            delete kt;
+            if (old_kt == kt) {
+                old_kt = NULL;
+            }
+        }
+        bthread::tls_bls.keytable = old_kt;
+        if(g) {
+            g->current_task()->local_storage.keytable = old_kt;
+        }
+    }
+    KeyTable* keytable;
+};
+
 static KeyTable* borrow_keytable(bthread_keytable_pool_t* pool) {
-    if (pool != NULL && pool->free_keytables) {
-        BAIDU_SCOPED_LOCK(pool->mutex);
-        KeyTable* p = (KeyTable*)pool->free_keytables;
+    if (pool != NULL && (pool->list->get()->keytable || pool->free_keytables)) {
+        pthread_rwlock_rdlock(&pool->rwlock);
+        KeyTable* p = pool->list->get()->keytable;
         if (p) {
-            pool->free_keytables = p->next;
+            pool->list->get()->keytable = p->next;
+            pthread_rwlock_unlock(&pool->rwlock);
             return p;
+        }
+        pthread_rwlock_unlock(&pool->rwlock);
+        if (pool->free_keytables) {
+            pthread_rwlock_wrlock(&pool->rwlock);
+            p = (KeyTable*)pool->free_keytables;
+            if (p) {
+                pool->free_keytables = p->next;
+                pthread_rwlock_unlock(&pool->rwlock);
+                return p;
+            }
+            pthread_rwlock_unlock(&pool->rwlock);
         }
     }
     return NULL;
@@ -226,14 +267,15 @@ void return_keytable(bthread_keytable_pool_t* pool, KeyTable* kt) {
         delete kt;
         return;
     }
-    std::unique_lock<pthread_mutex_t> mu(pool->mutex);
+    pthread_rwlock_rdlock(&pool->rwlock);
     if (pool->destroyed) {
-        mu.unlock();
+        pthread_rwlock_unlock(&pool->rwlock);
         delete kt;
         return;
     }
-    kt->next = (KeyTable*)pool->free_keytables;
-    pool->free_keytables = kt;
+    kt->next = pool->list->get()->keytable;
+    pool->list->get()->keytable = kt;
+    pthread_rwlock_unlock(&pool->rwlock);
 }
 
 static void cleanup_pthread(void* arg) {
@@ -279,7 +321,8 @@ int bthread_keytable_pool_init(bthread_keytable_pool_t* pool) {
         LOG(ERROR) << "Param[pool] is NULL";
         return EINVAL;
     }
-    pthread_mutex_init(&pool->mutex, NULL);
+    pthread_rwlock_init(&pool->rwlock, NULL);
+    pool->list = new butil::ThreadLocal<bthread::KeyTableList>();
     pool->free_keytables = NULL;
     pool->destroyed = 0;
     return 0;
@@ -291,33 +334,18 @@ int bthread_keytable_pool_destroy(bthread_keytable_pool_t* pool) {
         return EINVAL;
     }
     bthread::KeyTable* saved_free_keytables = NULL;
-    {
-        BAIDU_SCOPED_LOCK(pool->mutex);
-        if (pool->free_keytables) {
-            saved_free_keytables = (bthread::KeyTable*)pool->free_keytables;
-            pool->free_keytables = NULL;
-        }
-        pool->destroyed = 1;
-    }
-    // Cheat get/setspecific and destroy the keytables.
-    bthread::TaskGroup* const g = bthread::tls_task_group;
-    bthread::KeyTable* old_kt = bthread::tls_bls.keytable;
-    while (saved_free_keytables) {
+    pthread_rwlock_wrlock(&pool->rwlock);
+    pool->destroyed = 1;
+    delete pool->list;
+    saved_free_keytables = (bthread::KeyTable*)pool->free_keytables;
+    pool->free_keytables = NULL;
+    pthread_rwlock_unlock(&pool->rwlock);
+    while(saved_free_keytables) {
         bthread::KeyTable* kt = saved_free_keytables;
         saved_free_keytables = kt->next;
-        bthread::tls_bls.keytable = kt;
-        if (g) {
-            g->current_task()->local_storage.keytable = kt;
-        }
         delete kt;
-        if (old_kt == kt) {
-            old_kt = NULL;
-        }
     }
-    bthread::tls_bls.keytable = old_kt;
-    if (g) {
-        g->current_task()->local_storage.keytable = old_kt;
-    }
+    return 0;
     // TODO: return_keytable may race with this function, we don't destroy
     // the mutex right now.
     // pthread_mutex_destroy(&pool->mutex);
@@ -330,11 +358,12 @@ int bthread_keytable_pool_getstat(bthread_keytable_pool_t* pool,
         LOG(ERROR) << "Param[pool] or Param[stat] is NULL";
         return EINVAL;
     }
-    std::unique_lock<pthread_mutex_t> mu(pool->mutex);
+    pthread_rwlock_wrlock(&pool->rwlock);
     size_t count = 0;
     bthread::KeyTable* p = (bthread::KeyTable*)pool->free_keytables;
     for (; p; p = p->next, ++count) {}
     stat->nfree = count;
+    pthread_rwlock_unlock(&pool->rwlock);
     return 0;
 }
 
@@ -365,14 +394,15 @@ void bthread_keytable_pool_reserve(bthread_keytable_pool_t* pool,
             kt->set_data(key, data);
         }  // else append kt w/o data.
 
-        std::unique_lock<pthread_mutex_t> mu(pool->mutex);
+        pthread_rwlock_wrlock(&pool->rwlock);
         if (pool->destroyed) {
-            mu.unlock();
+            pthread_rwlock_unlock(&pool->rwlock);
             delete kt;
             break;
         }
         kt->next = (bthread::KeyTable*)pool->free_keytables;
         pool->free_keytables = kt;
+        pthread_rwlock_unlock(&pool->rwlock);
         if (data == NULL) {
             break;
         }

--- a/src/bthread/types.h
+++ b/src/bthread/types.h
@@ -83,17 +83,9 @@ inline std::ostream& operator<<(std::ostream& os, bthread_key_t key) {
 }
 #endif  // __cplusplus
 
-namespace bthread{
-class KeyTableList;
-}
-
-namespace butil {
-template <typename T> class ThreadLocal;
-}
-
 typedef struct {
     pthread_rwlock_t rwlock;
-    butil::ThreadLocal<bthread::KeyTableList>* list;
+    void* list;
     void* free_keytables;
     int destroyed;
 } bthread_keytable_pool_t;

--- a/src/bthread/types.h
+++ b/src/bthread/types.h
@@ -83,8 +83,17 @@ inline std::ostream& operator<<(std::ostream& os, bthread_key_t key) {
 }
 #endif  // __cplusplus
 
+namespace bthread{
+class KeyTableList;
+}
+
+namespace butil {
+template <typename T> class ThreadLocal;
+}
+
 typedef struct {
-    pthread_mutex_t mutex;
+    pthread_rwlock_t rwlock;
+    butil::ThreadLocal<bthread::KeyTableList>* list;
     void* free_keytables;
     int destroyed;
 } bthread_keytable_pool_t;

--- a/test/bthread_key_unittest.cpp
+++ b/test/bthread_key_unittest.cpp
@@ -396,7 +396,7 @@ TEST(KeyTest, using_pool) {
     ASSERT_EQ(0, bth2_data.seq);
         
     ASSERT_EQ(0, bthread_keytable_pool_destroy(&pool));
-    if(use_same_keytable) {
+    if (use_same_keytable) {
         EXPECT_EQ(bth_data.end_seq, bth_data.seq);
         EXPECT_EQ(0, bth2_data.seq); 
     } else {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:
#2635
Problem Summary:
当brpc server 下处理的应用执行时间较短(bthread生命周期短)，且使用了bthread_local变量时，由于keytable 由bthread_keytable_pool_t中的一个全局链表维护，borrow_keytable、return_keytable时内部加互斥锁，导致锁成为瓶颈。
![image](https://github.com/apache/brpc/assets/52315061/7a2122c9-f373-42af-badb-da4d9f834dac)

基于此，重新设计了bthread_keytable_pool_t：
新的bthread_keytable_pool_t结构体中，使用butil::ThreadLocal<bthread::KeyTableList>* list 保存TLS的KeyTable list。同时保留原有的free_keytables，不改变reserved_thread_local_data的语义，调用bthread_keytable_pool_reserve会在全局链表中预分配keytable.原有的互斥锁改为读写锁。
* borrow_keytable时优先从本地TLS链表中查找是否有可用的KeyTable，如果没有，且free_keytables不为NULL，再去从全局链表中加写锁获取keytable；如果都没有可用table，则返回NULL。
* return_keytable时只会将keytable插入TLS的KeyTable list中，由于是TLS变量，只有当bthread_keytable_pool_destroy才会产生竞争，所以只需要加写锁。
* bthread_keytable_pool_destroy时加写锁，首先delete butil::ThreadLocal<bthread::KeyTableList>* list，pool->destroyed = 1.然后如果free_keytables不为NULL，再释放free_keytables的空间。
* borrow_keytable、return_keytable内部只加读锁，bthread_keytable_pool_destroy、bthread_keytable_pool_reserve内部加写锁。sever正常运行时，一般只会调用borrow_keytable、return_keytable接口，不会产生锁的竞争。
### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
