### PR TITLE
Add debug log for Socket health check

### DIFF
--- a/src/brpc/details/health_check.cpp
+++ b/src/brpc/details/health_check.cpp
@@ -222,6 +222,10 @@ bool HealthCheckTask::OnTriggeringTask(timespec* next_abstime) {
         LOG(INFO) << "Cancel checking " << *ptr;
         ptr->AfterHCCompleted();
         return false;
+    } else {
+        RPC_VLOG << "Fail to check " << *ptr
+                 << ", error code=" << errno
+                 << ": " << berror();
     }
     ++ ptr->_hc_count;
     *next_abstime = butil::seconds_from_now(ptr->_health_check_interval_s);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

有用户反馈Socket被熔断后无法恢复，需要加上日志确定健康检查失败的原因。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
