### PR TITLE
fix h2 rpc_dump memory leak bug

### DIFF
--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -1578,15 +1578,17 @@ void ProcessHttpRequest(InputMessageBase *msg) {
                 }
             }
         }
-        SampledRequest* sample = AskToBeSampled();
-        if (sample && !is_http2) {
-            sample->meta.set_compress_type(COMPRESS_TYPE_NONE);
-            sample->meta.set_protocol_type(PROTOCOL_HTTP);
-            sample->meta.set_attachment_size(req_body.size());
+        if (!is_http2) {
+            SampledRequest* sample = AskToBeSampled();
+            if (sample) {
+                sample->meta.set_compress_type(COMPRESS_TYPE_NONE);
+                sample->meta.set_protocol_type(PROTOCOL_HTTP);
+                sample->meta.set_attachment_size(req_body.size());
 
-            butil::EndPoint ep;
-            MakeRawHttpRequest(&sample->request, &req_header, ep, &req_body);
-            sample->submit(start_parse_us);
+                butil::EndPoint ep;
+                MakeRawHttpRequest(&sample->request, &req_header, ep, &req_body);
+                sample->submit(start_parse_us);
+            }
         }
     } else {
         if (imsg_guard->read_body_progressively()) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
**h2 rpc_dump时 内存泄漏**。

具体是http和h2都走ProcessHttpRequest方法，在处理rpc_dump时，先AskToBeSampled创建堆对象再判is_http2，若是http2无释放堆对象逻辑。

发压cmd：rpc_press -protocol=h2 xxxx

### What is changed and the side effects?
Changed:
h2 req不做AskToBeSampled

修复前：
![image](https://github.com/apache/brpc/assets/9795716/2c37f39a-4282-42e4-b7bc-aae025bae5fc)
![image](https://github.com/apache/brpc/assets/9795716/37f56855-89be-42a0-9710-5909a6589288)
![image](https://github.com/apache/brpc/assets/9795716/35f679b4-a788-4600-98e3-d816b484a909)
![image](https://github.com/apache/brpc/assets/9795716/d7bc0f88-99f6-4e54-85ce-95c3a5a4e8fc)

[brpc_h2_rpc_dump_mem_leak_bug.pdf](https://github.com/user-attachments/files/15798428/brpc_h2_rpc_dump_mem_leak_bug.pdf)


修复后：
![image](https://github.com/apache/brpc/assets/9795716/e826f4bb-1e84-408d-b452-579ad6d48bcb)
![image](https://github.com/apache/brpc/assets/9795716/ddb6b167-0ecf-4716-8dc4-9367a250c3fe)
![image](https://github.com/apache/brpc/assets/9795716/a2036e8f-2fa1-44da-8e5d-6078ab02cbce)

[brpc_h2_rpc_dump_mem_leak_fixed.pdf](https://github.com/user-attachments/files/15798432/brpc_h2_rpc_dump_mem_leak_fixed.pdf)


Side effects:
- Performance effects(性能影响):
无
- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
