### PR TITLE
Support arena rpc pb message factory

### DIFF
--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -1041,7 +1041,7 @@ public:
     // Get `RpcPBMessages' according to `service' and `method'.
     // Common practice to create protobuf message:
     // service.GetRequestPrototype(&method).New() -> request;
-    // service.GetRequestPrototype(&method).New() -> response.
+    // service.GetResponsePrototype(&method).New() -> response.
     virtual RpcPBMessages* Get(const ::google::protobuf::Service& service,
                                const ::google::protobuf::MethodDescriptor& method) = 0;
     // Return `RpcPBMessages' to factory.

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -1027,7 +1027,9 @@ Server默认使用`DefaultRpcPBMessageFactory`。它是一个简单的工厂类�
 class RpcPBMessages {
 public:
     virtual ~RpcPBMessages() = default;
+    // Get protobuf request message.
     virtual google::protobuf::Message* Request() = 0;
+    // Get protobuf response message.
     virtual google::protobuf::Message* Response() = 0;
 };
 
@@ -1035,11 +1037,20 @@ public:
 class RpcPBMessageFactory {
 public:
     virtual ~RpcPBMessageFactory() = default;
+
+    // Get `RpcPBMessages' according to `service' and `method'.
+    // Common practice to create protobuf message:
+    // service.GetRequestPrototype(&method).New() -> request;
+    // service.GetRequestPrototype(&method).New() -> response.
     virtual RpcPBMessages* Get(const ::google::protobuf::Service& service,
                                const ::google::protobuf::MethodDescriptor& method) = 0;
-    virtual void Return(RpcPBMessages* protobuf_message) = 0;
+    // Return `RpcPBMessages' to factory.
+    virtual void Return(RpcPBMessages* messages) = 0;
 };
 ```
+
+### Protobuf arena
+
 
 # FAQ
 

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -1017,7 +1017,7 @@ public:
 
 Server默认使用`DefaultRpcPBMessageFactory`。它是一个简单的工厂类，通过`new`来创建请求/响应message和`delete`来销毁请求/响应message。
 
-如果用户希望自定义创建销毁机制，可以实现`RpcPBMessages`（请求/响应message的封装）和`RpcPBMessageFactory`（工厂类），并通过`ServerOptions.rpc_pb_message_factory`。
+如果用户希望自定义创建销毁机制，可以实现`RpcPBMessages`（请求/响应message的封装）和`RpcPBMessageFactory`（工厂类），并设置`ServerOptions.rpc_pb_message_factory`为自定义的`RpcPBMessageFactory`。注意：server启动后，server拥有了`RpcPBMessageFactory`的所有权。
 
 接口如下：
 
@@ -1051,6 +1051,11 @@ public:
 
 ### Protobuf arena
 
+Protobuf arena是一种Protobuf message内存管理机制，有着提高内存分配效率、减少内存碎片、对缓存友好等优点。详细信息见[C++ Arena Allocation Guide](https://protobuf.dev/reference/cpp/arenas/)。
+
+如果用户希望使用protobuf arena来管理Protobuf message内存，可以设置`ServerOptions.rpc_pb_message_factory = brpc::GetArenaRpcPBMessageFactory();`，使用默认的`start_block_size`（256 bytes）和`max_block_size`（8192 bytes）来创建arena。用户可以调用`brpc::GetArenaRpcPBMessageFactory<StartBlockSize, MaxBlockSize>();`自定义arena大小。
+
+注意：从Protobuf v3.14.0开始，[默认开启arena](https://github.com/protocolbuffers/protobuf/releases/tag/v3.14.0https://github.com/protocolbuffers/protobuf/releases/tag/v3.14.0)。但是Protobuf v3.14.0之前的版本，用户需要再proto文件中加上选项：`option cc_enable_arenas = true;`，所以为了兼容性，可以统一都加上该选项。
 
 # FAQ
 

--- a/docs/en/server.md
+++ b/docs/en/server.md
@@ -1008,6 +1008,41 @@ public:
         ...
 ```
 
