### PR TITLE
[MPSQ] fix a memleak in butil::ObjectPoolAllocator

### DIFF
--- a/src/butil/containers/mpsc_queue.h
+++ b/src/butil/containers/mpsc_queue.h
@@ -52,7 +52,7 @@ template <typename T>
 class ObjectPoolAllocator {
 public:
     void* Alloc() { return get_object<MPSCQueueNode<T>>(); }
-    void Free(void* p) { return_object(p); }
+    void Free(void* p) { return_object(static_cast<MPSCQueueNode<T>*>(p)); }
 };
 
 

--- a/test/mpsc_queue_unittest.cc
+++ b/test/mpsc_queue_unittest.cc
@@ -2,6 +2,9 @@
 #include <pthread.h>
 #include "butil/containers/mpsc_queue.h"
 
+#define BAIDU_CLEAR_OBJECT_POOL_AFTER_ALL_THREADS_QUIT
+#include "butil/object_pool.h"
+
 namespace {
 
 const uint MAX_COUNT = 1000000;
@@ -120,5 +123,22 @@ TEST(MPSCQueueTest, mpsc_multi_thread) {
 
 }
 
+struct MyObject {};
+
+TEST(MPSCQueueTest, mpsc_test_allocator) {
+    butil::ObjectPoolAllocator<MyObject> alloc;
+
+    auto  p = alloc.Alloc();
+    butil::ObjectPoolInfo info = butil::describe_objects<butil::MPSCQueueNode<MyObject>>();
+    ASSERT_EQ(1, info.item_num);
+
+    alloc.Free(p);
+    info = butil::describe_objects<butil::MPSCQueueNode<MyObject>>();
+    ASSERT_EQ(1, info.item_num);
+
+    p = alloc.Alloc();
+    info = butil::describe_objects<butil::MPSCQueueNode<MyObject>>();
+    ASSERT_EQ(1, info.item_num);
+}
 
 }


### PR DESCRIPTION
Without specifying the type of the pointer, the memory will return to the pool holding all `void' pointers.

### What problem does this PR solve?

Issue Number: #2724 

Problem Summary: see issue #2724 

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
