### PR TITLE
Fix rdma remove consumer error

### DIFF
--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -834,6 +834,10 @@ void Socket::BeforeRecycled() {
         sp->RemoveRefManually();
     }
 
+    // Reset `_io_event' at the end.
+    BRPC_SCOPE_EXIT {
+        _io_event.Reset();
+    };
     const int prev_fd = _fd.exchange(-1, butil::memory_order_relaxed);
     if (ValidFileDescriptor(prev_fd)) {
         if (_on_edge_triggered_events != NULL) {
@@ -844,7 +848,6 @@ void Socket::BeforeRecycled() {
             g_vars->channel_conn << -1;
         }
     }
-    _io_event.Reset();
 
 #if BRPC_WITH_RDMA
     if (_rdma_ep) {

--- a/test/endpoint_unittest.cpp
+++ b/test/endpoint_unittest.cpp
@@ -551,7 +551,7 @@ void TestConnectInterruptImpl(bool timed) {
         int64_t connect_ms = butil::cpuwide_time_ms() - start_ms;
         LOG(INFO) << "Connect to " << ep << ", cost " << connect_ms << "ms";
 
-        timespec abstime = butil::milliseconds_from_now(connect_ms + 1);
+        timespec abstime = butil::milliseconds_from_now(connect_ms * 2);
         rc = butil::pthread_timed_connect(
             sockfd, (struct sockaddr*) &serv_addr,
             serv_addr_size, &abstime);
@@ -570,12 +570,10 @@ void* ConnectThread(void* arg) {
     return NULL;
 }
 
-void sig_handler(int sig) {
-    LOG(INFO) << "sig=" << sig;
-}
+void do_nothing_handler(int) {}
 
 void register_sigurg() {
-    signal(SIGURG, sig_handler);
+    signal(SIGURG, do_nothing_handler);
 }
 
 void TestConnectInterrupt(bool timed) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 
1. #2707 导致RdmaEndpoint回收资源的时候无法从移除对应的fd，导致后续相同值的fd无法再加入到epoll中。
2. 修复EndPointTest.interrupt一些问题：超时时间太小导致失败、信号处理函数中打日志会申请内存导致core。

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
