### PR TITLE
Use butil::AlignedMemory instead of std::aligned_storage to align memory for placement new 

### DIFF
--- a/src/butil/compiler_specific.h
+++ b/src/butil/compiler_specific.h
@@ -124,6 +124,23 @@
 // Use like:
 //   class ALIGNAS(16) MyClass { ... }
 //   ALIGNAS(16) int array[4];
+//
+// In most places you can use the C++11 keyword "alignas", which is preferred.
+//
+// But compilers have trouble mixing __attribute__((...)) syntax with
+// alignas(...) syntax.
+//
+// Doesn't work in clang or gcc:
+//   struct alignas(16) __attribute__((packed)) S { char c; };
+// Works in clang but not gcc:
+//   struct __attribute__((packed)) alignas(16) S2 { char c; };
+// Works in clang and gcc:
+//   struct alignas(16) S3 { char c; } __attribute__((packed));
+//
+// There are also some attributes that must be specified *before* a class
+// definition: visibility (used for exporting functions/classes) is one of
+// these attributes. This means that it is not possible to use alignas() with a
+// class that is marked as exported.
 #if defined(COMPILER_MSVC)
 # define ALIGNAS(byte_alignment) __declspec(align(byte_alignment))
 #elif defined(COMPILER_GCC)

--- a/src/butil/containers/mpsc_queue.h
+++ b/src/butil/containers/mpsc_queue.h
@@ -24,6 +24,7 @@
 
 #include "butil/object_pool.h"
 #include "butil/type_traits.h"
+#include "butil/memory/manual_constructor.h"
 
 namespace butil {
 
@@ -32,8 +33,7 @@ struct BAIDU_CACHELINE_ALIGNMENT MPSCQueueNode {
     static MPSCQueueNode* const UNCONNECTED;
 
     MPSCQueueNode* next{NULL};
-    char data_mem[sizeof(T)]{};
-
+    ManualConstructor<T> data_mem;
 };
 
 template <typename T>
@@ -95,7 +95,7 @@ template <typename T, typename Alloc>
 void MPSCQueue<T, Alloc>::Enqueue(typename add_const_reference<T>::type data) {
     auto node = (MPSCQueueNode<T>*)_alloc.Alloc();
     node->next = MPSCQueueNode<T>::UNCONNECTED;
-    new ((void*)&node->data_mem) T(data);
+    node->data_mem.Init(data);
     EnqueueImpl(node);
 }
 
@@ -103,7 +103,7 @@ template <typename T, typename Alloc>
 void MPSCQueue<T, Alloc>::Enqueue(T&& data) {
     auto node = (MPSCQueueNode<T>*)_alloc.Alloc();
     node->next = MPSCQueueNode<T>::UNCONNECTED;
-    new ((void*)&node->data_mem) T(std::forward<T>(data));
+    node->data_mem.Init(data);
     EnqueueImpl(node);
 }
 
@@ -137,7 +137,7 @@ bool MPSCQueue<T, Alloc>::DequeueImpl(T* data) {
 
     _cur_enqueue_node.store(NULL, memory_order_relaxed);
     if (data) {
-        auto mem = (T* const)node->data_mem;
+        auto mem = (T* const)node->data_mem.get();
         *data = std::move(*mem);
     }
     MPSCQueueNode<T>* old_node = node;

--- a/src/butil/memory/manual_constructor.h
+++ b/src/butil/memory/manual_constructor.h
@@ -56,6 +56,11 @@ class ManualConstructor {
   inline Type& operator*() { return *get(); }
   inline const Type& operator*() const { return *get(); }
 
+  template<typename Ctor>
+  inline void InitBy(Ctor ctor) {
+    ctor(space_.void_data());
+  }
+
   // You can pass up to eight constructor arguments as arguments of Init().
   inline void Init() {
     new(space_.void_data()) Type;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2288 中引入用于对齐`Element`地址的`std::aligned_storage`在C++23中已经被废弃了。详细背景见[P1413R3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1413r3.pdf)提案。

Problem Summary:

### What is changed and the side effects?

Changed:

~~C++17起，使用[P1413R3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1413r3.pdf)提案中建议的`alignas(T) std::byte element_spaces[sizeof(T)]`来代替`std::aligned_storage`。~~

1. `butil::AlignedMemory`的实现跟[P1413R3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1413r3.pdf)提案中建议的`alignas(T) std::byte[sizeof(T)]`类似，优点是封装性更好，所以使用`butil::ManualConstructor`（包含`butil::AlignedMemory`）代替`std::aligned_storage`。
2. `MPSCQueueNode`、`ObjectPool`、`ResourcePool`也需要对齐。
3. 补充了一下`ALIGNAS`宏的一些注释（来自于chromium）。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
