### PR TITLE
Active Spinning and queue old bthread at the head for bthread mutex

### DIFF
--- a/src/bthread/butex.h
+++ b/src/bthread/butex.h
@@ -67,8 +67,13 @@ int butex_requeue(void* butex1, void* butex2);
 // abstime is not NULL.
 // About |abstime|:
 //   Different from FUTEX_WAIT, butex_wait uses absolute time.
+// About |prepend|:
+//   If |prepend| is true, queue the bthread at the head of the queue,
+//   otherwise at the tail.
 // Returns 0 on success, -1 otherwise and errno is set.
-int butex_wait(void* butex, int expected_value, const timespec* abstime);
+int butex_wait(void* butex, int expected_value,
+               const timespec* abstime,
+               bool prepend = false);
 
 }  // namespace bthread
 

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -182,6 +182,11 @@ public:
     // process make go on indefinitely.
     void push_rq(bthread_t tid);
 
+    // Returns size of local run queue.
+    size_t rq_size() const {
+        return _rq.volatile_size();
+    }
+
     bthread_tag_t tag() const { return _tag; }
 
 private:

--- a/src/butil/containers/linked_list.h
+++ b/src/butil/containers/linked_list.h
@@ -171,6 +171,11 @@ class LinkedList {
     e->InsertBefore(&root_);
   }
 
+  // Prepend |e| to the head of the linked list.
+  void Prepend(LinkNode<T>* e) {
+    e->InsertAfter(&root_);
+  }
+
   LinkNode<T>* head() const {
     return root_.next();
   }

--- a/src/butil/thread_local.h
+++ b/src/butil/thread_local.h
@@ -32,19 +32,24 @@
 
 #define BAIDU_VOLATILE_THREAD_LOCAL(type, var_name, default_value)             \
   BAIDU_THREAD_LOCAL type var_name = default_value;                            \
-  static __attribute__((noinline, unused)) type get_##var_name(void) {         \
+  __attribute__((noinline, unused)) type get_##var_name(void) {                \
     asm volatile("");                                                          \
     return var_name;                                                           \
   }                                                                            \
-  static __attribute__((noinline, unused)) type *get_ptr_##var_name(void) {    \
+  __attribute__((noinline, unused)) type *get_ptr_##var_name(void) {           \
     type *ptr = &var_name;                                                     \
     asm volatile("" : "+rm"(ptr));                                             \
     return ptr;                                                                \
   }                                                                            \
-  static __attribute__((noinline, unused)) void set_##var_name(type v) {       \
+  __attribute__((noinline, unused)) void set_##var_name(type v) {              \
     asm volatile("");                                                          \
     var_name = v;                                                              \
   }
+
+#define EXTERN_BAIDU_VOLATILE_THREAD_LOCAL(type, var_name)                     \
+    type get_##var_name(void);                                                 \
+    type *get_ptr_##var_name(void);                                            \
+    void set_##var_name(type v)
 
 #if (defined (__aarch64__) && defined (__GNUC__)) || defined(__clang__)
 // GNU compiler under aarch and Clang compiler is incorrectly caching the 
@@ -53,10 +58,17 @@
 #define BAIDU_GET_VOLATILE_THREAD_LOCAL(var_name) get_##var_name()
 #define BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(var_name) get_ptr_##var_name()
 #define BAIDU_SET_VOLATILE_THREAD_LOCAL(var_name, value) set_##var_name(value)
+
+#define EXTERN_BAIDU_VOLATILE_THREAD_LOCAL(type, var_name)                     \
+    type get_##var_name(void);                                                 \
+    type *get_ptr_##var_name(void);                                            \
+    void set_##var_name(type v)
 #else
 #define BAIDU_GET_VOLATILE_THREAD_LOCAL(var_name) var_name
 #define BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(var_name) &##var_name
 #define BAIDU_SET_VOLATILE_THREAD_LOCAL(var_name, value) var_name = value
+#define EXTERN_BAIDU_VOLATILE_THREAD_LOCAL(type, var_name)                     \
+    extern BAIDU_THREAD_LOCAL type var_name
 #endif
 
 namespace butil {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

golang mutex的演进中有两点优化：

1. fast path没抢到锁的竞争者，进入slow path之后，立即再抢一次锁，不成功就阻塞在butex中，等下次唤醒在抢锁。进入slow path之后的第一次抢锁大概率是会失败的。[[1]](https://github.com/golang/go/commit/edcad8639a902741dc49f77d000ed62b0cc6956f)
2. 被唤醒的队头竞争者跟新竞争者抢锁，大概率也是会失败。因为新竞争者占用着cpu且数量很多。如果将队头的竞争者放到队尾，显然不公平，甚至可能出现饥饿问题。[[2]](https://github.com/golang/go/commit/0556e26273f704db73df9e7c4c3d2e8434dec7be)

### What is changed and the side effects?

Changed:

1. 进入slow path之后，如果worker线程本地调度队列为空，尝试自旋4次再抢锁，这对于临界区小的场景是有意义的。
2. 被唤醒的队头竞争者抢锁失败后，会被重新放回队头。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
