### PR TITLE
add support for bthread cpu usage

### DIFF
--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -554,4 +554,12 @@ bthread_tag_t bthread_self_tag(void) {
                                               : BTHREAD_TAG_DEFAULT;
 }
 
+uint64_t bthread_cpu_clock_ns(void) {
+     bthread::TaskGroup* g = bthread::tls_task_group;
+    if (g != NULL && !g->is_current_main_task()) {
+        return g->current_task_cpu_clock_ns();
+    }
+    return 0;
+}
+
 }  // extern "C"

--- a/src/bthread/bthread.h
+++ b/src/bthread/bthread.h
@@ -397,6 +397,24 @@ extern bthread_tag_t bthread_self_tag(void);
 // Returns 0 on success, error code otherwise.
 extern int bthread_once(bthread_once_t* once_control, void (*init_routine)());
 
+ /**
+ * @brief Retrieves the CPU time consumed by the current bthread.
+ *
+ * This function returns the CPU time (in nanoseconds) used by the current 
+ * bthread, excluding time spent in blocking I/O operations. The result 
+ * provides an accurate measure of CPU time utilized by the bthread's 
+ * execution.
+ *
+ * @note The functionality of this function depends on the 
+ *       `bthread_enable_cpu_clock_stat` flag. Ensure this flag is enabled 
+ *       for the function to provide meaningful results. If the flag is 
+ *       disabled, the function may return an invalid value or behave 
+ *       unexpectedly.
+ *
+ * @return int64_t The CPU time in nanoseconds consumed by the bthread.
+ */
+extern uint64_t bthread_cpu_clock_ns(void);
+
 __END_DECLS
 
 #endif  // BTHREAD_BTHREAD_H

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -189,6 +189,15 @@ public:
 
     bthread_tag_t tag() const { return _tag; }
 
+    int64_t current_task_cpu_clock_ns() {
+        if (_last_cpu_clock_ns == 0) {
+            return 0;
+        }
+        int64_t total_ns = _cur_meta->stat.cpu_usage_ns;
+        total_ns += butil::cputhread_time_ns() - _last_cpu_clock_ns;
+        return total_ns;
+    }
+
 private:
 friend class TaskControl;
 
@@ -241,6 +250,8 @@ friend class TaskControl;
     // last scheduling time
     int64_t _last_run_ns;
     int64_t _cumulated_cputime_ns;
+    // last thread cpu clock
+    int64_t _last_cpu_clock_ns;
 
     size_t _nswitch;
     RemainedFn _last_context_remained;

--- a/src/bthread/task_meta.h
+++ b/src/bthread/task_meta.h
@@ -33,6 +33,7 @@ namespace bthread {
 struct TaskStatistics {
     int64_t cputime_ns;
     int64_t nswitch;
+    int64_t cpu_usage_ns;
 };
 
 class KeyTable;

--- a/src/butil/time.h
+++ b/src/butil/time.h
@@ -303,6 +303,14 @@ inline int64_t cpuwide_time_ns() {
 #endif // defined(BAIDU_INTERNAL)
 }
 
+// Get cpu clock time of the current thread in nanoseconds without the time spent in blocking I/O operations.
+// Cost ~200ns
+inline int64_t cputhread_time_ns() {
+    timespec now;
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &now);
+    return now.tv_sec * 1000000000L + now.tv_nsec;
+}
+
 inline int64_t cpuwide_time_us() {
     return cpuwide_time_ns() / 1000L;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2833 

Problem Summary:



### What is changed and the side effects?

Changed:
通过添加一个新的 ` bthread_cpu_clock_ns` 函数来获取当前bthread运行的时间，这个函数受 `bthread_enable_cpu_clock_stat` flag控制，默认不开启，需要获取运行时间的时候打开这个flag，用户在自己代码里面通过调用 `bthread_cpu_clock_ns`拿到运行时间采集到指标里面。

Side effects:
- Performance effects(性能影响): 打开开关后稍微影响bthrad调度的性能，一次调度增加 ~200ns的开销。

- Breaking backward compatibility(向后兼容性):  无

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
