### PR TITLE
fix bug: switch between stream_rpc and baidu_std

### DIFF
--- a/src/brpc/input_messenger.cpp
+++ b/src/brpc/input_messenger.cpp
@@ -114,9 +114,13 @@ ParseResult InputMessenger::CutInputMessage(
             }
 
             if (m->CreatedByConnect()) {
-                if((ProtocolType)cur_index == PROTOCOL_BAIDU_STD) {
+                if((ProtocolType)cur_index == PROTOCOL_BAIDU_STD && cur_index == preferred) {
                     // baidu_std may fall to streaming_rpc.
                     cur_index = (int)PROTOCOL_STREAMING_RPC;
+                    continue;
+                } else if((ProtocolType)cur_index == PROTOCOL_STREAMING_RPC && cur_index == preferred) {
+                    // streaming_rpc may fall to baidu_std.
+                    cur_index = (int)PROTOCOL_BAIDU_STD;
                     continue;
                 } else {
                     // The protocol is fixed at client-side, no need to try others.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/apache/brpc/issues/2677

Problem Summary: under `baidu_std`, server can not parse message when normal PRC and stream RPC arrive simultaneously 

### What is changed and the side effects?

Changed: switch between `baidu_std` and `stream_rpc` in `InputMessenger::CutInputMessage`

Side effects:
- Performance effects(性能影响): Little or none

- Breaking backward compatibility(向后兼容性): no

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
