### PR TITLE
Support backtrace log

### DIFF
--- a/src/bthread/mutex.cpp
+++ b/src/bthread/mutex.cpp
@@ -544,15 +544,9 @@ void CheckBthreadScheSafety() {
         return;
     }
 
-    static butil::atomic<bool> b_sched_in_p_lock_logged{false};
-    if (BAIDU_UNLIKELY(!b_sched_in_p_lock_logged.exchange(
-        true, butil::memory_order_relaxed))) {
-        butil::debug::StackTrace trace(true);
-        // It can only be checked once because the counter is messed up.
-        LOG(ERROR) << "bthread is suspended while holding "
-                   << tls_pthread_lock_count << " pthread locks."
-                   << std::endl << trace.ToString();
-    }
+    // It can only be checked once because the counter is messed up.
+    LOG_BACKTRACE_ONCE(ERROR) << "bthread is suspended while holding "
+                              << tls_pthread_lock_count << " pthread locks.";
 }
 #else
 #define ADD_TLS_PTHREAD_LOCK_COUNT ((void)0)

--- a/src/butil/logging.cc
+++ b/src/butil/logging.cc
@@ -1334,7 +1334,7 @@ void LogStream::FlushWithoutReset() {
     }
 
 #if !defined(OS_NACL) && !defined(__UCLIBC__)
-    if (FLAGS_print_stack_on_check && _is_check && _severity == BLOG_FATAL) {
+    if ((FLAGS_print_stack_on_check && _is_check && _severity == BLOG_FATAL) || _backtrace) {
         // Include a stack trace on a fatal.
         butil::debug::StackTrace trace;
         size_t count = 0;

--- a/src/bvar/detail/percentile.h
+++ b/src/bvar/detail/percentile.h
@@ -99,7 +99,7 @@ public:
             // No sample should be dropped
             CHECK_EQ(_num_samples, _num_added)
                 << "_num_added=" << _num_added
-                << " rhs._num_added" << rhs._num_added
+                << " rhs._num_added=" << rhs._num_added
                 << " _num_samples=" << _num_samples
                 << " rhs._num_samples=" << rhs._num_samples
                 << " SAMPLE_SIZE=" << SAMPLE_SIZE

--- a/test/logging_unittest.cc
+++ b/test/logging_unittest.cc
@@ -350,6 +350,12 @@ TEST_F(LoggingTest, check) {
     CHECK_GE(3, 3);
 }
 
+TEST_F(LoggingTest, log_backtrace) {
+    LOG_BACKTRACE_IF(INFO, true) << "log_backtrace_if";
+    LOG_BACKTRACE_IF_ONCE(INFO, true) << "log_backtrace_if_once";
+    LOG_BACKTRACE_ONCE(INFO) << "log_backtrace_once";
+}
+
 int foo(int* p) {
     return ++*p;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

有一些场景下，需要打印调用栈，但是crash_on_fatal_log=true时，CHECK会crash。

### What is changed and the side effects?

Changed:

支持打印调用栈，且不会crash。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
