### PR TITLE
socket: fix potential double close

### DIFF
--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -590,6 +590,7 @@ int Socket::ResetFileDescriptor(int fd) {
     // Make the fd non-blocking.
     if (butil::make_non_blocking(fd) != 0) {
         PLOG(ERROR) << "Fail to set fd=" << fd << " to non-blocking";
+        _fd.store(-1, butil::memory_order_release);
         return -1;
     }
     // turn off nagling.


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`_fd` should be reset if `ResetFileDescriptor` is going to return -1, otherwise the fd will be closed in callers like `CheckConnectedAndKeepWrite` or `Server::StartInernal` and socket lifecycle methods like `BeforeRecycled` or `WaitAndReset`.


### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):
No
- Breaking backward compatibility(向后兼容性): 
No
---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
