### PR TITLE
Fix build instructions in getting_started.md

### DIFF
--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -108,6 +108,7 @@ cmake -B build && cmake --build build -j6
 ```shell
 $ cd example/echo_c++
 $ cmake -B build && cmake --build build -j4
+$ cd build
 $ ./echo_server &
 $ ./echo_client
 ```


### PR DESCRIPTION
In the previous instructions, the operation of switching to the build directory was omitted.
![image](https://github.com/user-attachments/assets/a4296d42-31ea-4ad0-9f98-e3d09e9f697b)

