### PR TITLE
Support noncopyable sync objects

### DIFF
--- a/src/bthread/types.h
+++ b/src/bthread/types.h
@@ -23,6 +23,7 @@
 #define BTHREAD_TYPES_H
 
 #include <stdint.h>                            // uint64_t
+#include "butil/macros.h"
 #if defined(__cplusplus)
 #include "butil/logging.h"                      // CHECK
 #endif
@@ -164,7 +165,11 @@ typedef struct {
     size_t sampling_range;
 } bthread_contention_site_t;
 
-typedef struct {
+typedef struct bthread_mutex_t {
+#if defined(__cplusplus)
+    bthread_mutex_t() : butex(NULL), csite{} {}
+    DISALLOW_COPY_AND_ASSIGN(bthread_mutex_t);
+#endif
     unsigned* butex;
     bthread_contention_site_t csite;
 } bthread_mutex_t;
@@ -172,7 +177,11 @@ typedef struct {
 typedef struct {
 } bthread_mutexattr_t;
 
-typedef struct {
+typedef struct bthread_cond_t {
+#if defined(__cplusplus)
+    bthread_cond_t() : m(NULL), seq(NULL) {}
+    DISALLOW_COPY_AND_ASSIGN(bthread_cond_t);
+#endif
     bthread_mutex_t* m;
     int* seq;
 } bthread_cond_t;
@@ -208,8 +217,10 @@ friend int bthread::bthread_once_impl(bthread_once_t* once_control, void (*init_
         INITIALIZED,
     };
 
+
     bthread_once_t();
     ~bthread_once_t();
+    DISALLOW_COPY_AND_ASSIGN(bthread_once_t);
 
 private:
     butil::atomic<int>* _butex;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 

Problem Summary:

使用bthread_mutex、bthread_cond_t时，一旦不小心发现了拷贝，就会出现未定义行为。

### What is changed and the side effects?

Changed:

在C++环境中，禁止bthread_mutex、bthread_cond_t拷贝。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
