### PR TITLE
Upgrade Protobuf to v27.3 for building with bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 bazel_dep(name = 'abseil-cpp', version = '20210324.2', repo_name = 'com_google_absl')
 bazel_dep(name = 'bazel_skylib', version = '1.0.3')
 bazel_dep(name = 'boringssl', version = '0.0.0-20211025-d4f1ab9')
-bazel_dep(name = 'protobuf', version = '3.19.6', repo_name = 'com_google_protobuf')
+bazel_dep(name = 'protobuf', version = '27.3', repo_name = 'com_google_protobuf')
 bazel_dep(name = 'gflags', version = '2.2.2', repo_name = 'com_github_gflags_gflags')
 bazel_dep(name = 'glog', version = '0.5.0', repo_name = 'com_github_google_glog')
 bazel_dep(name = 'platforms', version = '0.0.4')


### PR DESCRIPTION
After using offical boost 1.83.0[1], rules_cc@0.0.13 are required, which, in turn, requires Protobuf v27.0.

Protobuf v27.0 is not compatible with GCC less than 13[2].

[1] https://github.com/apache/brpc/pull/2789
[2] https://github.com/protocolbuffers/protobuf/issues/16868

### What problem does this PR solve?

Issue Number: #2822

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
