### PR TITLE
Fix tcp connect interrupt

### DIFF
--- a/src/butil/fd_utility.h
+++ b/src/butil/fd_utility.h
@@ -41,7 +41,10 @@ int make_close_on_exec(int fd);
 
 // Disable nagling on file descriptor |socket|.
 // Returns 0 on success, -1 when error and errno is set (by setsockopt)
-int make_no_delay(int socket);
+int make_no_delay(int sockfd);
+
+// Return true if the socket is connected.
+int is_connected(int sockfd);
 
 }  // namespace butil
 

--- a/test/bthread_fd_unittest.cpp
+++ b/test/bthread_fd_unittest.cpp
@@ -34,9 +34,11 @@
 #include "bthread/interrupt_pthread.h"
 #include "bthread/bthread.h"
 #include "bthread/unstable.h"
+#include <netinet/tcp.h>
 #if defined(OS_MACOSX)
 #include <sys/types.h>                           // struct kevent
 #include <sys/event.h>                           // kevent(), kqueue()
+#include <netinet/tcp_fsm.h>
 #endif
 
 #ifndef NDEBUG
@@ -592,6 +594,54 @@ TEST(FDTest, bthread_connect) {
         ASSERT_EQ(ETIMEDOUT, errno);
         ASSERT_EQ(is_blocking, butil::is_blocking(sockfd));
     }
+}
+
+void TestConnectInterruptImpl(bool timed) {
+    butil::EndPoint ep;
+    ASSERT_EQ(0, butil::hostname2endpoint(g_hostname, 80, &ep));
+    struct sockaddr_storage serv_addr{};
+    socklen_t serv_addr_size = 0;
+    ASSERT_EQ(0, endpoint2sockaddr(ep, &serv_addr, &serv_addr_size));
+    butil::fd_guard sockfd(socket(serv_addr.ss_family, SOCK_STREAM, 0));
+    ASSERT_GE(sockfd, 0);
+
+    int rc;
+    if (timed) {
+        int64_t start_ms = butil::cpuwide_time_ms();
+        butil::tcp_connect(ep, NULL);
+        int64_t connect_ms = butil::cpuwide_time_ms() - start_ms;
+        LOG(INFO) << "Connect to " << ep << ", cost " << connect_ms << "ms";
+
+        timespec abstime = butil::milliseconds_from_now(connect_ms + 1);
+        rc = bthread_timed_connect(
+            sockfd, (struct sockaddr*) &serv_addr,
+            serv_addr_size, &abstime);
+    } else {
+        rc = bthread_timed_connect(
+            sockfd, (struct sockaddr*) &serv_addr,
+            serv_addr_size, NULL);
+    }
+    ASSERT_EQ(0, rc) << "errno=" << errno;
+    ASSERT_EQ(0, butil::is_connected(sockfd));
+
+}
+
+void* ConnectThread(void* arg) {
+    bool timed = *(bool*)arg;
+    TestConnectInterruptImpl(timed);
+    return NULL;
+}
+
+void TestConnectInterrupt(bool timed) {
+    bthread_t tid;
+    ASSERT_EQ(0, bthread_start_background(&tid, NULL, ConnectThread, &timed));
+    ASSERT_EQ(0, bthread_stop(tid));
+    ASSERT_EQ(0, bthread_join(tid, NULL));
+}
+
+TEST(FDTest, interrupt) {
+    TestConnectInterrupt(false);
+    TestConnectInterrupt(true);
 }
 
 } // namespace

