### PR TITLE
Support pthread mutex deadlock detection

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -583,6 +583,8 @@ void TaskGroup::sched(TaskGroup** pg) {
     sched_to(pg, next_tid);
 }
 
+extern void CheckBthreadScheSafety();
+
 void TaskGroup::sched_to(TaskGroup** pg, TaskMeta* next_meta) {
     TaskGroup* g = *pg;
 #ifndef NDEBUG
@@ -622,6 +624,7 @@ void TaskGroup::sched_to(TaskGroup** pg, TaskMeta* next_meta) {
 
         if (cur_meta->stack != NULL) {
             if (next_meta->stack != cur_meta->stack) {
+                CheckBthreadScheSafety();
                 jump_stack(cur_meta->stack, next_meta->stack);
                 // probably went to another group, need to assign g again.
                 g = BAIDU_GET_VOLATILE_THREAD_LOCAL(tls_task_group);

--- a/src/butil/debug/stack_trace.h
+++ b/src/butil/debug/stack_trace.h
@@ -42,7 +42,8 @@ BUTIL_EXPORT bool EnableInProcessStackDumpingForSandbox();
 class BUTIL_EXPORT StackTrace {
  public:
   // Creates a stacktrace from the current location.
-  StackTrace();
+  // Exclude constructor frame of StackTrace if |exclude_self| is true.
+  explicit StackTrace(bool exclude_self = false);
 
   // Creates a stacktrace from an existing array of instruction
   // pointers (such as returned by Addresses()).  |count| will be
@@ -82,7 +83,7 @@ class BUTIL_EXPORT StackTrace {
   // doesn't give much more information.
   static const int kMaxTraces = 62;
 
-  void* trace_[kMaxTraces];
+  void* trace_[kMaxTraces]{};
 
   // The number of valid frames in |trace_|.
   size_t count_;

--- a/src/butil/memory/scope_guard.h
+++ b/src/butil/memory/scope_guard.h
@@ -91,11 +91,11 @@ operator+(ScopeExitHelper, Callback&& callback) {
 
 #define BRPC_ANONYMOUS_VARIABLE(prefix) BAIDU_CONCAT(prefix, __COUNTER__)
 
-// The code in the braces of BAIDU_SCOPE_EXIT always executes at the end of the scope.
-// Variables used within BAIDU_SCOPE_EXIT are captured by reference.
+// The code in the braces of BRPC_SCOPE_EXIT always executes at the end of the scope.
+// Variables used within BRPC_SCOPE_EXIT are captured by reference.
 // Example:
 // int fd = open(...);
-// BAIDU_SCOPE_EXIT {
+// BRPC_SCOPE_EXIT {
 //     close(fd);
 // };
 // use fd ...

--- a/test/stack_trace_unittest.cc
+++ b/test/stack_trace_unittest.cc
@@ -109,10 +109,18 @@ TEST_F(StackTraceTest, MAYBE_OutputToStream) {
 
 // The test is used for manual testing, e.g., to see the raw output.
 TEST_F(StackTraceTest, DebugOutputToStream) {
-  StackTrace trace;
-  std::ostringstream os;
-  trace.OutputToStream(&os);
-  VLOG(1) << os.str();
+  {
+    StackTrace trace;
+    std::ostringstream os;
+    trace.OutputToStream(&os);
+    VLOG(1) << os.str();
+  }
+  {
+    StackTrace trace(true);
+    std::ostringstream os;
+    trace.OutputToStream(&os);
+    VLOG(1) << os.str();
+  }
 }
 
 // The test is used for manual testing, e.g., to see the raw output.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

线程锁临界区内挂起协程（bthread_mutex、sync rpc、bthread_usleep、bthread_yeild等），属于未定义行为（大概率会造成死锁）。目前缺少一种发现机制，只能等到出现死锁后查看调用栈再排查。

### What is changed and the side effects?

Changed:

brpc已经hook了pthread mutex接口，加锁的时候将线程局部变量加一，解锁的时候，将线程局部变量减一。只有在线程局部变量等于0的时候，挂起协程才是安全的，否则，将调用栈打印出来用于排查问题。该调用栈只打印一次，因为一旦出现pthread mutex临界区内挂起协程，线程局部变量已经是错乱的，后续的调用栈已经没有参考价值。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
