### PR TITLE
Change the default value of the bthread_tag in class ServerOptions to BTHREAD_TAG_DEFAULT

### DIFF
--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -151,7 +151,7 @@ ServerOptions::ServerOptions()
     , health_reporter(NULL)
     , rtmp_service(NULL)
     , redis_service(NULL)
-    , bthread_tag(BTHREAD_TAG_INVALID)
+    , bthread_tag(BTHREAD_TAG_DEFAULT)
     , rpc_pb_message_factory(new DefaultRpcPBMessageFactory())
     , ignore_eovercrowded(false) {
     if (s_ncore > 0) {
@@ -846,10 +846,6 @@ int Server::StartInternal(const butil::EndPoint& endpoint,
 #endif
     }
 
-    auto original_bthread_tag = _options.bthread_tag;
-    if (original_bthread_tag == BTHREAD_TAG_INVALID) {
-        _options.bthread_tag = BTHREAD_TAG_DEFAULT;
-    }
     if (_options.bthread_tag < BTHREAD_TAG_DEFAULT ||
         _options.bthread_tag >= FLAGS_task_group_ntags) {
         LOG(ERROR) << "Fail to set tag " << _options.bthread_tag << ", tag range is ["

--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -400,18 +400,16 @@ int bthread_setconcurrency_by_tag(int num, bthread_tag_t tag) {
     auto tag_ngroup = c->concurrency(tag);
     auto add = num - tag_ngroup;
 
-    if (add > 0) {
+    if (add >= 0) {
         auto added = c->add_workers(add, tag);
         bthread::FLAGS_bthread_concurrency += added;
         return (add == added ? 0 : EPERM);
 
-    } else if (add < 0){
+    } else {
         LOG(WARNING) << "Fail to set concurrency by tag: " << tag
-                     << ", tag concurrency must larger than old oncurrency. old concurrency: "
+                     << ", tag concurrency should be larger than old oncurrency. old concurrency: "
                      << tag_ngroup << ", new concurrency: " << num;
         return EPERM;
-    } else {
-        return 0;
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
将ServerOptions 中的bthread_tag默认值改为BTHREAD_TAG_DEFAULT && 简化代码逻辑
Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
