### PR TITLE
method level option to ignore server eovercrowded

### DIFF
--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -1067,8 +1067,6 @@ server.IgnoreEovercrowdedOf("...") = ...可设置method级别的ignore_eovercrow
 ```c++
 ServerOptions.ignore_eovercrowded = true;                   // Set the default ignore_eovercrowded for all methods
 server.IgnoreEovercrowdedOf("example.EchoService.Echo") = true;
-server.IgnoreEovercrowdedOf("example.EchoService", "Echo") = true;
-server.IgnoreEovercrowdedOf(&service, "Echo") = true;
 ```
 
 此设置一般**发生在AddService后，server启动前**。当设置失败时（比如对应的method不存在），server会启动失败同时提示用户修正IgnoreEovercrowdedOf设置错误。

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -1057,6 +1057,26 @@ Protobuf arena是一种Protobuf message内存管理机制，有着提高内存�
 
 注意：从Protobuf v3.14.0开始，[默认开启arena](https://github.com/protocolbuffers/protobuf/releases/tag/v3.14.0https://github.com/protocolbuffers/protobuf/releases/tag/v3.14.0)。但是Protobuf v3.14.0之前的版本，用户需要再proto文件中加上选项：`option cc_enable_arenas = true;`，所以为了兼容性，可以统一都加上该选项。
 
+## server端忽略eovercrowded
+### server级别忽略eovercrowded
+设置ServerOptions.ignore_eovercrowded，默认值0代表不忽略
+
+### method级别忽略eovercrowded
+server.IgnoreEovercrowdedOf("...") = ...可设置method级别的ignore_eovercrowded。也可以通过设置ServerOptions.ignore_eovercrowded一次性为所有的method设置忽略eovercrowded。
+
+```c++
+ServerOptions.ignore_eovercrowded = true;                   // Set the default ignore_eovercrowded for all methods
+server.IgnoreEovercrowdedOf("example.EchoService.Echo") = true;
+server.IgnoreEovercrowdedOf("example.EchoService", "Echo") = true;
+server.IgnoreEovercrowdedOf(&service, "Echo") = true;
+```
+
+此设置一般**发生在AddService后，server启动前**。当设置失败时（比如对应的method不存在），server会启动失败同时提示用户修正IgnoreEovercrowdedOf设置错误。
+
+当ServerOptions.ignore_eovercrowded和server.IgnoreEovercrowdedOf("...")=...同时被设置时，任何一个设置为true，就表示会忽略eovercrowded。
+
+注意：没有service级别的ignore_eovercrowded。
+
 # FAQ
 
 ### Q: Fail to write into fd=1865 SocketId=8905@10.208.245.43:54742@8230: Got EOF是什么意思

--- a/docs/en/server.md
+++ b/docs/en/server.md
@@ -1063,8 +1063,6 @@ server.IgnoreEovercrowdedOf("...") = … sets ignore_eovercrowded of the method.
 ```c++
 ServerOptions.ignore_eovercrowded = true;                   // Set the default ignore_eovercrowded for all methods
 server.IgnoreEovercrowdedOf("example.EchoService.Echo") = true;
-server.IgnoreEovercrowdedOf("example.EchoService", "Echo") = true;
-server.IgnoreEovercrowdedOf(&service, "Echo") = true;
 ```
 
 The code is generally put **after AddService, before Start() of the server**. When a setting fails(namely the method does not exist), server will fail to start and notify user to fix settings on IgnoreEovercrowdedOf.

--- a/docs/en/server.md
+++ b/docs/en/server.md
@@ -1051,6 +1051,28 @@ Users can set `ServerOptions.rpc_pb_message_factory = brpc::GetArenaRpcPBMessage
 
 Note: Since Protocol Buffers v3.14.0, Arenas are now unconditionally enabled. However, for versions prior to Protobuf v3.14.0, users need to add the option `option cc_enable_arenas = true;` to the proto file. so for compatibility, this option can be added uniformly.
 
+## Ignoring eovercrowded on server-side
+### Ignore eovercrowded on server-level
+
+Set ServerOptions.ignore_eovercrowded. Default value is 0 which means not ignored.
+
+### Ignore eovercrowded on method-level
+
+server.IgnoreEovercrowdedOf("...") = … sets ignore_eovercrowded of the method. Possible settings:
+
+```c++
+ServerOptions.ignore_eovercrowded = true;                   // Set the default ignore_eovercrowded for all methods
+server.IgnoreEovercrowdedOf("example.EchoService.Echo") = true;
+server.IgnoreEovercrowdedOf("example.EchoService", "Echo") = true;
+server.IgnoreEovercrowdedOf(&service, "Echo") = true;
+```
+
+The code is generally put **after AddService, before Start() of the server**. When a setting fails(namely the method does not exist), server will fail to start and notify user to fix settings on IgnoreEovercrowdedOf.
+
+When method-level and server-level ignore_eovercrowded are both set, if any one of them is set to true, eovercrowded will be ignored.
+
+NOTE: No service-level ignore_eovercrowded.
+
 # FAQ
 
 ### Q: Fail to write into fd=1865 SocketId=8905@10.208.245.43:54742@8230: Got EOF

--- a/src/brpc/baidu_master_service.cpp
+++ b/src/brpc/baidu_master_service.cpp
@@ -22,7 +22,7 @@
 namespace brpc {
 
 BaiduMasterService::BaiduMasterService()
-    :_status(new(std::nothrow) MethodStatus) {
+    : _status(new (std::nothrow) MethodStatus), ignore_eovercrowded(false) {
     LOG_IF(FATAL, NULL == _status) << "Fail to new MethodStatus";
 }
 

--- a/src/brpc/baidu_master_service.cpp
+++ b/src/brpc/baidu_master_service.cpp
@@ -22,7 +22,7 @@
 namespace brpc {
 
 BaiduMasterService::BaiduMasterService()
-    : _status(new (std::nothrow) MethodStatus), ignore_eovercrowded(false) {
+    : _status(new (std::nothrow) MethodStatus), _ignore_eovercrowded(false) {
     LOG_IF(FATAL, NULL == _status) << "Fail to new MethodStatus";
 }
 

--- a/src/brpc/baidu_master_service.h
+++ b/src/brpc/baidu_master_service.h
@@ -45,8 +45,12 @@ public:
         return _max_concurrency;
     }
 
-    bool& IgnoreEOverCrowded() {
-        return ignore_eovercrowded;
+    bool ignore_eovercrowded() {
+        return _ignore_eovercrowded;
+    }
+
+    void set_ignore_eovercrowded(bool ignore_eovercrowded) {
+        _ignore_eovercrowded = ignore_eovercrowded;
     }
 
     virtual void ProcessRpcRequest(Controller* cntl,
@@ -96,7 +100,7 @@ friend class Server;
 
     MethodStatus* _status;
     AdaptiveMaxConcurrency _max_concurrency;
-    bool ignore_eovercrowded;
+    bool _ignore_eovercrowded;
 };
 
 }

--- a/src/brpc/baidu_master_service.h
+++ b/src/brpc/baidu_master_service.h
@@ -96,7 +96,7 @@ friend class Server;
 
     MethodStatus* _status;
     AdaptiveMaxConcurrency _max_concurrency;
-    bool ignore_eovercrowded = false;
+    bool ignore_eovercrowded;
 };
 
 }

--- a/src/brpc/baidu_master_service.h
+++ b/src/brpc/baidu_master_service.h
@@ -45,6 +45,10 @@ public:
         return _max_concurrency;
     }
 
+    bool& IgnoreEOverCrowded() {
+        return ignore_eovercrowded;
+    }
+
     virtual void ProcessRpcRequest(Controller* cntl,
                                    const SerializedRequest* request,
                                    SerializedResponse* response,
@@ -92,6 +96,7 @@ friend class Server;
 
     MethodStatus* _status;
     AdaptiveMaxConcurrency _max_concurrency;
+    bool ignore_eovercrowded = false;
 };
 
 }

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -491,12 +491,6 @@ void ProcessRpcRequest(InputMessageBase* msg_base) {
             cntl->SetFailed(ELOGOFF, "Server is stopping");
             break;
         }
-        
-        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded) {
-            cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
-                            butil::endpoint2str(socket->remote_side()).c_str());
-            break;
-        }
 
         if (!server_accessor.AddConcurrency(cntl.get())) {
             cntl->SetFailed(
@@ -524,6 +518,13 @@ void ProcessRpcRequest(InputMessageBase* msg_base) {
         google::protobuf::Service* svc = NULL;
         google::protobuf::MethodDescriptor* method = NULL;
         if (NULL != server->options().baidu_master_service) {
+          if (socket->is_overcrowded() &&
+              !server->options().ignore_eovercrowded &&
+              !server->options().baidu_master_service->IgnoreEOverCrowded()) {
+            cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
+                            butil::endpoint2str(socket->remote_side()).c_str());
+            break;
+          }
             svc = server->options().baidu_master_service;
             auto sampled_request = new (std::nothrow) SampledRequest;
             if (NULL == sampled_request) {
@@ -586,10 +587,13 @@ void ProcessRpcRequest(InputMessageBase* msg_base) {
                 mp->service->CallMethod(mp->method, cntl.get(), &breq, &bres, NULL);
                 break;
             }
-            if (socket->is_overcrowded() && !server->options().ignore_eovercrowded && !mp->ignore_eovercrowded) {
-                cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
-                                butil::endpoint2str(socket->remote_side()).c_str());
-                break;
+            if (socket->is_overcrowded() &&
+                !server->options().ignore_eovercrowded &&
+                !mp->ignore_eovercrowded) {
+              cntl->SetFailed(
+                  EOVERCROWDED, "Connection to %s is overcrowded",
+                  butil::endpoint2str(socket->remote_side()).c_str());
+              break;
             }
             // Switch to service-specific error.
             non_service_error.release();

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -586,6 +586,11 @@ void ProcessRpcRequest(InputMessageBase* msg_base) {
                 mp->service->CallMethod(mp->method, cntl.get(), &breq, &bres, NULL);
                 break;
             }
+            if (socket->is_overcrowded() && !server->options().ignore_eovercrowded && !mp->ignore_eovercrowded) {
+                cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
+                                butil::endpoint2str(socket->remote_side()).c_str());
+                break;
+            }
             // Switch to service-specific error.
             non_service_error.release();
             method_status = mp->status;

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -520,7 +520,7 @@ void ProcessRpcRequest(InputMessageBase* msg_base) {
         if (NULL != server->options().baidu_master_service) {
           if (socket->is_overcrowded() &&
               !server->options().ignore_eovercrowded &&
-              !server->options().baidu_master_service->IgnoreEOverCrowded()) {
+              !server->options().baidu_master_service->ignore_eovercrowded()) {
             cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
                             butil::endpoint2str(socket->remote_side()).c_str());
             break;

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -1495,7 +1495,9 @@ void ProcessHttpRequest(InputMessageBase *msg) {
     // NOTE: accesses to builtin services are not counted as part of
     // concurrency, therefore are not limited by ServerOptions.max_concurrency.
     if (!sp->is_builtin_service && !sp->params.is_tabbed) {
-        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded && !sp->ignore_eovercrowded) {
+        if (socket->is_overcrowded() &&
+            !server->options().ignore_eovercrowded &&
+            !sp->ignore_eovercrowded) {
             cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
                             butil::endpoint2str(socket->remote_side()).c_str());
             return;

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -1495,7 +1495,7 @@ void ProcessHttpRequest(InputMessageBase *msg) {
     // NOTE: accesses to builtin services are not counted as part of
     // concurrency, therefore are not limited by ServerOptions.max_concurrency.
     if (!sp->is_builtin_service && !sp->params.is_tabbed) {
-        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded) {
+        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded && !sp->ignore_eovercrowded) {
             cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
                             butil::endpoint2str(socket->remote_side()).c_str());
             return;

--- a/src/brpc/policy/hulu_pbrpc_protocol.cpp
+++ b/src/brpc/policy/hulu_pbrpc_protocol.cpp
@@ -448,7 +448,9 @@ void ProcessHuluRequest(InputMessageBase* msg_base) {
             sp->service->CallMethod(sp->method, cntl.get(), &breq, &bres, NULL);
             break;
         }
-        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded && !sp->ignore_eovercrowded) {
+        if (socket->is_overcrowded() &&
+            !server->options().ignore_eovercrowded &&
+            !sp->ignore_eovercrowded) {
             cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
                             butil::endpoint2str(socket->remote_side()).c_str());
             break;

--- a/src/brpc/policy/hulu_pbrpc_protocol.cpp
+++ b/src/brpc/policy/hulu_pbrpc_protocol.cpp
@@ -422,12 +422,6 @@ void ProcessHuluRequest(InputMessageBase* msg_base) {
             break;
         }
 
-        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded) {
-            cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
-                            butil::endpoint2str(socket->remote_side()).c_str());
-            break;
-        }
-
         if (!server_accessor.AddConcurrency(cntl.get())) {
             cntl->SetFailed(ELIMIT, "Reached server's max_concurrency=%d",
                             server->options().max_concurrency);
@@ -454,6 +448,12 @@ void ProcessHuluRequest(InputMessageBase* msg_base) {
             sp->service->CallMethod(sp->method, cntl.get(), &breq, &bres, NULL);
             break;
         }
+        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded && !sp->ignore_eovercrowded) {
+            cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
+                            butil::endpoint2str(socket->remote_side()).c_str());
+            break;
+        }
+
         // Switch to service-specific error.
         non_service_error.release();
         method_status = sp->status;

--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -400,7 +400,9 @@ void ProcessSofaRequest(InputMessageBase* msg_base) {
                             meta.method().c_str());
             break;
         }
-        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded && !sp->ignore_eovercrowded) {
+        if (socket->is_overcrowded() &&
+            !server->options().ignore_eovercrowded &&
+            !sp->ignore_eovercrowded) {
             cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
                             butil::endpoint2str(socket->remote_side()).c_str());
             break;

--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -381,12 +381,6 @@ void ProcessSofaRequest(InputMessageBase* msg_base) {
             break;
         }
 
-        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded) {
-            cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
-                            butil::endpoint2str(socket->remote_side()).c_str());
-            break;
-        }
-
         if (!server_accessor.AddConcurrency(cntl.get())) {
             cntl->SetFailed(
                 ELIMIT, "Reached server's max_concurrency=%d",
@@ -404,6 +398,11 @@ void ProcessSofaRequest(InputMessageBase* msg_base) {
         if (NULL == sp) {
             cntl->SetFailed(ENOMETHOD, "Fail to find method=%s", 
                             meta.method().c_str());
+            break;
+        }
+        if (socket->is_overcrowded() && !server->options().ignore_eovercrowded && !sp->ignore_eovercrowded) {
+            cntl->SetFailed(EOVERCROWDED, "Connection to %s is overcrowded",
+                            butil::endpoint2str(socket->remote_side()).c_str());
             break;
         }
         // Switch to service-specific error.

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -180,7 +180,8 @@ Server::MethodProperty::MethodProperty()
     , http_url(NULL)
     , service(NULL)
     , method(NULL)
-    , status(NULL) {
+    , status(NULL)
+    , ignore_eovercrowded(false) {
 }
 
 static timeval GetUptime(void* arg/*start_time*/) {

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -795,6 +795,7 @@ static bool OptionsAvailableOverRdma(const ServerOptions* opt) {
 #endif
 
 static AdaptiveMaxConcurrency g_default_max_concurrency_of_method(0);
+static bool g_default_ignore_eovercrowded(false);
 
 int Server::StartInternal(const butil::EndPoint& endpoint,
                           const PortRange& port_range,
@@ -2300,6 +2301,74 @@ AdaptiveMaxConcurrency& Server::MaxConcurrencyOf(google::protobuf::Service* serv
 int Server::MaxConcurrencyOf(google::protobuf::Service* service,
                              const butil::StringPiece& method_name) const {
     return MaxConcurrencyOf(service->GetDescriptor()->full_name(), method_name);
+}
+
+bool& Server::IgnoreEovercrowdedOf(MethodProperty* mp) {
+    if (IsRunning()) {
+        LOG(WARNING) << "IgnoreEovercrowdedOf is only allowd before Server started";
+        return g_default_ignore_eovercrowded;
+    }
+    if (mp->status == NULL) {
+        LOG(ERROR) << "method=" << mp->method->full_name()
+                   << " does not support max_concurrency";
+        _failed_to_set_max_concurrency_of_method = true;
+        return g_default_ignore_eovercrowded;
+    }
+    return mp->ignore_eovercrowded;
+}
+
+bool Server::IgnoreEovercrowdedOf(const MethodProperty* mp) const {
+    if (IsRunning()) {
+        LOG(WARNING) << "IgnoreEovercrowdedOf is only allowd before Server started";
+        return g_default_ignore_eovercrowded;
+    }
+    if (mp == NULL || mp->status == NULL) {
+        return false;
+    }
+    return mp->ignore_eovercrowded;
+}
+
+bool& Server::IgnoreEovercrowdedOf(const butil::StringPiece& full_method_name) {
+    MethodProperty* mp = _method_map.seek(full_method_name);
+    if (mp == NULL) {
+        LOG(ERROR) << "Fail to find method=" << full_method_name;
+        _failed_to_set_max_concurrency_of_method = true;
+        return g_default_ignore_eovercrowded;
+    }
+    return IgnoreEovercrowdedOf(mp);
+}
+
+bool Server::IgnoreEovercrowdedOf(const butil::StringPiece& full_method_name) const {
+    return IgnoreEovercrowdedOf(_method_map.seek(full_method_name));
+}
+
+bool& Server::IgnoreEovercrowdedOf(const butil::StringPiece& full_service_name,
+                              const butil::StringPiece& method_name) {
+    MethodProperty* mp = const_cast<MethodProperty*>(
+        FindMethodPropertyByFullName(full_service_name, method_name));
+    if (mp == NULL) {
+        LOG(ERROR) << "Fail to find method=" << full_service_name
+                   << '/' << method_name;
+        _failed_to_set_max_concurrency_of_method = true;
+        return g_default_ignore_eovercrowded;
+    }
+    return IgnoreEovercrowdedOf(mp);
+}
+
+bool Server::IgnoreEovercrowdedOf(const butil::StringPiece& full_service_name,
+                             const butil::StringPiece& method_name) const {
+    return IgnoreEovercrowdedOf(FindMethodPropertyByFullName(
+                                full_service_name, method_name));
+}
+
+bool& Server::IgnoreEovercrowdedOf(google::protobuf::Service* service,
+                              const butil::StringPiece& method_name) {
+    return IgnoreEovercrowdedOf(service->GetDescriptor()->full_name(), method_name);
+}
+
+bool Server::IgnoreEovercrowdedOf(google::protobuf::Service* service,
+                             const butil::StringPiece& method_name) const {
+    return IgnoreEovercrowdedOf(service->GetDescriptor()->full_name(), method_name);
 }
 
 bool Server::AcceptRequest(Controller* cntl) const {

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -417,6 +417,7 @@ public:
         const google::protobuf::MethodDescriptor* method;
         MethodStatus* status;
         AdaptiveMaxConcurrency max_concurrency;
+        bool ignore_eovercrowded = false;
 
         MethodProperty();
     };
@@ -595,6 +596,19 @@ public:
     int MaxConcurrencyOf(google::protobuf::Service* service,
                          const butil::StringPiece& method_name) const;
 
+    bool& IgnoreEovercrowdedOf(const butil::StringPiece& full_method_name);
+    bool IgnoreEovercrowdedOf(const butil::StringPiece& full_method_name) const;
+
+    bool& IgnoreEovercrowdedOf(const butil::StringPiece& full_service_name,
+                          const butil::StringPiece& method_name);
+    bool IgnoreEovercrowdedOf(const butil::StringPiece& full_service_name,
+                         const butil::StringPiece& method_name) const;
+
+    bool& IgnoreEovercrowdedOf(google::protobuf::Service* service,
+                          const butil::StringPiece& method_name);
+    bool IgnoreEovercrowdedOf(google::protobuf::Service* service,
+                         const butil::StringPiece& method_name) const;
+
     int Concurrency() const {
         return butil::subtle::NoBarrier_Load(&_concurrency);
     };
@@ -699,6 +713,8 @@ friend class Controller;
 
     AdaptiveMaxConcurrency& MaxConcurrencyOf(MethodProperty*);
     int MaxConcurrencyOf(const MethodProperty*) const;
+    bool& IgnoreEovercrowdedOf(MethodProperty*);
+    bool IgnoreEovercrowdedOf(const MethodProperty*) const;
 
     static bool CreateConcurrencyLimiter(const AdaptiveMaxConcurrency& amc,
                                          ConcurrencyLimiter** out);

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -417,6 +417,10 @@ public:
         const google::protobuf::MethodDescriptor* method;
         MethodStatus* status;
         AdaptiveMaxConcurrency max_concurrency;
+        // ignore_eovercrowded on method-level, it should be used with carefulness. 
+        // It might introduce inbalance between methods, 
+        // as some methods(ignore_eovercrowded=1) might never return eovercrowded 
+        // while other methods(ignore_eovercrowded=0) keep returning eovercrowded. 
         bool ignore_eovercrowded = false;
 
         MethodProperty();

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -420,7 +420,8 @@ public:
         // ignore_eovercrowded on method-level, it should be used with carefulness. 
         // It might introduce inbalance between methods, 
         // as some methods(ignore_eovercrowded=1) might never return eovercrowded 
-        // while other methods(ignore_eovercrowded=0) keep returning eovercrowded. 
+        // while other methods(ignore_eovercrowded=0) keep returning eovercrowded.
+        // currently only valid for baidu_rpc, http_rpc, hulu_pbrpc and sofa_pbrpc protocols 
         bool ignore_eovercrowded = false;
 
         MethodProperty();

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -419,10 +419,10 @@ public:
         AdaptiveMaxConcurrency max_concurrency;
         // ignore_eovercrowded on method-level, it should be used with carefulness. 
         // It might introduce inbalance between methods, 
-        // as some methods(ignore_eovercrowded=1) might never return eovercrowded 
-        // while other methods(ignore_eovercrowded=0) keep returning eovercrowded.
-        // currently only valid for baidu_rpc, http_rpc, hulu_pbrpc and sofa_pbrpc protocols 
-        bool ignore_eovercrowded = false;
+        // as some methods(ignore_eovercrowded=true) might never return eovercrowded 
+        // while other methods(ignore_eovercrowded=false) keep returning eovercrowded.
+        // currently only valid for baidu_master_service, baidu_rpc, http_rpc, hulu_pbrpc and sofa_pbrpc protocols 
+        bool ignore_eovercrowded;
 
         MethodProperty();
     };

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -604,16 +604,6 @@ public:
     bool& IgnoreEovercrowdedOf(const butil::StringPiece& full_method_name);
     bool IgnoreEovercrowdedOf(const butil::StringPiece& full_method_name) const;
 
-    bool& IgnoreEovercrowdedOf(const butil::StringPiece& full_service_name,
-                          const butil::StringPiece& method_name);
-    bool IgnoreEovercrowdedOf(const butil::StringPiece& full_service_name,
-                         const butil::StringPiece& method_name) const;
-
-    bool& IgnoreEovercrowdedOf(google::protobuf::Service* service,
-                          const butil::StringPiece& method_name);
-    bool IgnoreEovercrowdedOf(google::protobuf::Service* service,
-                         const butil::StringPiece& method_name) const;
-
     int Concurrency() const {
         return butil::subtle::NoBarrier_Load(&_concurrency);
     };
@@ -718,8 +708,6 @@ friend class Controller;
 
     AdaptiveMaxConcurrency& MaxConcurrencyOf(MethodProperty*);
     int MaxConcurrencyOf(const MethodProperty*) const;
-    bool& IgnoreEovercrowdedOf(MethodProperty*);
-    bool IgnoreEovercrowdedOf(const MethodProperty*) const;
 
     static bool CreateConcurrencyLimiter(const AdaptiveMaxConcurrency& amc,
                                          ConcurrencyLimiter** out);

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -751,6 +751,7 @@ friend class Controller;
     // number of the virtual services for mapping URL to methods.
     int _virtual_service_count;
     bool _failed_to_set_max_concurrency_of_method;
+    bool _failed_to_set_ignore_eovercrowded;
     Acceptor* _am;
     Acceptor* _internal_am;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed: add a method-level option(only valid for baidu_rpc, http_rpc, hulu_pbrpc and sofa_pbrpc protocols) to enable ignore eovercrowded errors for some methods.

Side effects:
- Performance effects(性能影响): no or little

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
