### PR TITLE
fix gflags bthread_concurrency_by_tag validate error

### DIFF
--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -40,7 +40,7 @@ DEFINE_int32(bthread_min_concurrency, 0,
 
 DEFINE_int32(bthread_current_tag, BTHREAD_TAG_DEFAULT, "Set bthread concurrency for this tag");
 
-DEFINE_int32(bthread_concurrency_by_tag, 0,
+DEFINE_int32(bthread_concurrency_by_tag, 8 + BTHREAD_EPOLL_THREAD_NUM,
              "Number of pthread workers of FLAGS_bthread_current_tag");
 
 static bool never_set_bthread_concurrency = true;
@@ -153,7 +153,7 @@ static bool validate_bthread_current_tag(const char*, int32_t val) {
     BAIDU_SCOPED_LOCK(bthread::g_task_control_mutex);
     auto c = bthread::get_task_control();
     if (c == NULL) {
-        FLAGS_bthread_concurrency_by_tag = 0;
+        FLAGS_bthread_concurrency_by_tag = 8 + BTHREAD_EPOLL_THREAD_NUM;
         return true;
     }
     FLAGS_bthread_concurrency_by_tag = c->concurrency(val);

--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -38,13 +38,12 @@ DEFINE_int32(bthread_min_concurrency, 0,
             " The laziness is disabled when this value is non-positive,"
             " and workers will be created eagerly according to -bthread_concurrency and bthread_setconcurrency(). ");
 
-DEFINE_int32(bthread_current_tag, BTHREAD_TAG_DEFAULT, "Set bthread concurrency for this tag");
+DEFINE_int32(bthread_current_tag, BTHREAD_TAG_INVALID, "Set bthread concurrency for this tag");
 
 DEFINE_int32(bthread_concurrency_by_tag, 8 + BTHREAD_EPOLL_THREAD_NUM,
              "Number of pthread workers of FLAGS_bthread_current_tag");
 
 static bool never_set_bthread_concurrency = true;
-static bool never_set_bthread_concurrency_by_tag = true;
 
 static bool validate_bthread_concurrency(const char*, int32_t val) {
     // bthread_setconcurrency sets the flag on success path which should
@@ -147,7 +146,9 @@ static bool validate_bthread_min_concurrency(const char*, int32_t val) {
 }
 
 static bool validate_bthread_current_tag(const char*, int32_t val) {
-    if (val < BTHREAD_TAG_DEFAULT || val >= FLAGS_task_group_ntags) {
+    if (val == BTHREAD_TAG_INVALID) {
+        return true;
+    } else if (val < BTHREAD_TAG_DEFAULT || val >= FLAGS_task_group_ntags) {
         return false;
     }
     BAIDU_SCOPED_LOCK(bthread::g_task_control_mutex);
@@ -385,12 +386,10 @@ int bthread_getconcurrency_by_tag(bthread_tag_t tag) {
 }
 
 int bthread_setconcurrency_by_tag(int num, bthread_tag_t tag) {
-    if (bthread::never_set_bthread_concurrency_by_tag) {
-        bthread::never_set_bthread_concurrency_by_tag = false;
+    if (tag == BTHREAD_TAG_INVALID) {
         return 0;
-    }
-    if (tag < BTHREAD_TAG_DEFAULT || tag >= FLAGS_task_group_ntags) {
-        return EPERM;
+    } else if (tag < BTHREAD_TAG_DEFAULT || tag >= FLAGS_task_group_ntags) {
+        return EINVAL;
     }
     auto c = bthread::get_or_new_task_control();
     BAIDU_SCOPED_LOCK(bthread::g_task_control_mutex);

--- a/test/bthread_setconcurrency_unittest.cpp
+++ b/test/bthread_setconcurrency_unittest.cpp
@@ -199,7 +199,7 @@ int current_tag(int tag) {
 }
 
 TEST(BthreadTest, current_tag) {
-    ASSERT_EQ(false, current_tag(-1));
+    ASSERT_EQ(false, current_tag(-2));
     ASSERT_EQ(true, current_tag(0));
     ASSERT_EQ(false, current_tag(1));
 }
@@ -213,7 +213,6 @@ int concurrency_by_tag(int num) {
 }
 
 TEST(BthreadTest, concurrency_by_tag) {
-    ASSERT_EQ(concurrency_by_tag(1), true);
     ASSERT_EQ(concurrency_by_tag(1), false);
     auto con = bthread_getconcurrency_by_tag(0);
     ASSERT_EQ(concurrency_by_tag(con), true);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:
https://github.com/apache/brpc/issues/2542

Problem Summary:
升级到1.10.0版本后，重复解析两次 gflags 后，flags bthread_concurrency_by_tag validate会报错的问题又复现了。
是由于在默认配置下，第二次解析gflags时，num = 0，tag_ngroup = FALGS_bthread_concurrency。两者不想等导致返回了EPERM。
gflags的默认配置下，只有一个tag且等于0，bthread_concurrency_by_tag的默认值应该设置成等于bthread_concurrency的默认值，这样也比较合理。
![6M4`0}5K%XVK@V@0(DNK71K](https://github.com/user-attachments/assets/73ddc063-546c-49aa-abdc-11b7fa727311)

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](../../master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
