### PR TITLE
Add NonreflectableMessage

### DIFF
--- a/src/brpc/esp_head.h
+++ b/src/brpc/esp_head.h
@@ -18,6 +18,8 @@
 #ifndef BRPC_ESP_HEAD_H
 #define BRPC_ESP_HEAD_H
 
+#include <cstdint>
+
 namespace brpc {
 
 #pragma pack(push, r1, 1)

--- a/src/brpc/esp_message.cpp
+++ b/src/brpc/esp_message.cpp
@@ -17,22 +17,14 @@
 
 #include "esp_message.h"
 
-#include <google/protobuf/reflection_ops.h>     // ReflectionOps::Merge
-#include <google/protobuf/wire_format.h>        // WireFormatLite::GetTagWireType
-
+#include "brpc/proto_base.pb.h"
 #include "butil/logging.h"
 
 namespace brpc {
 
 EspMessage::EspMessage()
-    : ::google::protobuf::Message() {
+    : MessageHelper<EspMessage>::BaseType() {
     SharedCtor();
-}
-
-EspMessage::EspMessage(const EspMessage& from)
-    : ::google::protobuf::Message() {
-    SharedCtor();
-    MergeFrom(from);
 }
 
 void EspMessage::SharedCtor() {
@@ -50,81 +42,19 @@ const ::google::protobuf::Descriptor* EspMessage::descriptor() {
     return EspMessageBase::descriptor();
 }
 
-EspMessage* EspMessage::New() const {
-    return new EspMessage;
-}
-
-#if GOOGLE_PROTOBUF_VERSION >= 3006000
-EspMessage* EspMessage::New(::google::protobuf::Arena* arena) const {
-    return CreateMaybeMessage<EspMessage>(arena);
-}
-#endif
-
 void EspMessage::Clear() {
     head.body_len = 0;
     body.clear();
 }
 
-bool EspMessage::MergePartialFromCodedStream(
-        ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
-    ::google::protobuf::uint32 tag;
-
-    while ((tag = input->ReadTag()) != 0) {
-        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
-                ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
-            return true;
-        }
-    }
-    return true;
-#undef DO_
-}
-
-void EspMessage::SerializeWithCachedSizes(
-        ::google::protobuf::io::CodedOutputStream*) const {
-}
-
-::google::protobuf::uint8* EspMessage::SerializeWithCachedSizesToArray(
-        ::google::protobuf::uint8* target) const {
-    return target;
-}
-
-int EspMessage::ByteSize() const {
+size_t EspMessage::ByteSizeLong() const {
     return sizeof(head) + body.size();
-}
-
-void EspMessage::MergeFrom(const ::google::protobuf::Message& from) {
-    CHECK_NE(&from, this);
-    const EspMessage* source = dynamic_cast<const EspMessage*>(&from);
-    if (source == NULL) {
-        ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-    } else {
-        MergeFrom(*source);
-    }
 }
 
 void EspMessage::MergeFrom(const EspMessage& from) {
     CHECK_NE(&from, this);
     head = from.head;
     body = from.body;
-}
-
-void EspMessage::CopyFrom(const ::google::protobuf::Message& from) {
-    if (&from == this) {
-        return;
-    }
-
-    Clear();
-    MergeFrom(from);
-}
-
-void EspMessage::CopyFrom(const EspMessage& from) {
-    if (&from == this) {
-        return;
-    }
-
-    Clear();
-    MergeFrom(from);
 }
 
 bool EspMessage::IsInitialized() const {
@@ -138,13 +68,6 @@ void EspMessage::Swap(EspMessage* other) {
         head = tmp;
         body.swap(other->body);
     }
-}
-
-::google::protobuf::Metadata EspMessage::GetMetadata() const {
-    ::google::protobuf::Metadata metadata;
-    metadata.descriptor = EspMessage::descriptor();
-    metadata.reflection = NULL;
-    return metadata;
 }
 
 } // namespace brpc

--- a/src/brpc/esp_message.h
+++ b/src/brpc/esp_message.h
@@ -18,64 +18,33 @@
 #ifndef BRPC_ESP_MESSAGE_H
 #define BRPC_ESP_MESSAGE_H
 
-#include <string>
-
-#include <google/protobuf/message.h>
-#include <google/protobuf/generated_message_reflection.h>   // dynamic_cast_if_available
-#include <google/protobuf/reflection_ops.h>     // ReflectionOps::Merge
-
 #include "brpc/esp_head.h"
-#include "butil/iobuf.h"       
-#include "brpc/proto_base.pb.h"
-#include "brpc/pb_compat.h"
+#include "brpc/message_helper.h"
+#include "butil/iobuf.h"
 
 namespace brpc {
 
-class EspMessage : public ::google::protobuf::Message {
+class EspMessage : public MessageHelper<EspMessage>::BaseType {
 public:
     EspHead head;
     butil::IOBuf body;
 
 public:
     EspMessage();
-    virtual ~EspMessage();
-
-    EspMessage(const EspMessage& from);
-
-    inline EspMessage& operator=(const EspMessage& from) {
-        CopyFrom(from);
-        return *this;
-    }
+    ~EspMessage() override;
 
     static const ::google::protobuf::Descriptor* descriptor();
-    static const EspMessage& default_instance();
 
     void Swap(EspMessage* other);
 
     // implements Message ----------------------------------------------
 
-    EspMessage* New() const PB_319_OVERRIDE;
-#if GOOGLE_PROTOBUF_VERSION >= 3006000
-    EspMessage* New(::google::protobuf::Arena* arena) const override;
-#endif
-    void CopyFrom(const ::google::protobuf::Message& from) PB_321_OVERRIDE;
-    void MergeFrom(const ::google::protobuf::Message& from) override;
-    void CopyFrom(const EspMessage& from);
-    void MergeFrom(const EspMessage& from);
+    void MergeFrom(const EspMessage& from) override;
     void Clear() override;
     bool IsInitialized() const override;
 
-    int ByteSize() const;
-    bool MergePartialFromCodedStream(
-            ::google::protobuf::io::CodedInputStream* input) PB_310_OVERRIDE;
-    void SerializeWithCachedSizes(
-            ::google::protobuf::io::CodedOutputStream* output) const PB_310_OVERRIDE;
-    ::google::protobuf::uint8* SerializeWithCachedSizesToArray(
-            ::google::protobuf::uint8* output) const PB_310_OVERRIDE;
-    int GetCachedSize() const PB_422_OVERRIDE { return ByteSize(); }
-
-protected:
-    ::google::protobuf::Metadata GetMetadata() const override;
+    size_t ByteSizeLong() const override;
+    int GetCachedSize() const override { return static_cast<int>(ByteSizeLong()); }
 
 private:
     void SharedCtor();

--- a/src/brpc/message_helper.h
+++ b/src/brpc/message_helper.h
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef BRPC_MESSAGE_HELPER_H
+#define BRPC_MESSAGE_HELPER_H
+
+#include "brpc/nonreflectable_message.h"
+
+namespace brpc {
+
+template <typename T>
+struct MessageHelper {
+    using BaseType = NonreflectableMessage<T>;
+};
+
+} // namespace brpc
+
+#endif // BRPC_MESSAGE_HELPER_H

--- a/src/brpc/nonreflectable_message.h
+++ b/src/brpc/nonreflectable_message.h
@@ -1,0 +1,200 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef BRPC_NONREFLECTABLE_MESSAGE_H
+#define BRPC_NONREFLECTABLE_MESSAGE_H
+
+#include <google/protobuf/message.h>
+
+namespace brpc {
+
+//
+// In bRPC, some non-Protobuf based protocol messages are also designed to implement
+// Protobuf Message interfaces, to provide a unified protocol message.
+// The API of Protobuf Message changes frequently, and these non-Protobuf based protocol
+// messages do not rely on the reflection functionality of Protobuf.
+//
+// NonreflectableMessage is designed to isolate upstream API changes and
+// provides basic implementations to simplify the adaptation process.
+//
+// Function implementations are kept order with the upstream,
+// and use only #if version_check #endif, to make maintenance easier.
+//
+template <typename T>
+class NonreflectableMessage : public ::google::protobuf::Message {
+public:
+#if GOOGLE_PROTOBUF_VERSION < 3019000
+    Message* New() const override {
+        return new T();
+    }
+#endif
+
+#if GOOGLE_PROTOBUF_VERSION >= 3000000
+    Message* New(::google::protobuf::Arena* arena) const override {
+        return ::google::protobuf::Arena::Create<T>(arena);
+    }
+#endif
+
+#if GOOGLE_PROTOBUF_VERSION < 3021000
+    void CopyFrom(const ::google::protobuf::Message& other) override {
+        if (&other == this) {
+            return;
+        }
+        Clear();
+        MergeFrom(other);
+    }
+#endif
+
+    inline void CopyFrom(const NonreflectableMessage& other) {
+        if (&other == this) {
+            return;
+        }
+        Clear();
+        MergeFrom(other);
+    }
+
+#if GOOGLE_PROTOBUF_VERSION < 5026000
+    void MergeFrom(const ::google::protobuf::Message& other) override {
+        if (&other == this) {
+            return;
+        }
+
+        // Cross-type merging is meaningless, call implementation of subclass
+#if GOOGLE_PROTOBUF_VERSION >= 3007000
+        const T* same_type_other = ::google::protobuf::DynamicCastToGenerated<T>(&other);
+#elif GOOGLE_PROTOBUF_VERSION >= 3000000
+        const T* same_type_other = ::google::protobuf::internal::DynamicCastToGenerated<const T>(&other);
+#endif // GOOGLE_PROTOBUF_VERSION
+        if (same_type_other != nullptr) {
+            MergeFrom(*same_type_other);
+        } else {
+            Message::MergeFrom(other);
+        }
+    }
+#endif // member function closure
+
+    virtual void MergeFrom(const T&) = 0;
+
+#if GOOGLE_PROTOBUF_VERSION > 3019000 && GOOGLE_PROTOBUF_VERSION < 5026000
+    // Unsupported by default.
+    std::string InitializationErrorString() const override {
+        return "unknown error";
+    }
+#endif
+
+#if GOOGLE_PROTOBUF_VERSION < 3019000
+    // Unsupported by default.
+    void DiscardUnknownFields() override {}
+#endif
+
+#if GOOGLE_PROTOBUF_VERSION < 5026000
+    // Unsupported by default.
+    size_t SpaceUsedLong() const override {
+        return 0;
+    }
+#endif
+
+    // Unsupported by default.
+    ::std::string GetTypeName() const override {
+        return {};
+    }
+
+    void Clear() override {}
+
+#if GOOGLE_PROTOBUF_VERSION < 3010000
+    bool MergePartialFromCodedStream(::google::protobuf::io::CodedInputStream*) override {
+        return true;
+    }
+#endif
+
+    // Quickly check if all required fields have values set.
+    // Unsupported by default.
+    bool IsInitialized() const override {
+        return true;
+    }
+
+#if GOOGLE_PROTOBUF_VERSION >= 3010000 && GOOGLE_PROTOBUF_VERSION <= 5026000
+    const char* _InternalParse(
+            const char* ptr, ::google::protobuf::internal::ParseContext*) override {
+        return ptr;
+    }
+#endif
+
+    // Size of bytes after serialization.
+    size_t ByteSizeLong() const override {
+        return 0;
+    }
+
+#if GOOGLE_PROTOBUF_VERSION >= 3007000 && GOOGLE_PROTOBUF_VERSION < 3010000
+    void SerializeWithCachedSizes(::google::protobuf::io::CodedOutputStream*) const override {}
+#endif
+
+#if GOOGLE_PROTOBUF_VERSION >= 3010000 && GOOGLE_PROTOBUF_VERSION < 3011000
+    uint8_t* InternalSerializeWithCachedSizesToArray(
+            uint8_t* ptr, ::google::protobuf::io::EpsCopyOutputStream*) const override {
+        return ptr;
+    }
+#endif
+
+#if GOOGLE_PROTOBUF_VERSION >= 3011000
+    uint8_t* _InternalSerialize(
+            uint8_t* ptr, ::google::protobuf::io::EpsCopyOutputStream*) const override {
+        return ptr;
+    }
+#endif
+
+#if GOOGLE_PROTOBUF_VERSION < 4025000
+    // Unnecessary for Nonreflectable message.
+    int GetCachedSize() const override {
+        return 0;
+    }
+#endif
+
+#if GOOGLE_PROTOBUF_VERSION < 4025000
+    // Unnecessary for Nonreflectable message.
+    void SetCachedSize(int) const override {}
+#endif
+
+public:
+    // Only can be used to determine whether the Types are the same.
+    ::google::protobuf::Metadata GetMetadata() const override {
+        ::google::protobuf::Metadata metadata{};
+        // can only be used to
+        metadata.descriptor = reinterpret_cast<const ::google::protobuf::Descriptor*>(&_instance);
+        metadata.reflection = reinterpret_cast<const ::google::protobuf::Reflection*>(&_instance);
+        return metadata;
+    }
+
+    // Only can be used to determine whether the Types are the same.
+    inline static const ::google::protobuf::Descriptor* descriptor() noexcept {
+        return default_instance().GetMetadata().descriptor;
+    }
+
+    inline static const T& default_instance() noexcept {
+        return _instance;
+    }
+
+private:
+    static T _instance;
+};
+
+template <typename T>
+T NonreflectableMessage<T>::_instance;
+
+} // namespace brpc
+
+#endif // BRPC_NONREFLECTABLE_MESSAGE_H


### PR DESCRIPTION
See https://github.com/apache/brpc/pull/2722#issuecomment-2272559689, inspired by unreflectable_message of @oathdruid.

### What problem does this PR solve?

Issue Number: #2757

Problem Summary:

隔离 Protobuf Message API，简化内部消息类型实现，简化后续 Protobuf 适配工作

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
