### PR TITLE
fix: use space instead of tab

### DIFF
--- a/src/bvar/mvariable.cpp
+++ b/src/bvar/mvariable.cpp
@@ -261,13 +261,13 @@ size_t MVariable::dump_exposed(Dumper* dumper, const DumpOptions* options) {
         if (entry) {
             n += entry->var->dump(dumper, &opt);
         }
-	if (n > static_cast<size_t>(FLAGS_bvar_max_dump_multi_dimension_metric_number)) {
+        if (n > static_cast<size_t>(FLAGS_bvar_max_dump_multi_dimension_metric_number)) {
             LOG(WARNING) << "truncated because of \
-		            exceed max dump multi dimension label number["
-			 << FLAGS_bvar_max_dump_multi_dimension_metric_number
-			 << "]";
+                            exceed max dump multi dimension label number["
+                         << FLAGS_bvar_max_dump_multi_dimension_metric_number
+                         << "]";
             break;
-	}
+        }
     }
     return n;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

**Mixing tabs and spaces causes confusions.**


<img width="895" alt="image" src="https://github.com/user-attachments/assets/611af284-639d-45a5-947f-ecbbcc6c1542">


### What is changed and the side effec

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
