### PR TITLE
Fix build failure with -std=c++17 option

### DIFF
--- a/src/butil/containers/optional.h
+++ b/src/butil/containers/optional.h
@@ -27,6 +27,9 @@
 // After C++17, `optional` is an alias for `std::optional`.
 
 #if __cplusplus >= 201703L
+
+#include <optional>
+
 namespace butil {
 using std::in_place_t;
 using std::in_place;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

build fails when building with -std=c++17 on

![image](https://github.com/user-attachments/assets/b9a960a5-7dee-4871-8957-c878ffe64c9d)


### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
