### PR TITLE
Instruct LeakSanitizer to ignore designated memory leaks of Server and Singleton

### DIFF
--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -26,8 +26,7 @@
 #include "bthread/unstable.h"                       // bthread_keytable_pool_init
 #include "butil/macros.h"                           // ARRAY_SIZE
 #include "butil/fd_guard.h"                         // fd_guard
-#include "butil/logging.h"
-// CHECK
+#include "butil/logging.h"                          // CHECK
 #include "butil/time.h"
 #include "butil/class_name.h"
 #include "butil/string_printf.h"

--- a/src/butil/compiler_specific.h
+++ b/src/butil/compiler_specific.h
@@ -199,6 +199,19 @@
 #define WARN_UNUSED_RESULT
 #endif
 
+// Compiler feature-detection.
+// clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension
+#if defined(__has_feature)
+#define BUTIL_HAS_FEATURE(FEATURE) __has_feature(FEATURE)
+#else
+#define BUTIL_HAS_FEATURE(FEATURE) 0
+#endif
+
+// Instruct ASan is enabled.
+#if BUTIL_HAS_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#define BUTIL_USE_ASAN 1
+#endif
+
 // Tell the compiler a function is using a printf-style format string.
 // |format_param| is the one-based index of the format string parameter;
 // |dots_param| is the one-based index of the "..." parameter.

--- a/src/butil/debug/leak_annotations.h
+++ b/src/butil/debug/leak_annotations.h
@@ -19,7 +19,7 @@
 // ANNOTATE_LEAKING_OBJECT_PTR(X): the heap object referenced by pointer X will
 // be annotated as a leak.
 
-#if defined(LEAK_SANITIZER) && !defined(OS_NACL)
+#if (defined(LEAK_SANITIZER) && !defined(OS_NACL)) || defined(BUTIL_USE_ASAN)
 
 // Public LSan API from <sanitizer/lsan_interface.h>.
 extern "C" {

--- a/src/butil/lazy_instance.h
+++ b/src/butil/lazy_instance.h
@@ -105,6 +105,7 @@ struct LeakyLazyInstanceTraits {
 #endif
 
   static Type* New(void* instance) {
+    // Instruct LeakSanitizer to ignore the designated memory leak.
     ANNOTATE_SCOPED_MEMORY_LEAK;
     return DefaultLazyInstanceTraits<Type>::New(instance);
   }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #2164, resolve #1390, resolve #2470

Problem Summary:

### What is changed and the side effects?

Changed:

让LSan忽略Server和Singleton一些设计上预期内的内存泄漏。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
