### PR TITLE
switch boost dependency in bzlmod to bcr

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,10 +18,9 @@
 #
 common --registry=https://bcr.bazel.build
 common --registry=https://baidu.github.io/babylon/registry
-common --registry=https://raw.githubusercontent.com/bazelboost/registry/main
 
 build --cxxopt="-std=c++17"
-# Use gnu11 for asm keyword.
+# Use gnu17 for asm keyword.
 build --conlyopt="-std=gnu17"
 
 # Enable position independent code (this is the default on macOS and Windows)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
   compatibility_level = 1,
 )
 
-# https://bcr.bazel.build
+# --registry=https://bcr.bazel.build
 bazel_dep(name = 'abseil-cpp', version = '20210324.2', repo_name = 'com_google_absl')
 bazel_dep(name = 'bazel_skylib', version = '1.0.3')
 bazel_dep(name = 'boringssl', version = '0.0.0-20211025-d4f1ab9')
@@ -16,11 +16,10 @@ bazel_dep(name = 'rules_cc', version = '0.0.1')
 bazel_dep(name = 'rules_proto', version = '4.0.0')
 bazel_dep(name = 'zlib', version = '1.2.13', repo_name = 'com_github_madler_zlib')
 
-# https://baidu.github.io/babylon/registry
-# https://raw.githubusercontent.com/bazelboost/registry/main
+# --registry=https://baidu.github.io/babylon/registry
 bazel_dep(name = 'leveldb', version = '1.23', repo_name = 'com_github_google_leveldb')
-bazel_dep(name = 'openssl', version = '3.3.1')
-bazel_dep(name = 'thrift', version = '0.20.0', repo_name = 'org_apache_thrift')
+bazel_dep(name = 'openssl', version = '3.3.2')
+bazel_dep(name = 'thrift', version = '0.21.0', repo_name = 'org_apache_thrift')
 
 # test only
 bazel_dep(name = 'googletest', version = '1.14.0.bcr.1', repo_name = 'com_google_googletest', dev_dependency = True)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary: 
boost has already officially published to bcr. switch to use that

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
