### PR TITLE
fixbug: there is a ',' before 'quantile=' when labels is empty

### DIFF
--- a/src/bvar/multi_dimension_inl.h
+++ b/src/bvar/multi_dimension_inl.h
@@ -372,7 +372,7 @@ void MultiDimension<T>::make_labels_kvpair_string(std::ostream& os,
         comma[0] = ',';
     }
     if (quantile > 0) {
-        os << ",quantile=\"" << quantile << "\"";
+        os << comma << "quantile=\"" << quantile << "\"";
     }
     os << "}";
 }


### PR DESCRIPTION
### What problem does this PR solve?
当 mbvar 的 label 为空时，mbvar latency 的 tag 会多一个逗号，导致 prometheus 无法识别这样的上报。
旧的错误格式如下：
rpc_rough_rank_latency{,quantile="99"}
修复后的格式如下：
rpc_rough_rank_latency{quantile="99"}
Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