+## RPC Protobuf message factory
+
+`DefaultRpcPBMessageFactory' is used at server-side by default. It is a simple factory class that uses `new' to create request/response messages and `delete' to destroy request/response messages.
+
+Users can implement `RpcPBMessages' (encapsulation of request/response message) and `RpcPBMessageFactory' (factory class) to customize the creation and destruction mechanism of protobuf message, and then set to `ServerOptions.rpc_pb_message_factory'.
+
+The interface is as follows:
+
+```c++
+// Inherit this class to customize rpc protobuf messages,
+// include request and response.
+class RpcPBMessages {
+public:
+    virtual ~RpcPBMessages() = default;
+    // Get protobuf request message.
+    virtual google::protobuf::Message* Request() = 0;
+    // Get protobuf response message.
+    virtual google::protobuf::Message* Response() = 0;
+};
+
+// Factory to manage `RpcPBMessages'.
+class RpcPBMessageFactory {
+public:
+    virtual ~RpcPBMessageFactory() = default;
+    // Get `RpcPBMessages' according to `service' and `method'.
+    // Common practice to create protobuf message:
+    // service.GetRequestPrototype(&method).New() -> request;
+    // service.GetRequestPrototype(&method).New() -> response.
+    virtual RpcPBMessages* Get(const ::google::protobuf::Service& service,
+                               const ::google::protobuf::MethodDescriptor& method) = 0;
+    // Return `RpcPBMessages' to factory.
+    virtual void Return(RpcPBMessages* protobuf_message) = 0;
+};
+```
+
 # FAQ
 
 ### Q: Fail to write into fd=1865 SocketId=8905@10.208.245.43:54742@8230: Got EOF

--- a/docs/en/server.md
+++ b/docs/en/server.md
@@ -1035,7 +1035,7 @@ public:
     // Get `RpcPBMessages' according to `service' and `method'.
     // Common practice to create protobuf message:
     // service.GetRequestPrototype(&method).New() -> request;
-    // service.GetRequestPrototype(&method).New() -> response.
+    // service.GetResponsePrototype(&method).New() -> response.
     virtual RpcPBMessages* Get(const ::google::protobuf::Service& service,
                                const ::google::protobuf::MethodDescriptor& method) = 0;
     // Return `RpcPBMessages' to factory.

--- a/docs/en/server.md
+++ b/docs/en/server.md
@@ -1010,9 +1010,9 @@ public:
 
 ## RPC Protobuf message factory
 
-`DefaultRpcPBMessageFactory' is used at server-side by default. It is a simple factory class that uses `new' to create request/response messages and `delete' to destroy request/response messages.
+`DefaultRpcPBMessageFactory' is used at server-side by default. It is a simple factory class that uses `new' to create request/response messages and `delete' to destroy request/response messages. Currently, the baidu_std protocol and HTTP protocol support this feature.
 
-Users can implement `RpcPBMessages' (encapsulation of request/response message) and `RpcPBMessageFactory' (factory class) to customize the creation and destruction mechanism of protobuf message, and then set to `ServerOptions.rpc_pb_message_factory'.
+Users can implement `RpcPBMessages' (encapsulation of request/response message) and `RpcPBMessageFactory' (factory class) to customize the creation and destruction mechanism of protobuf message, and then set to `ServerOptions.rpc_pb_message_factory`. Note: After the server is started, the server owns the `RpcPBMessageFactory`.
 
 The interface is as follows:
 
@@ -1042,6 +1042,14 @@ public:
     virtual void Return(RpcPBMessages* protobuf_message) = 0;
 };
 ```
+
+### Protobuf arena
+
+Protobuf arena is a Protobuf message memory management mechanism with the advantages of improving memory allocation efficiency, reducing memory fragmentation, and being cache-friendly. For more information, see [C++ Arena Allocation Guide](https://protobuf.dev/reference/cpp/arenas/).
+
+Users can set `ServerOptions.rpc_pb_message_factory = brpc::GetArenaRpcPBMessageFactory();` to manage Protobuf message memory,  with the default `start_block_size` (256 bytes) and `max_block_size` (8192 bytes). Alternatively, users can use `brpc::GetArenaRpcPBMessageFactory<StartBlockSize, MaxBlockSize>();` to customize the arena size.
+
+Note: Since Protocol Buffers v3.14.0, Arenas are now unconditionally enabled. However, for versions prior to Protobuf v3.14.0, users need to add the option `option cc_enable_arenas = true;` to the proto file. so for compatibility, this option can be added uniformly.
 
 # FAQ
 

--- a/src/brpc/rpc_pb_message_factory.cpp
+++ b/src/brpc/rpc_pb_message_factory.cpp
@@ -16,7 +16,6 @@
 // under the License.
 
 #include "brpc/rpc_pb_message_factory.h"
-#include "butil/object_pool.h"
 
 namespace brpc {
 

--- a/src/brpc/rpc_pb_message_factory.h
+++ b/src/brpc/rpc_pb_message_factory.h
@@ -44,7 +44,7 @@ public:
     // Get `RpcPBMessages' according to `service' and `method'.
     // Common practice to create protobuf message:
     // service.GetRequestPrototype(&method).New() -> request;
-    // service.GetRequestPrototype(&method).New() -> response.
+    // service.GetResponsePrototype(&method).New() -> response.
     virtual RpcPBMessages* Get(const ::google::protobuf::Service& service,
                                const ::google::protobuf::MethodDescriptor& method) = 0;
     // Return `RpcPBMessages' to factory.

--- a/src/brpc/rpc_pb_message_factory.h
+++ b/src/brpc/rpc_pb_message_factory.h
@@ -21,6 +21,8 @@
 #include <google/protobuf/service.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
