### PR TITLE
Fix multi FlatMap scale and size

### DIFF
--- a/src/butil/bit_array.h
+++ b/src/butil/bit_array.h
@@ -28,18 +28,22 @@
 
 namespace butil {
 
+#define BIT_ARRAY_LEN(nbit) (((nbit) + 63 ) / 64 * 8)
+
 // Create an array with at least |nbit| bits. The array is not cleared.
-inline uint64_t* bit_array_malloc(size_t nbit)
-{
+inline uint64_t* bit_array_malloc(size_t nbit) {
     if (!nbit) {
         return NULL;
     }
-    return (uint64_t*)malloc((nbit + 63 ) / 64 * 8/*different from /8*/);
+    return (uint64_t*)malloc(BIT_ARRAY_LEN(nbit)/*different from /8*/);
+}
+
+inline void bit_array_free(uint64_t* array) {
+    free(array);
 }
 
 // Set bit 0 ~ nbit-1 of |array| to be 0
-inline void bit_array_clear(uint64_t* array, size_t nbit)
-{
+inline void bit_array_clear(uint64_t* array, size_t nbit) {
     const size_t off = (nbit >> 6);
     memset(array, 0, off * 8);
     const size_t last = (off << 6);
@@ -49,22 +53,19 @@ inline void bit_array_clear(uint64_t* array, size_t nbit)
 }
 
 // Set i-th bit (from left, counting from 0) of |array| to be 1
-inline void bit_array_set(uint64_t* array, size_t i)
-{
+inline void bit_array_set(uint64_t* array, size_t i) {
     const size_t off = (i >> 6);
     array[off] |= (((uint64_t)1) << (i - (off << 6)));
 }
 
 // Set i-th bit (from left, counting from 0) of |array| to be 0
-inline void bit_array_unset(uint64_t* array, size_t i)
-{
+inline void bit_array_unset(uint64_t* array, size_t i) {
     const size_t off = (i >> 6);
     array[off] &= ~(((uint64_t)1) << (i - (off << 6)));
 }
 
 // Get i-th bit (from left, counting from 0) of |array|
-inline uint64_t bit_array_get(const uint64_t* array, size_t i)
-{
+inline uint64_t bit_array_get(const uint64_t* array, size_t i) {
     const size_t off = (i >> 6);
     return (array[off] & (((uint64_t)1) << (i - (off << 6))));
 }
@@ -72,8 +73,7 @@ inline uint64_t bit_array_get(const uint64_t* array, size_t i)
 // Find index of first 1-bit from bit |begin| to |end| in |array|.
 // Returns |end| if all bits are 0.
 // This function is of O(nbit) complexity.
-inline size_t bit_array_first1(const uint64_t* array, size_t begin, size_t end)
-{
+inline size_t bit_array_first1(const uint64_t* array, size_t begin, size_t end) {
     size_t off1 = (begin >> 6);
     const size_t first = (off1 << 6);
     if (first != begin) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

1. Multi模式下，插入数据发生hash冲突的时候，size没有加一。另一方面，插入数据不能自动扩容。
2. m1 = m2，m1扩容后m1._nbucket不等于m2._nbucket的时候，m1的_buckets上除了插入数据的位置，其他位置没有set_invalid，后续使用会出现内存问题。
3. 扩容时，_buckets和_thumbnail都是先释放再申请新的内存。如果申请失败了，FlatMap就完全不可用了。

### What is changed and the side effects?

Changed:

1. size++。另外，当FlatMap负载超过阈值，则遍历Bucket链表，当存在不同的key的时候，则扩容。否则，不扩容直接插入。因为key一样，扩容后这些数据还是在同一个链表上。
2. 扩容后都要初始化_buckets和_thumbnail数组。
3. 申请内存成功后，再将其复制给_buckets和_thumbnail。一旦出现错误，则先释放已经申请的内存再返回失败。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