--- a/test/bthread_fd_unittest.cpp
+++ b/test/bthread_fd_unittest.cpp
@@ -612,7 +612,7 @@ void TestConnectInterruptImpl(bool timed) {
         int64_t connect_ms = butil::cpuwide_time_ms() - start_ms;
         LOG(INFO) << "Connect to " << ep << ", cost " << connect_ms << "ms";
 
-        timespec abstime = butil::milliseconds_from_now(connect_ms + 1);
+        timespec abstime = butil::milliseconds_from_now(connect_ms + 100);
         rc = bthread_timed_connect(
             sockfd, (struct sockaddr*) &serv_addr,
             serv_addr_size, &abstime);

--- a/test/endpoint_unittest.cpp
+++ b/test/endpoint_unittest.cpp
@@ -23,6 +23,10 @@
 #include "butil/logging.h"
 #include "butil/containers/flat_map.h"
 #include "butil/details/extended_endpoint.hpp"
+#include <netinet/tcp.h>
+#if defined(OS_MACOSX)
+#include <netinet/tcp_fsm.h>
+#endif
 
 namespace butil {
 int pthread_timed_connect(int sockfd, const struct sockaddr* serv_addr,
@@ -526,6 +530,72 @@ TEST(EndPointTest, tcp_connect) {
         ASSERT_EQ(ETIMEDOUT, errno);
         ASSERT_EQ(is_blocking, butil::is_blocking(sockfd));
     }
+}
+
+bool g_connect_startd = false;
+
+void TestConnectInterruptImpl(bool timed) {
+    butil::EndPoint ep;
+    ASSERT_EQ(0, butil::hostname2endpoint(g_hostname, 80, &ep));
+
+    struct sockaddr_storage serv_addr{};
+    socklen_t serv_addr_size = 0;
+    ASSERT_EQ(0, endpoint2sockaddr(ep, &serv_addr, &serv_addr_size));
+    butil::fd_guard sockfd(socket(serv_addr.ss_family, SOCK_STREAM, 0));
+    ASSERT_LE(0, sockfd);
+
+    int rc;
+    if (timed) {
+        int64_t start_ms = butil::cpuwide_time_ms();
+        butil::tcp_connect(ep, NULL);
+        int64_t connect_ms = butil::cpuwide_time_ms() - start_ms;
+        LOG(INFO) << "Connect to " << ep << ", cost " << connect_ms << "ms";
+
+        timespec abstime = butil::milliseconds_from_now(connect_ms + 1);
+        rc = butil::pthread_timed_connect(
+            sockfd, (struct sockaddr*) &serv_addr,
+            serv_addr_size, &abstime);
+    } else {
+        rc = butil::pthread_timed_connect(
+            sockfd, (struct sockaddr*) &serv_addr,
+            serv_addr_size, NULL);
+    }
+    ASSERT_EQ(0, rc) << "errno=" << errno;
+    ASSERT_EQ(0, butil::is_connected(sockfd));
+}
+
+void* ConnectThread(void* arg) {
+    bool timed = *(bool*)arg;
+    TestConnectInterruptImpl(timed);
+    return NULL;
+}
+
+void sig_handler(int sig) {
+    LOG(INFO) << "sig=" << sig;
+}
+
+void register_sigurg() {
+    signal(SIGURG, sig_handler);
+}
+
+void TestConnectInterrupt(bool timed) {
+    g_connect_startd = false;
+    pthread_t tid;
+    ASSERT_EQ(0, pthread_create(&tid, NULL, ConnectThread, &timed));
+
+    while (g_connect_startd) {
+        usleep(1000);
+    }
+
+    ASSERT_EQ(0, pthread_kill(tid, SIGURG));
+
+    pthread_join(tid, NULL);
+}
+
+TEST(EndPointTest, interrupt) {
+    register_sigurg();
+    TestConnectInterrupt(false);
+    TestConnectInterrupt(true);
 }
 
 } // end of namespace

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -43,7 +43,7 @@ print_bt () {
     COREFILE=$(find . -name "core*" -type f -printf "%T@ %p\n" | sort -k 1 -n | cut -d' ' -f 2- | tail -n 1)
     if [ ! -z "$COREFILE" ]; then
         >&2 echo "corefile=$COREFILE prog=$1"
-        gdb -c "$COREFILE" $1 -ex "thread apply all bt" -ex "set pagination 0" -batch;
+        gdb -c "$COREFILE" $1 -ex "bt" -ex "thread apply all bt" -ex "set pagination 0" -batch;
     fi
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

tcp_connect被中断之后，返回结果是有问题的：
1. `bthread_timed_connect / bthread_connect`：`butex_wait`返回0，errno等于`EWOULDBLOCK`或者`EINTR`，最后tcp_connect返回一个未连接成功的socket fd。
2. `pthread_timed_connect `：返回-1，errno等于`EINTR`。

### What is changed and the side effects?

Changed:

当errno等于`EWOULDBLOCK`或者`EINTR`，`pthread_fd_wait / bthread_fd_wait`继续wait到连接成功或者失败。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
