### PR TITLE
add openSSL_ROOT_DIR check on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ if(WITH_BORINGSSL)
     find_package(BoringSSL)
     include_directories(${BORINGSSL_INCLUDE_DIR})
 else()
-    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
         set(OPENSSL_ROOT_DIR
             "/usr/local/opt/openssl" # Homebrew installed OpenSSL
         )


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2714 

Problem Summary:
On macos, originally it was mandatory to set `OPENSSL_ROOT_DIR` to` /usr/local/opt-openssl`, but now a judgment is added, only if `OPENSSL_ROOT_DIR` is not set. Is set to `/usr/local/opt-openssl`

### What is changed and the side effects?

Changed:

Added a judgment to the cmake file

Side effects:
- Performance effects(性能影响): NO

- Breaking backward compatibility(向后兼容性): YES

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
