### PR TITLE
Send unauthorized response to client when authentication fails

### DIFF
--- a/src/brpc/authenticator.h
+++ b/src/brpc/authenticator.h
@@ -74,13 +74,11 @@ public:
                                  const butil::EndPoint& client_addr,
                                  AuthContext* out_ctx) const = 0;
 
-    // Implement this method to decide whether to send a response
-    // to the client when authentication fails.
-    // Returns true to indicate a response needs to be sent,
-    // otherwise no response is needed.
-    virtual bool GetUnauthorizedResponseInfo(std::string& response_str) const {
-        (void)response_str;
-        return false;
+    // Implement this method to unauthorized error text which
+    // will be sent as a part of error text in baidu_std/hulu_pbrpc
+    // protocol or body in http protocol.
+    virtual std::string GetUnauthorizedErrorText() const {
+        return "";
     }
 
 };

--- a/src/brpc/authenticator.h
+++ b/src/brpc/authenticator.h
@@ -57,7 +57,7 @@ private:
 
 class Authenticator {
 public:
-    virtual ~Authenticator() {}
+    virtual ~Authenticator() = default;
 
     // Implement this method to generate credential information
     // into `auth_str' which will be sent to `VerifyCredential'
@@ -73,6 +73,15 @@ public:
     virtual int VerifyCredential(const std::string& auth_str,
                                  const butil::EndPoint& client_addr,
                                  AuthContext* out_ctx) const = 0;
+
+    // Implement this method to decide whether to send a response
+    // to the client when authentication fails.
+    // Returns true to indicate a response needs to be sent,
+    // otherwise no response is needed.
+    virtual bool GetUnauthorizedResponseInfo(std::string& response_str) const {
+        (void)response_str;
+        return false;
+    }
 
 };
 

--- a/src/brpc/policy/http_rpc_protocol.h
+++ b/src/brpc/policy/http_rpc_protocol.h
@@ -40,7 +40,6 @@ struct CommonStrings {
     std::string CONTENT_TYPE_SPRING_PROTO;
     std::string ERROR_CODE;
     std::string AUTHORIZATION;
-    std::string WWW_AUTHENTICATE;
     std::string ACCEPT_ENCODING;
     std::string CONTENT_ENCODING;
     std::string CONTENT_LENGTH;

--- a/src/brpc/policy/http_rpc_protocol.h
+++ b/src/brpc/policy/http_rpc_protocol.h
@@ -40,6 +40,7 @@ struct CommonStrings {
     std::string CONTENT_TYPE_SPRING_PROTO;
     std::string ERROR_CODE;
     std::string AUTHORIZATION;
+    std::string WWW_AUTHENTICATE;
     std::string ACCEPT_ENCODING;
     std::string CONTENT_ENCODING;
     std::string CONTENT_LENGTH;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

当前server鉴权失败时，会直接关闭连接。client只有`EEOF`的错误，没法快速定位问题。

### What is changed and the side effects?

Changed:

在`Authenticator`增加一个接口，支持返回一个错误响应给client再关闭连接。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