+#include <google/protobuf/arena.h>
+#include "butil/object_pool.h"
 
 namespace brpc {
 
@@ -29,7 +31,9 @@ namespace brpc {
 class RpcPBMessages {
 public:
     virtual ~RpcPBMessages() = default;
+    // Get protobuf request message.
     virtual google::protobuf::Message* Request() = 0;
+    // Get protobuf response message.
     virtual google::protobuf::Message* Response() = 0;
 };
 
@@ -37,9 +41,14 @@ public:
 class RpcPBMessageFactory {
 public:
     virtual ~RpcPBMessageFactory() = default;
+    // Get `RpcPBMessages' according to `service' and `method'.
+    // Common practice to create protobuf message:
+    // service.GetRequestPrototype(&method).New() -> request;
+    // service.GetRequestPrototype(&method).New() -> response.
     virtual RpcPBMessages* Get(const ::google::protobuf::Service& service,
                                const ::google::protobuf::MethodDescriptor& method) = 0;
-    virtual void Return(RpcPBMessages* protobuf_message) = 0;
+    // Return `RpcPBMessages' to factory.
+    virtual void Return(RpcPBMessages* messages) = 0;
 };
 
 class DefaultRpcPBMessageFactory : public RpcPBMessageFactory {
@@ -49,6 +58,80 @@ public:
     void Return(RpcPBMessages* messages) override;
 };
 
+namespace internal {
+
+// Allocate protobuf message from arena.
+// The arena is created with `StartBlockSize' and `MaxBlockSize' options.
+// For more details, see `google::protobuf::ArenaOptions'.
+template<size_t StartBlockSize, size_t MaxBlockSize>
+struct ArenaRpcPBMessages : public RpcPBMessages {
+    struct ArenaOptionsWrapper {
+    public:
+        ArenaOptionsWrapper() {
+            options.start_block_size = StartBlockSize;
+            options.max_block_size = MaxBlockSize;
+        }
+
+    private:
+    friend struct ArenaRpcPBMessages;
+        ::google::protobuf::ArenaOptions options;
+    };
+
+    explicit ArenaRpcPBMessages(ArenaOptionsWrapper options_wrapper)
+        : arena(options_wrapper.options)
+        , request(NULL)
+        , response(NULL) {}
+
+    ::google::protobuf::Message* Request() override { return request; }
+    ::google::protobuf::Message* Response() override { return response; }
+
+    ::google::protobuf::Arena arena;
+    ::google::protobuf::Message* request;
+    ::google::protobuf::Message* response;
+};
+
+template<size_t StartBlockSize, size_t MaxBlockSize>
+class ArenaRpcPBMessageFactory : public RpcPBMessageFactory {
+    typedef ::brpc::internal::ArenaRpcPBMessages<StartBlockSize, MaxBlockSize>
+        ArenaRpcPBMessages;
+public:
+    ArenaRpcPBMessageFactory() {
+        _arena_options.start_block_size = StartBlockSize;
+        _arena_options.max_block_size = MaxBlockSize;
+    }
+
+    RpcPBMessages* Get(const ::google::protobuf::Service& service,
+                       const ::google::protobuf::MethodDescriptor& method) override {
+        typename ArenaRpcPBMessages::ArenaOptionsWrapper options_wrapper;
+        auto messages = butil::get_object<ArenaRpcPBMessages>(options_wrapper);
+        messages->request = service.GetRequestPrototype(&method).New(&messages->arena);
+        messages->response = service.GetResponsePrototype(&method).New(&messages->arena);
+        return messages;
+    }
+
+    void Return(RpcPBMessages* messages) override {
+        auto arena_messages = static_cast<ArenaRpcPBMessages*>(messages);
+        arena_messages->request = NULL;
+        arena_messages->response = NULL;
+        butil::return_object(arena_messages);
+    }
+
+private:
+    ::google::protobuf::ArenaOptions _arena_options;
+};
+
+}
+
+template<size_t StartBlockSize, size_t MaxBlockSize>
+RpcPBMessageFactory* GetArenaRpcPBMessageFactory() {
+    return new ::brpc::internal::ArenaRpcPBMessageFactory<StartBlockSize, MaxBlockSize>();
+}
+
+BUTIL_FORCE_INLINE RpcPBMessageFactory* GetArenaRpcPBMessageFactory() {
+    // Default arena options, same as `google::protobuf::ArenaOptions'.
+    return GetArenaRpcPBMessageFactory<256, 8192>();
+}
+
 } // namespace brpc
 
-#endif //BRPC_RPC_PB_MESSAGE_FACTORY_H
+#endif // BRPC_RPC_PB_MESSAGE_FACTORY_H

--- a/test/v3.proto
+++ b/test/v3.proto
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+syntax="proto3";
+
+package v3;
+
+option cc_generic_services = true;
+// https://github.com/protocolbuffers/protobuf/releases/tag/v3.14.0
+// Since Protocol Buffers v3.14.0, Arenas are now unconditionally enabled.
+// cc_enable_arenas no longer has any effect.
+option cc_enable_arenas = true;
+
+message EchoRequest {
+    string message = 1;
+};
+
+message EchoResponse {
+    string message = 1;
+};
+
+service EchoService {
+    rpc Echo(EchoRequest) returns (EchoResponse);
+};


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #535

Problem Summary:

### What is changed and the side effects?

Changed:

1. 目前bRPC已经不支持pb 2.x，没有了兼容性方面的顾虑，所以在#2718 的基础上支持pb3 arena机制即可。
2. HTTP协议支持RpcPBMessageFactory。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
