### PR TITLE
add check for bthread_setconcurrency_by_tag

### DIFF
--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -392,6 +392,10 @@ int bthread_setconcurrency_by_tag(int num, bthread_tag_t tag) {
     if (tag < BTHREAD_TAG_DEFAULT || tag >= FLAGS_task_group_ntags) {
         return EPERM;
     }
+    if (num < BTHREAD_MIN_CONCURRENCY || num > BTHREAD_MAX_CONCURRENCY) {
+        LOG(ERROR) << "Invalid concurrency_by_tag=" << num;
+        return EINVAL;
+    }
     auto c = bthread::get_or_new_task_control();
     BAIDU_SCOPED_LOCK(bthread::g_task_control_mutex);
     auto ngroup = c->concurrency();


### PR DESCRIPTION
### What problem does this PR solve?

add check for bthread_setconcurrency_by_tag, make sure bRPC workers number in one group between BTHREAD_MIN_CONCURRENCY and BTHREAD_MAX_CONCURRENCY

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
