### PR TITLE
Fix unused private field warning of FastPthreadMutex

### DIFF
--- a/src/bthread/mutex.cpp
+++ b/src/bthread/mutex.cpp
@@ -658,7 +658,7 @@ void submit_contention(const bthread_contention_site_t& csite, int64_t now_ns) {
 }
 
 #if BRPC_DEBUG_LOCK
-#define MUTEX_RESET_OWNER_COMMON(owner)                                                     \
+#define MUTEX_RESET_OWNER_COMMON(owner)                                              \
     ((butil::atomic<bool>*)&(owner).hold)                                            \
         ->store(false, butil::memory_order_relaxed)
 
@@ -678,9 +678,9 @@ void submit_contention(const bthread_contention_site_t& csite, int64_t now_ns) {
                    << std::endl << trace.ToString();                                 \
     }
 #else
-#define MUTEX_RESET_OWNER_COMMON(owner) ((void)0)
-#define PTHREAD_MUTEX_SET_OWNER(owner) ((void)0)
-#define PTHREAD_MUTEX_CHECK_OWNER(owner) ((void)0)
+#define MUTEX_RESET_OWNER_COMMON(owner) ((void)owner)
+#define PTHREAD_MUTEX_SET_OWNER(owner) ((void)owner)
+#define PTHREAD_MUTEX_CHECK_OWNER(owner) ((void)owner)
 #endif // BRPC_DEBUG_LOCK
 
 namespace internal {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
