### PR TITLE
Fix malloc deadlock caused by contention profiler

### DIFF
--- a/src/brpc/builtin/hotspots_service.cpp
+++ b/src/brpc/builtin/hotspots_service.cpp
@@ -33,8 +33,8 @@
 #include "brpc/details/tcmalloc_extension.h"
 
 extern "C" {
-int __attribute__((weak)) ProfilerStart(const char* fname);
-void __attribute__((weak)) ProfilerStop();
+int BAIDU_WEAK ProfilerStart(const char* fname);
+void BAIDU_WEAK ProfilerStop();
 }
 
 namespace bthread {

--- a/src/brpc/builtin/pprof_service.cpp
+++ b/src/brpc/builtin/pprof_service.cpp
@@ -41,8 +41,8 @@ extern "C" {
 #if defined(OS_LINUX)
 extern char *program_invocation_name;
 #endif
-int __attribute__((weak)) ProfilerStart(const char* fname);
-void __attribute__((weak)) ProfilerStop();
+int BAIDU_WEAK ProfilerStart(const char* fname);
+void BAIDU_WEAK ProfilerStop();
 }
 
 namespace bthread {

--- a/src/brpc/policy/rtmp_protocol.cpp
+++ b/src/brpc/policy/rtmp_protocol.cpp
@@ -39,7 +39,7 @@
 // we mark the symbol as weak. If the runtime does not have the function,
 // handshaking will fallback to the simple one.
 extern "C" {
-const EVP_MD* __attribute__((weak)) EVP_sha256(void);
+const EVP_MD* BAIDU_WEAK EVP_sha256(void);
 }
 
 

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -57,8 +57,7 @@
 #endif
 
 namespace bthread {
-size_t __attribute__((weak))
-get_sizes(const bthread_id_list_t* list, size_t* cnt, size_t n);
+size_t BAIDU_WEAK get_sizes(const bthread_id_list_t* list, size_t* cnt, size_t n);
 }
 
 

--- a/src/butil/debug/stack_trace.cc
+++ b/src/butil/debug/stack_trace.cc
@@ -21,14 +21,17 @@ StackTrace::StackTrace(const void* const* trace, size_t count) {
   count_ = count;
 }
 
-StackTrace::~StackTrace() {
-}
-
 const void *const *StackTrace::Addresses(size_t* count) const {
   *count = count_;
   if (count_)
     return trace_;
   return NULL;
+}
+
+size_t StackTrace::CopyAddressTo(void** buffer, size_t max_nframes) const {
+    size_t nframes = std::min(count_, max_nframes);
+    memcpy(buffer, trace_, nframes * sizeof(void*));
+    return nframes;
 }
 
 std::string StackTrace::ToString() const {

--- a/src/butil/debug/stack_trace.h
+++ b/src/butil/debug/stack_trace.h
@@ -59,11 +59,19 @@ class BUTIL_EXPORT StackTrace {
 
   // Copying and assignment are allowed with the default functions.
 
-  ~StackTrace();
-
   // Gets an array of instruction pointer values. |*count| will be set to the
   // number of elements in the returned array.
   const void* const* Addresses(size_t* count) const;
+
+  // Gets the number of frames in the stack trace.
+  size_t FrameCount() const { return count_; }
+
+  // Copies the stack trace to |buffer|,
+  // where the size is min(max_nframes, frame_count()).
+  size_t CopyAddressTo(void** dest, size_t max_nframes) const;
+
+  // Whether if the given symbol is found in the stack trace.
+  bool FindSymbol(void* symbol) const;
 
   // Prints the stack trace to stderr.
   void Print() const;

--- a/src/butil/iobuf_profiler.cpp
+++ b/src/butil/iobuf_profiler.cpp
@@ -24,7 +24,7 @@
 #include "butil/hash.h"
 #include <execinfo.h>
 
-extern int __attribute__((weak)) GetStackTrace(void** result, int max_depth, int skip_count);
+extern int BAIDU_WEAK GetStackTrace(void** result, int max_depth, int skip_count);
 
 namespace butil {
 
@@ -296,9 +296,7 @@ void SubmitIOBufSample(IOBuf::Block* block, int64_t ref) {
     auto sample = IOBufSample::New();
     sample->block = block;
     sample->count = ref;
-    sample->nframes = GetStackTrace(sample->stack,
-                                    arraysize(sample->stack),
-                                    0); // may lock
+    sample->nframes = GetStackTrace(sample->stack, arraysize(sample->stack), 0);
     IOBufProfiler::GetInstance()->Submit(sample);
 }
 

--- a/src/butil/object_pool.h
+++ b/src/butil/object_pool.h
@@ -69,6 +69,11 @@ template <typename T> struct ObjectPoolValidator {
 
 namespace butil {
 
+// Whether if FreeChunk of LocalPool is empty.
+template <typename T> inline bool local_pool_free_empty() {
+    return ObjectPool<T>::singleton()->local_free_empty();
+}
+
 // Get an object typed |T|. The object should be cleared before usage.
 // NOTE: T must be default-constructible.
 template <typename T> inline T* get_object() {

--- a/src/butil/object_pool_inl.h
+++ b/src/butil/object_pool_inl.h
@@ -216,12 +216,24 @@ public:
             return -1;
         }
 
+        inline bool free_empty() const {
+            return 0 == _cur_free.nfree;
+        }
+
     private:
         ObjectPool* _pool;
         Block* _cur_block;
         size_t _cur_block_index;
         FreeChunk _cur_free;
     };
+
+    inline bool local_free_empty() {
+        LocalPool* lp = get_or_new_local_pool();
+        if (BAIDU_LIKELY(lp != NULL)) {
+            return lp->free_empty();
+        }
+        return true;
+    }
 
     inline T* get_object() {
         LocalPool* lp = get_or_new_local_pool();

--- a/src/butil/third_party/dynamic_annotations/dynamic_annotations.c
+++ b/src/butil/third_party/dynamic_annotations/dynamic_annotations.c
@@ -255,7 +255,7 @@ static int GetRunningOnValgrind(void) {
 }
 
 /* See the comments in dynamic_annotations.h */
-int __attribute__((weak)) RunningOnValgrind(void) {
+int DYNAMIC_ANNOTATIONS_ATTRIBUTE_WEAK RunningOnValgrind(void) {
   static volatile int running_on_valgrind = -1;
   /* C doesn't have thread-safe initialization of statics, and we
      don't want to depend on pthread_once here, so hack it. */

--- a/src/butil/third_party/symbolize/symbolize.h
+++ b/src/butil/third_party/symbolize/symbolize.h
@@ -150,6 +150,8 @@ _START_GOOGLE_NAMESPACE_
 // returns false.
 bool Symbolize(void *pc, char *out, int out_size);
 
+bool SymbolizeAddress(void *pc, uint64_t *out);
+
 _END_GOOGLE_NAMESPACE_
 
 #endif  // BUTIL_SYMBOLIZE_H_

--- a/test/stack_trace_unittest.cc
+++ b/test/stack_trace_unittest.cc
@@ -8,7 +8,32 @@
 
 #include "butil/debug/stack_trace.h"
 #include "butil/logging.h"
+#include "butil/scoped_lock.h"
 #include <gtest/gtest.h>
+
+extern "C" {
+void TestFindSymbol1();
+void TestFindSymbol2();
+void TestFindSymbol3();
+
+void TestFindSymbol1() {
+    butil::debug::StackTrace trace;
+    ASSERT_TRUE(trace.ToString().find("TestFindSymbol1") != std::string::npos) << trace.ToString();
+    ASSERT_TRUE(trace.ToString().find("TestFindSymbol2") != std::string::npos) << trace.ToString();
+    ASSERT_TRUE(trace.ToString().find("TestFindSymbol3") == std::string::npos) << trace.ToString();
+    ASSERT_TRUE(trace.FindSymbol((void*)TestFindSymbol2)) << trace.ToString();
+    ASSERT_TRUE(trace.FindSymbol((void*)TestFindSymbol1)) << trace.ToString();
+    ASSERT_FALSE(trace.FindSymbol((void*)TestFindSymbol3)) << trace.ToString();
+}
+
+void TestFindSymbol2() {
+    TestFindSymbol1();
+}
+
+void TestFindSymbol3() {
+    TestFindSymbol1();
+}
+}
 
 namespace butil {
 namespace debug {
@@ -107,20 +132,25 @@ TEST_F(StackTraceTest, MAYBE_OutputToStream) {
 #endif  // define(OS_MACOSX)
 }
 
+void CheckDebugOutputToStream(bool exclude_self) {
+    StackTrace trace(exclude_self);
+    size_t count;
+    const void* const* addrs = trace.Addresses(&count);
+    ASSERT_EQ(count, trace.FrameCount());
+    void* addr = malloc(sizeof(void*) * count);
+    size_t copied_count = trace.CopyAddressTo((void**)addr, count);
+    ASSERT_EQ(count, copied_count);
+    ASSERT_EQ(0, memcmp(addrs, addr, sizeof(void*) * count));
+
+    std::ostringstream os;
+    trace.OutputToStream(&os);
+    VLOG(1) << os.str();
+}
+
 // The test is used for manual testing, e.g., to see the raw output.
 TEST_F(StackTraceTest, DebugOutputToStream) {
-  {
-    StackTrace trace;
-    std::ostringstream os;
-    trace.OutputToStream(&os);
-    VLOG(1) << os.str();
-  }
-  {
-    StackTrace trace(true);
-    std::ostringstream os;
-    trace.OutputToStream(&os);
-    VLOG(1) << os.str();
-  }
+  CheckDebugOutputToStream(false);
+  CheckDebugOutputToStream(true);
 }
 
 // The test is used for manual testing, e.g., to see the raw output.
@@ -205,6 +235,33 @@ TEST_F(StackTraceTest, itoa_r) {
   EXPECT_EQ("00688", itoa_r_wrapper(0x688, 128, 16, 5));
 }
 #endif  // defined(OS_POSIX) && !defined(OS_ANDROID)
+
+void TestFindSymbol1();
+void TestFindSymbol2();
+void TestFindSymbol3();
+
+void TestFindSymbol1() {
+    butil::debug::StackTrace trace;
+    ASSERT_TRUE(trace.ToString().find("TestFindSymbol1") != std::string::npos) << trace.ToString();
+    ASSERT_TRUE(trace.ToString().find("TestFindSymbol2") != std::string::npos) << trace.ToString();
+    ASSERT_TRUE(trace.ToString().find("TestFindSymbol3") == std::string::npos) << trace.ToString();
+    ASSERT_TRUE(trace.FindSymbol((void*)TestFindSymbol2)) << trace.ToString();
+    ASSERT_TRUE(trace.FindSymbol((void*)TestFindSymbol1)) << trace.ToString();
+    ASSERT_FALSE(trace.FindSymbol((void*)TestFindSymbol3)) << trace.ToString();
+}
+
+void TestFindSymbol2() {
+    TestFindSymbol1();
+}
+
+void TestFindSymbol3() {
+    TestFindSymbol1();
+}
+
+TEST_F(StackTraceTest, find_symbol) {
+    ::TestFindSymbol2();
+    TestFindSymbol2();
+}
 
 }  // namespace debug
 }  // namespace butil


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #859 

Problem Summary:

### What is changed and the side effects?

Changed:

目前contention profiler在最后submit的时候，有两种情况会申请内存：

1. 第一次submit时创建单例：ObjectPool、AgentCombiner::Agent；
2. ObjectPool::LocalPool::FreeChunk为空。

对于这两种情况，查找调用栈，发现存在malloc的符号，则不提交这次采样结果。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
