### PR TITLE
Fix gflags namespace

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,7 +29,6 @@ COPTS = [
     "-D__STDC_FORMAT_MACROS",
     "-D__STDC_LIMIT_MACROS",
     "-D__STDC_CONSTANT_MACROS",
-    "-DGFLAGS_NS=google",
 ] + select({
     "//bazel/config:brpc_with_glog": ["-DBRPC_WITH_GLOG=1"],
     "//conditions:default": ["-DBRPC_WITH_GLOG=0"],

--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -259,15 +259,6 @@ fi
 PROTOC=$(find_bin_or_die protoc)
 
 GFLAGS_HDR=$(find_dir_of_header_or_die gflags/gflags.h)
-# namespace of gflags may not be google, grep it from source.
-GFLAGS_NS=$(grep "namespace [_A-Za-z0-9]\+ {" $GFLAGS_HDR/gflags/gflags_declare.h | head -1 | awk '{print $2}')
-if [ "$GFLAGS_NS" = "GFLAGS_NAMESPACE" ]; then
-    GFLAGS_NS=$(grep "#define GFLAGS_NAMESPACE [_A-Za-z0-9]\+" $GFLAGS_HDR/gflags/gflags_declare.h | head -1 | awk '{print $3}')
-fi
-if [ -z "$GFLAGS_NS" ]; then
-    >&2 $ECHO "Fail to grep namespace of gflags source $GFLAGS_HDR/gflags/gflags_declare.h"
-    exit 1
-fi
 
 PROTOBUF_HDR=$(find_dir_of_header_or_die google/protobuf/message.h)
 PROTOBUF_VERSION=$(grep '#define GOOGLE_PROTOBUF_VERSION [0-9]\+' $PROTOBUF_HDR/google/protobuf/stubs/common.h | awk '{print $3}')
@@ -432,7 +423,7 @@ append_to_output "STATIC_LINKINGS=$STATIC_LINKINGS"
 append_to_output "DYNAMIC_LINKINGS=$DYNAMIC_LINKINGS"
 
 # CPP means C PreProcessing, not C PlusPlus
-CPPFLAGS="${CPPFLAGS}  -DBRPC_WITH_GLOG=$WITH_GLOG -DGFLAGS_NS=$GFLAGS_NS -DBRPC_DEBUG_BTHREAD_SCHE_SAFETY=$BRPC_DEBUG_BTHREAD_SCHE_SAFETY -DBRPC_DEBUG_LOCK=$BRPC_DEBUG_LOCK"
+CPPFLAGS="${CPPFLAGS}  -DBRPC_WITH_GLOG=$WITH_GLOG -DBRPC_DEBUG_BTHREAD_SCHE_SAFETY=$BRPC_DEBUG_BTHREAD_SCHE_SAFETY -DBRPC_DEBUG_LOCK=$BRPC_DEBUG_LOCK"
 
 # Avoid over-optimizations of TLS variables by GCC>=4.8
 # See: https://github.com/apache/brpc/issues/1693

--- a/src/brpc/builtin/flags_service.cpp
+++ b/src/brpc/builtin/flags_service.cpp
@@ -63,7 +63,7 @@ static std::string HtmlReplace(const std::string& s) {
     }
 }
 
-static void PrintFlag(std::ostream& os, const GFLAGS_NS::CommandLineFlagInfo& flag,
+static void PrintFlag(std::ostream& os, const GFLAGS_NAMESPACE::CommandLineFlagInfo& flag,
                       bool use_html) {
     if (use_html) {
         os << "<tr><td>";
@@ -108,8 +108,8 @@ void FlagsService::set_value_page(Controller* cntl,
                                   ::google::protobuf::Closure* done) {
     ClosureGuard done_guard(done);
     const std::string& name = cntl->http_request().unresolved_path();
-    GFLAGS_NS::CommandLineFlagInfo info;
-    if (!GFLAGS_NS::GetCommandLineFlagInfo(name.c_str(), &info)) {
+    GFLAGS_NAMESPACE::CommandLineFlagInfo info;
+    if (!GFLAGS_NAMESPACE::GetCommandLineFlagInfo(name.c_str(), &info)) {
         cntl->SetFailed(ENOMETHOD, "No such gflag");
         return;
     }
@@ -155,8 +155,8 @@ void FlagsService::default_method(::google::protobuf::RpcController* cntl_base,
         if (use_html && cntl->http_request().uri().GetQuery("withform")) {
             return set_value_page(cntl, done_guard.release());
         }
-        GFLAGS_NS::CommandLineFlagInfo info;
-        if (!GFLAGS_NS::GetCommandLineFlagInfo(constraint.c_str(), &info)) {
+        GFLAGS_NAMESPACE::CommandLineFlagInfo info;
+        if (!GFLAGS_NAMESPACE::GetCommandLineFlagInfo(constraint.c_str(), &info)) {
             cntl->SetFailed(ENOMETHOD, "No such gflag");
             return;
         }
@@ -169,8 +169,8 @@ void FlagsService::default_method(::google::protobuf::RpcController* cntl_base,
                             constraint.c_str());
             return;
         }
-        if (GFLAGS_NS::SetCommandLineOption(constraint.c_str(),
-                                         value_str->c_str()).empty()) {
+        if (GFLAGS_NAMESPACE::SetCommandLineOption(constraint.c_str(),
+                                                   value_str->c_str()).empty()) {
             cntl->SetFailed(EPERM, "Fail to set `%s' to %s",
                             constraint.c_str(),
                             (value_str->empty() ? "empty string" : value_str->c_str()));
@@ -218,8 +218,8 @@ void FlagsService::default_method(::google::protobuf::RpcController* cntl_base,
         // Only exact names. We don't have to iterate all flags in this case.
         for (std::set<std::string>::iterator it = exact.begin();
              it != exact.end(); ++it) {
-            GFLAGS_NS::CommandLineFlagInfo info;
-            if (GFLAGS_NS::GetCommandLineFlagInfo(it->c_str(), &info)) {
+            GFLAGS_NAMESPACE::CommandLineFlagInfo info;
+            if (GFLAGS_NAMESPACE::GetCommandLineFlagInfo(it->c_str(), &info)) {
                 PrintFlag(os, info, use_html);
                 os << '\n';
             }
@@ -227,10 +227,10 @@ void FlagsService::default_method(::google::protobuf::RpcController* cntl_base,
 
     } else {
         // Iterate all flags and filter.
-        std::vector<GFLAGS_NS::CommandLineFlagInfo> flag_list;
+        std::vector<GFLAGS_NAMESPACE::CommandLineFlagInfo> flag_list;
         flag_list.reserve(128);
-        GFLAGS_NS::GetAllFlags(&flag_list);
-        for (std::vector<GFLAGS_NS::CommandLineFlagInfo>::iterator
+        GFLAGS_NAMESPACE::GetAllFlags(&flag_list);
+        for (std::vector<GFLAGS_NAMESPACE::CommandLineFlagInfo>::iterator
                  it = flag_list.begin(); it != flag_list.end(); ++it) {
             if (!constraint.empty() &&
                 exact.find(it->name) == exact.end() &&

--- a/src/brpc/builtin/rpcz_service.cpp
+++ b/src/brpc/builtin/rpcz_service.cpp
@@ -65,7 +65,7 @@ void RpczService::enable(::google::protobuf::RpcController* cntl_base,
     const bool use_html = UseHTML(cntl->http_request());
     cntl->http_response().set_content_type(
         use_html ? "text/html" : "text/plain");
-    if (!GFLAGS_NS::SetCommandLineOption("enable_rpcz", "true").empty()) {
+    if (!GFLAGS_NAMESPACE::SetCommandLineOption("enable_rpcz", "true").empty()) {
         if (use_html) {
             // Redirect to /rpcz
             cntl->response_attachment().append(
@@ -94,7 +94,7 @@ void RpczService::disable(::google::protobuf::RpcController* cntl_base,
     const bool use_html = UseHTML(cntl->http_request());
     cntl->http_response().set_content_type(
         use_html ? "text/html" : "text/plain");
-    if (!GFLAGS_NS::SetCommandLineOption("enable_rpcz", "false").empty()) {
+    if (!GFLAGS_NAMESPACE::SetCommandLineOption("enable_rpcz", "false").empty()) {
         if (use_html) {
             // Redirect to /rpcz
             cntl->response_attachment().append(

--- a/src/brpc/rpc_dump.cpp
+++ b/src/brpc/rpc_dump.cpp
@@ -139,7 +139,7 @@ void SampledRequest::destroy() {
 // Save gflags which could be reloaded at anytime.
 void RpcDumpContext::SaveFlags() {
     std::string dir;
-    CHECK(GFLAGS_NS::GetCommandLineOption("rpc_dump_dir", &dir));
+    CHECK(GFLAGS_NAMESPACE::GetCommandLineOption("rpc_dump_dir", &dir));
     
     const size_t pos = dir.find("<app>");
     if (pos != std::string::npos) {

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -28,6 +28,7 @@
 #include "butil/fast_rand.h"
 #include "butil/unique_ptr.h"
 #include "butil/third_party/murmurhash3/murmurhash3.h" // fmix64
+#include "butil/reloadable_flags.h"
 #include "bthread/errno.h"                  // ESTOP
 #include "bthread/butex.h"                  // butex_*
 #include "bthread/sys_futex.h"              // futex_wake_private
@@ -41,24 +42,17 @@ namespace bthread {
 static const bthread_attr_t BTHREAD_ATTR_TASKGROUP = {
     BTHREAD_STACKTYPE_UNKNOWN, 0, NULL, BTHREAD_TAG_INVALID };
 
-static bool pass_bool(const char*, bool) { return true; }
-
 DEFINE_bool(show_bthread_creation_in_vars, false, "When this flags is on, The time "
             "from bthread creation to first run will be recorded and shown in /vars");
-const bool ALLOW_UNUSED dummy_show_bthread_creation_in_vars =
-    ::GFLAGS_NS::RegisterFlagValidator(&FLAGS_show_bthread_creation_in_vars,
-                                    pass_bool);
+BUTIL_VALIDATE_GFLAG(show_bthread_creation_in_vars, butil::PassValidate);
 
 DEFINE_bool(show_per_worker_usage_in_vars, false,
             "Show per-worker usage in /vars/bthread_per_worker_usage_<tid>");
-const bool ALLOW_UNUSED dummy_show_per_worker_usage_in_vars =
-    ::GFLAGS_NS::RegisterFlagValidator(&FLAGS_show_per_worker_usage_in_vars,
-                                    pass_bool);
+BUTIL_VALIDATE_GFLAG(show_per_worker_usage_in_vars, butil::PassValidate);
 
 DEFINE_bool(bthread_enable_cpu_clock_stat, false,
             "Enable CPU clock statistics for bthread");
-const bool ALLOW_UNUSED dummy_bthread_enable_cpu_clock_stat =  ::GFLAGS_NS::RegisterFlagValidator(&FLAGS_bthread_enable_cpu_clock_stat,
-                                    pass_bool);
+BUTIL_VALIDATE_GFLAG(bthread_enable_cpu_clock_stat, butil::PassValidate);
 
 BAIDU_VOLATILE_THREAD_LOCAL(TaskGroup*, tls_task_group, NULL);
 // Sync with TaskMeta::local_storage when a bthread is created or destroyed.

--- a/src/butil/logging.cc
+++ b/src/butil/logging.cc
@@ -102,6 +102,7 @@ typedef pthread_mutex_t* MutexHandle;
 #include "butil/containers/doubly_buffered_data.h"
 #include "butil/memory/singleton.h"
 #include "butil/endpoint.h"
+#include "butil/reloadable_flags.h"
 #ifdef BAIDU_INTERNAL
 #include "butil/comlog_sink.h"
 #endif
@@ -122,8 +123,11 @@ namespace logging {
 
 DEFINE_bool(crash_on_fatal_log, false,
             "Crash process when a FATAL log is printed");
+BUTIL_VALIDATE_GFLAG(crash_on_fatal_log, butil::PassValidate);
+
 DEFINE_bool(print_stack_on_check, true,
             "Print the stack trace when a CHECK was failed");
+BUTIL_VALIDATE_GFLAG(print_stack_on_check, butil::PassValidate);
 
 DEFINE_int32(v, 0, "Show all VLOG(m) messages for m <= this."
              " Overridable by --vmodule.");
@@ -140,6 +144,7 @@ DEFINE_bool(log_bid, true, "Log bthread id");
 DEFINE_int32(minloglevel, 0, "Any log at or above this level will be "
              "displayed. Anything below this level will be silently ignored. "
              "0=INFO 1=NOTICE 2=WARNING 3=ERROR 4=FATAL");
+BUTIL_VALIDATE_GFLAG(minloglevel, butil::NonNegativeInteger);
 
 DEFINE_bool(log_hostname, false, "Add host after pid in each log so"
             " that we know where logs came from when using aggregation tools"
@@ -1930,7 +1935,7 @@ static bool validate_vmodule(const char*, const std::string& vmodule) {
     return on_reset_vmodule(vmodule.c_str()) == 0;
 }
 
-const bool ALLOW_UNUSED validate_vmodule_dummy = GFLAGS_NS::RegisterFlagValidator(
+const bool ALLOW_UNUSED validate_vmodule_dummy = GFLAGS_NAMESPACE::RegisterFlagValidator(
     &FLAGS_vmodule, &validate_vmodule);
 
 // [Thread-safe] Reset FLAGS_v.
@@ -1959,26 +1964,7 @@ static bool validate_v(const char*, int32_t v) {
     on_reset_verbose(v);
     return true;
 }
-
-const bool ALLOW_UNUSED validate_v_dummy = GFLAGS_NS::RegisterFlagValidator(
-    &FLAGS_v, &validate_v);
-
-static bool PassValidate(const char*, bool) {
-    return true;
-}
-
-const bool ALLOW_UNUSED validate_crash_on_fatal_log =
-    GFLAGS_NS::RegisterFlagValidator(&FLAGS_crash_on_fatal_log, PassValidate);
-
-const bool ALLOW_UNUSED validate_print_stack_on_check =
-    GFLAGS_NS::RegisterFlagValidator(&FLAGS_print_stack_on_check, PassValidate);
-
-static bool NonNegativeInteger(const char*, int32_t v) {
-    return v >= 0;
-}
-
-const bool ALLOW_UNUSED validate_min_log_level = GFLAGS_NS::RegisterFlagValidator(
-    &FLAGS_minloglevel, NonNegativeInteger);
+BUTIL_VALIDATE_GFLAG(v, validate_v);
 
 }  // namespace logging
 

--- a/src/butil/reloadable_flags.h
+++ b/src/butil/reloadable_flags.h
@@ -34,12 +34,11 @@
 //
 // This macro does not work for string-flags because they're thread-unsafe to
 // modify directly. To emphasize this, you have to write the validator by
-// yourself and use GFLAGS_NS::GetCommandLineOption() to acess the flag.
-#define BUTIL_VALIDATE_GFLAG(flag, validate_fn)                     \
-    namespace butil_flags {}                                       \
-    const int register_FLAGS_ ## flag ## _dummy                    \
-                 __attribute__((__unused__)) =                     \
-        ::butil::RegisterFlagValidatorOrDieImpl<                   \
+// yourself and use GFLAGS_NAMESPACE::GetCommandLineOption() to acess the flag.
+#define BUTIL_VALIDATE_GFLAG(flag, validate_fn)                   \
+    namespace butil_flags {}                                      \
+    const int ALLOW_UNUSED register_FLAGS_ ## flag ## _dummy =    \
+        ::butil::RegisterFlagValidatorOrDieImpl<                  \
             decltype(FLAGS_##flag)>(&FLAGS_##flag, (validate_fn))
 
 
@@ -56,11 +55,16 @@ bool PositiveInteger(const char*, T v) {
 }
 
 template <typename T>
+bool NonNegativeInteger(const char*, T v) {
+    return v >= 0;
+}
+
+template <typename T>
 bool RegisterFlagValidatorOrDieImpl(
     const T* flag, bool (*validate_fn)(const char*, T val)) {
     static_assert(!butil::is_same<std::string, T>::value,
                   "Not support string flags");
-    if (GFLAGS_NS::RegisterFlagValidator(flag, validate_fn)) {
+    if (::GFLAGS_NAMESPACE::RegisterFlagValidator(flag, validate_fn)) {
         return true;
     }
     // Error printed by gflags does not have newline. Add one to it.

--- a/src/bvar/gflag.cpp
+++ b/src/bvar/gflag.cpp
@@ -34,8 +34,8 @@ GFlag::GFlag(const butil::StringPiece& prefix,
 }
 
 void GFlag::describe(std::ostream& os, bool quote_string) const {
-    GFLAGS_NS::CommandLineFlagInfo info;
-    if (!GFLAGS_NS::GetCommandLineFlagInfo(gflag_name().c_str(), &info)) {
+    GFLAGS_NAMESPACE::CommandLineFlagInfo info;
+    if (!GFLAGS_NAMESPACE::GetCommandLineFlagInfo(gflag_name().c_str(), &info)) {
         if (quote_string) {
             os << '"';
         }
@@ -54,8 +54,8 @@ void GFlag::describe(std::ostream& os, bool quote_string) const {
 
 #ifdef BAIDU_INTERNAL
 void GFlag::get_value(boost::any* value) const {
-    GFLAGS_NS::CommandLineFlagInfo info;
-    if (!GFLAGS_NS::GetCommandLineFlagInfo(gflag_name().c_str(), &info)) {
+    GFLAGS_NAMESPACE::CommandLineFlagInfo info;
+    if (!GFLAGS_NAMESPACE::GetCommandLineFlagInfo(gflag_name().c_str(), &info)) {
         *value = "Unknown gflag=" + gflag_name();
     } else if (info.type == "string") {
         *value = info.current_value;
@@ -78,14 +78,14 @@ void GFlag::get_value(boost::any* value) const {
 
 std::string GFlag::get_value() const {
     std::string str;
-    if (!GFLAGS_NS::GetCommandLineOption(gflag_name().c_str(), &str)) {
+    if (!GFLAGS_NAMESPACE::GetCommandLineOption(gflag_name().c_str(), &str)) {
         return "Unknown gflag=" + gflag_name();
     }
     return str;
 }
 
 bool GFlag::set_value(const char* value) {
-    return !GFLAGS_NS::SetCommandLineOption(gflag_name().c_str(), value).empty();
+    return !GFLAGS_NAMESPACE::SetCommandLineOption(gflag_name().c_str(), value).empty();
 }
 
 }  // namespace bvar

--- a/src/bvar/latency_recorder.cpp
+++ b/src/bvar/latency_recorder.cpp
@@ -19,25 +19,25 @@
 
 #include <gflags/gflags.h>
 #include "butil/unique_ptr.h"
+#include "butil/reloadable_flags.h"
 #include "bvar/latency_recorder.h"
 
 namespace bvar {
 
-// Reloading following gflags does not change names of the corresponding bvars.
-// Avoid reloading in practice.
-DEFINE_int32(bvar_latency_p1, 80, "First latency percentile");
-DEFINE_int32(bvar_latency_p2, 90, "Second latency percentile");
-DEFINE_int32(bvar_latency_p3, 99, "Third latency percentile");
-
 static bool valid_percentile(const char*, int32_t v) {
     return v > 0 && v < 100;
 }
-const bool ALLOW_UNUSED dummy_bvar_latency_p1 = ::GFLAGS_NS::RegisterFlagValidator(
-    &FLAGS_bvar_latency_p1, valid_percentile);
-const bool ALLOW_UNUSED dummy_bvar_latency_p2 = ::GFLAGS_NS::RegisterFlagValidator(
-    &FLAGS_bvar_latency_p2, valid_percentile);
-const bool ALLOW_UNUSED dummy_bvar_latency_p3 = ::GFLAGS_NS::RegisterFlagValidator(
-    &FLAGS_bvar_latency_p3, valid_percentile);
+
+// Reloading following gflags does not change names of the corresponding bvars.
+// Avoid reloading in practice.
+DEFINE_int32(bvar_latency_p1, 80, "First latency percentile");
+BUTIL_VALIDATE_GFLAG(bvar_latency_p1, valid_percentile);
+
+DEFINE_int32(bvar_latency_p2, 90, "Second latency percentile");
+BUTIL_VALIDATE_GFLAG(bvar_latency_p2, valid_percentile);
+
+DEFINE_int32(bvar_latency_p3, 99, "Third latency percentile");
+BUTIL_VALIDATE_GFLAG(bvar_latency_p3, valid_percentile);
 
 namespace detail {
 

--- a/src/bvar/mvariable.cpp
+++ b/src/bvar/mvariable.cpp
@@ -24,6 +24,7 @@
 #include "butil/containers/flat_map.h"           // butil::FlatMap
 #include "butil/scoped_lock.h"                   // BAIDU_SCOPE_LOCK
 #include "butil/file_util.h"                     // butil::FilePath
+#include "butil/reloadable_flags.h"
 #include "bvar/variable.h"
 #include "bvar/mvariable.h"
 
@@ -35,10 +36,6 @@ DECLARE_bool(bvar_abort_on_same_name);
 
 extern bool s_bvar_may_abort;
 
-DEFINE_int32(bvar_max_multi_dimension_metric_number, 1024, "Max number of multi dimension");
-DEFINE_int32(bvar_max_dump_multi_dimension_metric_number, 1024,
-    "Max number of multi dimension metric number to dump by prometheus rpc service");
-
 static bool validator_bvar_max_multi_dimension_metric_number(const char*, int32_t v) {
     if (v < 1) {
         LOG(ERROR) << "Invalid bvar_max_multi_dimension_metric_number=" << v;
@@ -47,6 +44,10 @@ static bool validator_bvar_max_multi_dimension_metric_number(const char*, int32_
     return true;
 }
 
+DEFINE_int32(bvar_max_multi_dimension_metric_number, 1024, "Max number of multi dimension");
+BUTIL_VALIDATE_GFLAG(bvar_max_multi_dimension_metric_number,
+                     validator_bvar_max_multi_dimension_metric_number);
+
 static bool validator_bvar_max_dump_multi_dimension_metric_number(const char*, int32_t v) {
     if (v < 0) {
         LOG(ERROR) << "Invalid bvar_max_dump_multi_dimension_metric_number=" << v;
@@ -54,13 +55,10 @@ static bool validator_bvar_max_dump_multi_dimension_metric_number(const char*, i
     }
     return true;
 }
-
-
-const bool ALLOW_UNUSED dummp_bvar_max_multi_dimension_metric_number = ::GFLAGS_NS::RegisterFlagValidator(
-    &FLAGS_bvar_max_multi_dimension_metric_number, validator_bvar_max_multi_dimension_metric_number);
-
-const bool ALLOW_UNUSED dummp_bvar_max_dump_multi_dimension_metric_number = ::GFLAGS_NS::RegisterFlagValidator(
-  &FLAGS_bvar_max_dump_multi_dimension_metric_number, validator_bvar_max_dump_multi_dimension_metric_number);
+DEFINE_int32(bvar_max_dump_multi_dimension_metric_number, 1024,
+             "Max number of multi dimension metric number to dump by prometheus rpc service");
+BUTIL_VALIDATE_GFLAG(bvar_max_dump_multi_dimension_metric_number,
+                     validator_bvar_max_dump_multi_dimension_metric_number);
 
 class MVarEntry {
 public:

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -29,7 +29,6 @@ COPTS = [
     "-fPIC",
     "-Wno-unused-parameter",
     "-fno-omit-frame-pointer",
-    "-DGFLAGS_NS=google",
     "-fno-access-control",
     "-DBAZEL_TEST=1",
     "-DBVAR_NOT_LINK_DEFAULT_VARIABLES",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
     message(FATAL_ERROR "Googletest is not available")
 endif()
 
-set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DBRPC_WITH_RDMA=${WITH_RDMA_VAL} -DGFLAGS_NS=${GFLAGS_NS}")
+set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${DEFINE_CLOCK_GETTIME} -DBRPC_WITH_GLOG=${WITH_GLOG_VAL} -DBRPC_WITH_RDMA=${WITH_RDMA_VAL}")
 set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} -DBTHREAD_USE_FAST_PTHREAD_MUTEX -D__const__=__unused__ -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES -D__STRICT_ANSI__ -include ${PROJECT_SOURCE_DIR}/test/sstream_workaround.h")
 set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -g -O2 -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer")
 use_cxx11()

--- a/test/brpc_alpn_protocol_unittest.cpp
+++ b/test/brpc_alpn_protocol_unittest.cpp
@@ -32,7 +32,7 @@ DEFINE_string(listen_addr, "0.0.0.0:8011", "Server listen address.");
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);    
+    ::GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_block_pool_unittest.cpp
+++ b/test/brpc_block_pool_unittest.cpp
@@ -214,6 +214,6 @@ TEST_F(BlockPoolTest, dump_info) {
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
     brpc::FLAGS_idle_timeout_second = 0;
     brpc::FLAGS_max_connection_pool_size = 0;
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_circuit_breaker_unittest.cpp
+++ b/test/brpc_circuit_breaker_unittest.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]) {
     brpc::FLAGS_circuit_breaker_max_isolation_duration_ms = kMaxIsolationDurationMs;
     brpc::FLAGS_circuit_breaker_half_open_window_size = kHalfWindowSize;
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_coroutine_unittest.cpp
+++ b/test/brpc_coroutine_unittest.cpp
@@ -24,7 +24,7 @@
 int main(int argc, char* argv[]) {
 #ifdef BRPC_ENABLE_COROUTINE
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 #else
     printf("bRPC coroutine is not enabled, please add -std=c++20 to compile options\n");

--- a/test/brpc_esp_protocol_unittest.cpp
+++ b/test/brpc_esp_protocol_unittest.cpp
@@ -37,7 +37,7 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_grpc_protocol_unittest.cpp
+++ b/test/brpc_grpc_protocol_unittest.cpp
@@ -27,12 +27,12 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
-    if (GFLAGS_NS::SetCommandLineOption("http_body_compress_threshold", "0").empty()) {
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
+    if (GFLAGS_NAMESPACE::SetCommandLineOption("http_body_compress_threshold", "0").empty()) {
         std::cerr << "Fail to set -crash_on_fatal_log" << std::endl;
         return -1;
     }
-    if (GFLAGS_NS::SetCommandLineOption("crash_on_fatal_log", "true").empty()) {
+    if (GFLAGS_NAMESPACE::SetCommandLineOption("crash_on_fatal_log", "true").empty()) {
         std::cerr << "Fail to set -crash_on_fatal_log" << std::endl;
         return -1;
     }

--- a/test/brpc_http_message_unittest.cpp
+++ b/test/brpc_http_message_unittest.cpp
@@ -32,7 +32,7 @@ DECLARE_bool(allow_http_1_1_request_without_host);
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     brpc::FLAGS_allow_http_1_1_request_without_host = true;
     return RUN_ALL_TESTS();
 }
@@ -77,7 +77,7 @@ TEST(HttpMessageTest, http_method) {
 }
 
 TEST(HttpMessageTest, eof) {
-    GFLAGS_NS::SetCommandLineOption("verbose", "100");
+    GFLAGS_NAMESPACE::SetCommandLineOption("verbose", "100");
     const char* http_request = 
         "GET /CloudApiControl/HttpServer/telematics/v3/weather?location=%E6%B5%B7%E5%8D%97%E7%9C%81%E7%9B%B4%E8%BE%96%E5%8E%BF%E7%BA%A7%E8%A1%8C%E6%94%BF%E5%8D%95%E4%BD%8D&output=json&ak=0l3FSP6qA0WbOzGRaafbmczS HTTP/1.1\r\n"
         "X-Host: api.map.baidu.com\r\n"

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -65,12 +65,12 @@ extern bvar::CollectorSpeedLimit g_rpc_dump_sl;
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
-    if (GFLAGS_NS::SetCommandLineOption("socket_max_unwritten_bytes", "2000000").empty()) {
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
+    if (GFLAGS_NAMESPACE::SetCommandLineOption("socket_max_unwritten_bytes", "2000000").empty()) {
         std::cerr << "Fail to set -socket_max_unwritten_bytes" << std::endl;
         return -1;
     }
-    if (GFLAGS_NS::SetCommandLineOption("crash_on_fatal_log", "true").empty()) {
+    if (GFLAGS_NAMESPACE::SetCommandLineOption("crash_on_fatal_log", "true").empty()) {
         std::cerr << "Fail to set -crash_on_fatal_log" << std::endl;
         return -1;
     }

--- a/test/brpc_hulu_pbrpc_protocol_unittest.cpp
+++ b/test/brpc_hulu_pbrpc_protocol_unittest.cpp
@@ -39,7 +39,7 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_interceptor_unittest.cpp
+++ b/test/brpc_interceptor_unittest.cpp
@@ -32,7 +32,7 @@ DECLARE_bool(use_http_error_code);
 
 int main(int argc, char* argv[]) {
     ::testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_load_balancer_unittest.cpp
+++ b/test/brpc_load_balancer_unittest.cpp
@@ -1191,11 +1191,11 @@ TEST_F(LoadBalancerTest, invalid_lb_params) {
 }
 
 TEST_F(LoadBalancerTest, revived_from_all_failed_intergrated) {
-    GFLAGS_NS::SetCommandLineOption("circuit_breaker_short_window_size", "20");
-    GFLAGS_NS::SetCommandLineOption("circuit_breaker_short_window_error_percent", "30");
+    GFLAGS_NAMESPACE::SetCommandLineOption("circuit_breaker_short_window_size", "20");
+    GFLAGS_NAMESPACE::SetCommandLineOption("circuit_breaker_short_window_error_percent", "30");
     // Those two lines force the interval of first hc to 3s
-    GFLAGS_NS::SetCommandLineOption("circuit_breaker_max_isolation_duration_ms", "3000");
-    GFLAGS_NS::SetCommandLineOption("circuit_breaker_min_isolation_duration_ms", "3000");
+    GFLAGS_NAMESPACE::SetCommandLineOption("circuit_breaker_max_isolation_duration_ms", "3000");
+    GFLAGS_NAMESPACE::SetCommandLineOption("circuit_breaker_min_isolation_duration_ms", "3000");
 
     const char* lb_algo[] = { "random:min_working_instances=2 hold_seconds=2",
                               "rr:min_working_instances=2 hold_seconds=2" };

--- a/test/brpc_mongo_protocol_unittest.cpp
+++ b/test/brpc_mongo_protocol_unittest.cpp
@@ -39,7 +39,7 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_public_pbrpc_protocol_unittest.cpp
+++ b/test/brpc_public_pbrpc_protocol_unittest.cpp
@@ -38,7 +38,7 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_rdma_unittest.cpp
+++ b/test/brpc_rdma_unittest.cpp
@@ -1955,7 +1955,7 @@ TEST_F(RdmaTest, try_memory_pool_empty) {
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 #if BRPC_WITH_RDMA
     rdma::FLAGS_rdma_trace_verbose = true;
     rdma::FLAGS_rdma_memory_pool_max_regions = 2;

--- a/test/brpc_rtmp_unittest.cpp
+++ b/test/brpc_rtmp_unittest.cpp
@@ -37,7 +37,7 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_server_unittest.cpp
+++ b/test/brpc_server_unittest.cpp
@@ -60,7 +60,7 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_socket_unittest.cpp
+++ b/test/brpc_socket_unittest.cpp
@@ -66,7 +66,7 @@ void EchoProcessHuluRequest(brpc::InputMessageBase* msg_base);
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     brpc::Protocol dummy_protocol = 
                              { brpc::policy::ParseHuluMessage,
                                brpc::SerializeRequestDefault, 
@@ -591,8 +591,8 @@ public:
 
 TEST_F(SocketTest, app_level_health_check) {
     int old_health_check_interval = brpc::FLAGS_health_check_interval;
-    GFLAGS_NS::SetCommandLineOption("health_check_path", "/HealthCheckTestService");
-    GFLAGS_NS::SetCommandLineOption("health_check_interval", "1");
+    GFLAGS_NAMESPACE::SetCommandLineOption("health_check_path", "/HealthCheckTestService");
+    GFLAGS_NAMESPACE::SetCommandLineOption("health_check_interval", "1");
 
     butil::EndPoint point(butil::IP_ANY, 7777);
     brpc::ChannelOptions options;
@@ -644,10 +644,10 @@ TEST_F(SocketTest, app_level_health_check) {
         ASSERT_GT(cntl.response_attachment().size(), (size_t)0);
     }
 
-    GFLAGS_NS::SetCommandLineOption("health_check_path", "");
+    GFLAGS_NAMESPACE::SetCommandLineOption("health_check_path", "");
     char hc_buf[8];
     snprintf(hc_buf, sizeof(hc_buf), "%d", old_health_check_interval);
-    GFLAGS_NS::SetCommandLineOption("health_check_interval", hc_buf);
+    GFLAGS_NAMESPACE::SetCommandLineOption("health_check_interval", hc_buf);
 }
 
 TEST_F(SocketTest, health_check) {

--- a/test/brpc_sofa_pbrpc_protocol_unittest.cpp
+++ b/test/brpc_sofa_pbrpc_protocol_unittest.cpp
@@ -38,7 +38,7 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/brpc_ssl_unittest.cpp
+++ b/test/brpc_ssl_unittest.cpp
@@ -45,7 +45,7 @@ void ExtractHostnames(X509* x, std::vector<std::string>* hostnames);
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     brpc::GlobalInitializeOrDie();
     return RUN_ALL_TESTS();
 }

--- a/test/bthread_butex_multi_tag_unittest.cpp
+++ b/test/bthread_butex_multi_tag_unittest.cpp
@@ -27,7 +27,7 @@ DECLARE_int32(task_group_ntags);
 int main(int argc, char* argv[]) {
     FLAGS_task_group_ntags = 3;
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/bthread_key_unittest.cpp
+++ b/test/bthread_key_unittest.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
     bthread::FLAGS_key_table_list_size = 20;
     bthread::FLAGS_borrow_from_globle_size = 20;
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
 

--- a/test/bthread_setconcurrency_unittest.cpp
+++ b/test/bthread_setconcurrency_unittest.cpp
@@ -140,13 +140,13 @@ void* add_concurrency_proc(void*) {
 bool set_min_concurrency(int num) {
     std::stringstream ss;
     ss << num;
-    std::string ret = GFLAGS_NS::SetCommandLineOption("bthread_min_concurrency", ss.str().c_str());
+    std::string ret = GFLAGS_NAMESPACE::SetCommandLineOption("bthread_min_concurrency", ss.str().c_str());
     return !ret.empty();
 }
 
 int get_min_concurrency() {
     std::string ret;
-    GFLAGS_NS::GetCommandLineOption("bthread_min_concurrency", &ret);
+    GFLAGS_NAMESPACE::GetCommandLineOption("bthread_min_concurrency", &ret);
     return atoi(ret.c_str());
 }
 
@@ -194,7 +194,7 @@ TEST(BthreadTest, min_concurrency) {
 int current_tag(int tag) {
     std::stringstream ss;
     ss << tag;
-    std::string ret = GFLAGS_NS::SetCommandLineOption("bthread_current_tag", ss.str().c_str());
+    std::string ret = GFLAGS_NAMESPACE::SetCommandLineOption("bthread_current_tag", ss.str().c_str());
     return !(ret.empty());
 }
 
@@ -208,7 +208,7 @@ int concurrency_by_tag(int num) {
     std::stringstream ss;
     ss << num;
     std::string ret =
-        GFLAGS_NS::SetCommandLineOption("bthread_concurrency_by_tag", ss.str().c_str());
+        GFLAGS_NAMESPACE::SetCommandLineOption("bthread_concurrency_by_tag", ss.str().c_str());
     return !(ret.empty());
 }
 

--- a/test/bthread_unittest.cpp
+++ b/test/bthread_unittest.cpp
@@ -27,7 +27,7 @@
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     int rc = RUN_ALL_TESTS();
     return rc;
 }

--- a/test/butil_unittest_main.cpp
+++ b/test/butil_unittest_main.cpp
@@ -27,8 +27,8 @@ DEFINE_bool(disable_coredump, false, "Never core dump");
 int main(int argc, char** argv) {
     butil::AtExitManager at_exit;
     testing::InitGoogleTest(&argc, argv);
-    
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     if (FLAGS_disable_coredump) {
         rlimit core_limit;
         core_limit.rlim_cur = 0;
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
         setrlimit(RLIMIT_CORE, &core_limit);
     }
 #if !BRPC_WITH_GLOG
-    CHECK(!GFLAGS_NS::SetCommandLineOption("crash_on_fatal_log", "true").empty());
+    CHECK(!GFLAGS_NAMESPACE::SetCommandLineOption("crash_on_fatal_log", "true").empty());
 #endif
     return RUN_ALL_TESTS();
 }

--- a/test/bvar_file_dumper_unittest.cpp
+++ b/test/bvar_file_dumper_unittest.cpp
@@ -34,7 +34,7 @@ TEST_F(FileDumperTest, filters) {
     bvar::Adder<int> a3("a_error");
     bvar::Adder<int> a4("process_*");
     bvar::Adder<int> a5("default");
-    GFLAGS_NS::SetCommandLineOption("bvar_dump_interval", "1");
-    GFLAGS_NS::SetCommandLineOption("bvar_dump", "true");
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_dump_interval", "1");
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_dump", "true");
     sleep(2);
 }

--- a/test/bvar_multi_dimension_unittest.cpp
+++ b/test/bvar_multi_dimension_unittest.cpp
@@ -401,17 +401,17 @@ TEST_F(MultiDimensionTest, mlatencyrecorder) {
     std::string old_bvar_latency_p2;
     std::string old_bvar_latency_p3;
 
-    GFLAGS_NS::GetCommandLineOption("bvar_dump_interval", &old_bvar_dump_interval);
-    GFLAGS_NS::GetCommandLineOption("mbvar_dump", &old_mbvar_dump);
-    GFLAGS_NS::GetCommandLineOption("bvar_latency_p1", &old_bvar_latency_p1);
-    GFLAGS_NS::GetCommandLineOption("bvar_latency_p2", &old_bvar_latency_p2);
-    GFLAGS_NS::GetCommandLineOption("bvar_latency_p3", &old_bvar_latency_p3);
+    GFLAGS_NAMESPACE::GetCommandLineOption("bvar_dump_interval", &old_bvar_dump_interval);
+    GFLAGS_NAMESPACE::GetCommandLineOption("mbvar_dump", &old_mbvar_dump);
+    GFLAGS_NAMESPACE::GetCommandLineOption("bvar_latency_p1", &old_bvar_latency_p1);
+    GFLAGS_NAMESPACE::GetCommandLineOption("bvar_latency_p2", &old_bvar_latency_p2);
+    GFLAGS_NAMESPACE::GetCommandLineOption("bvar_latency_p3", &old_bvar_latency_p3);
 
-    GFLAGS_NS::SetCommandLineOption("bvar_dump_interval", "1");
-    GFLAGS_NS::SetCommandLineOption("mbvar_dump", "true");
-    GFLAGS_NS::SetCommandLineOption("bvar_latency_p1", "60");
-    GFLAGS_NS::SetCommandLineOption("bvar_latency_p2", "70");
-    GFLAGS_NS::SetCommandLineOption("bvar_latency_p3", "80");
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_dump_interval", "1");
+    GFLAGS_NAMESPACE::SetCommandLineOption("mbvar_dump", "true");
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_latency_p1", "60");
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_latency_p2", "70");
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_latency_p3", "80");
 
     bvar::MultiDimension<bvar::LatencyRecorder> my_mlatencyrecorder("client_request_count_mlatencyrecorder", labels);
     std::list<std::string> labels_value = {"tc", "get", "200"};
@@ -424,11 +424,11 @@ TEST_F(MultiDimensionTest, mlatencyrecorder) {
     ASSERT_LE(7, my_latencyrecorder->qps());
     ASSERT_EQ(7, my_latencyrecorder->count());
 
-    GFLAGS_NS::SetCommandLineOption("bvar_dump_interval", old_bvar_dump_interval.c_str());
-    GFLAGS_NS::SetCommandLineOption("mbvar_dump", old_mbvar_dump.c_str());
-    GFLAGS_NS::SetCommandLineOption("bvar_latency_p1", old_bvar_latency_p1.c_str());
-    GFLAGS_NS::SetCommandLineOption("bvar_latency_p2", old_bvar_latency_p2.c_str());
-    GFLAGS_NS::SetCommandLineOption("bvar_latency_p3", old_bvar_latency_p3.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_dump_interval", old_bvar_dump_interval.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("mbvar_dump", old_mbvar_dump.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_latency_p1", old_bvar_latency_p1.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_latency_p2", old_bvar_latency_p2.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_latency_p3", old_bvar_latency_p3.c_str());
 }
 
 TEST_F(MultiDimensionTest, mstatus) {

--- a/test/bvar_mvariable_unittest.cpp
+++ b/test/bvar_mvariable_unittest.cpp
@@ -158,15 +158,15 @@ TEST_F(MVariableTest, dump) {
     std::string old_mbvar_dump_prefix;
     std::string old_mbvar_dump_format;
 
-    GFLAGS_NS::GetCommandLineOption("bvar_dump_interval", &old_bvar_dump_interval);
-    GFLAGS_NS::GetCommandLineOption("mbvar_dump", &old_mbvar_dump);
-    GFLAGS_NS::GetCommandLineOption("mbvar_dump_prefix", &old_mbvar_dump_prefix);
-    GFLAGS_NS::GetCommandLineOption("mbvar_dump_format", &old_mbvar_dump_format);
+    GFLAGS_NAMESPACE::GetCommandLineOption("bvar_dump_interval", &old_bvar_dump_interval);
+    GFLAGS_NAMESPACE::GetCommandLineOption("mbvar_dump", &old_mbvar_dump);
+    GFLAGS_NAMESPACE::GetCommandLineOption("mbvar_dump_prefix", &old_mbvar_dump_prefix);
+    GFLAGS_NAMESPACE::GetCommandLineOption("mbvar_dump_format", &old_mbvar_dump_format);
 
-    GFLAGS_NS::SetCommandLineOption("bvar_dump_interval", "1");
-    GFLAGS_NS::SetCommandLineOption("mbvar_dump", "true");
-    GFLAGS_NS::SetCommandLineOption("mbvar_dump_prefix", "my_mdump_prefix");
-    GFLAGS_NS::SetCommandLineOption("mbvar_dump_format", "common");
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_dump_interval", "1");
+    GFLAGS_NAMESPACE::SetCommandLineOption("mbvar_dump", "true");
+    GFLAGS_NAMESPACE::SetCommandLineOption("mbvar_dump_prefix", "my_mdump_prefix");
+    GFLAGS_NAMESPACE::SetCommandLineOption("mbvar_dump_format", "common");
 
     bvar::MultiDimension<bvar::Adder<int> > my_madder("dump_adder", labels);
     std::list<std::string> labels_value1 {"gz", "post", "200"};
@@ -218,10 +218,10 @@ TEST_F(MVariableTest, dump) {
     *my_latencyrecorder1 << 3 << 6 << 9;
     sleep(2);
     
-    GFLAGS_NS::SetCommandLineOption("bvar_dump_interval", old_bvar_dump_interval.c_str());
-    GFLAGS_NS::SetCommandLineOption("mbvar_dump", old_mbvar_dump.c_str());
-    GFLAGS_NS::SetCommandLineOption("mbvar_dump_prefix", old_mbvar_dump_prefix.c_str());
-    GFLAGS_NS::SetCommandLineOption("mbvar_dump_format", old_mbvar_dump_format.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("bvar_dump_interval", old_bvar_dump_interval.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("mbvar_dump", old_mbvar_dump.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("mbvar_dump_prefix", old_mbvar_dump_prefix.c_str());
+    GFLAGS_NAMESPACE::SetCommandLineOption("mbvar_dump_format", old_mbvar_dump_format.c_str());
 }
 
 TEST_F(MVariableTest, test_describe_exposed) {

--- a/test/bvar_variable_unittest.cpp
+++ b/test/bvar_variable_unittest.cpp
@@ -396,6 +396,6 @@ TEST_F(VariableTest, recursive_mutex) {
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }

--- a/test/logging_unittest.cc
+++ b/test/logging_unittest.cc
@@ -59,8 +59,8 @@ public:
         ::logging::FLAGS_crash_on_fatal_log = _old_crash_on_fatal_log;
         if (::logging::FLAGS_v != 0) {
             // Clear -verbose to avoid affecting other tests.
-            ASSERT_FALSE(GFLAGS_NS::SetCommandLineOption("v", "0").empty());
-            ASSERT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule", "").empty());
+            ASSERT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("v", "0").empty());
+            ASSERT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule", "").empty());
         }
     }
 private:
@@ -218,11 +218,11 @@ TEST_F(LoggingTest, log_at) {
 TEST_F(LoggingTest, vlog_sanity) {
     ::logging::FLAGS_crash_on_fatal_log = false;
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("v", "1").empty());
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("v", "1").empty());
     
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule",
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule",
                                                "logging_unittest=1").empty());
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule",
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule",
                                                "logging_UNITTEST=2").empty());
 
     for (int i = 0; i < 10; ++i) {
@@ -238,7 +238,7 @@ TEST_F(LoggingTest, vlog_sanity) {
     VLOG_NE(0) << "always on";
     EXPECT_EQ("always on", LOG_STREAM(INFO).content_str());
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule",
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule",
                                               "logging_unittest=0").empty());
     for (int i = 0; i < 10; ++i) {
         VLOG_NE(i) << "vlog " << i;
@@ -246,7 +246,7 @@ TEST_F(LoggingTest, vlog_sanity) {
     EXPECT_EQ("", LOG_STREAM(VERBOSE).content_str());
     EXPECT_EQ("vlog 0", LOG_STREAM(INFO).content_str());
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule",
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule",
                      "logging_unittest=0,logging_unittest=1").empty());
     for (int i = 0; i < 10; ++i) {
         VLOG_NE(i) << "vlog " << i;
@@ -254,7 +254,7 @@ TEST_F(LoggingTest, vlog_sanity) {
     EXPECT_EQ("vlog 1", LOG_STREAM(VERBOSE).content_str());
     EXPECT_EQ("vlog 0", LOG_STREAM(INFO).content_str());
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule",
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule",
                      "logging_unittest=1,logging_unittest=0").empty());
     for (int i = 0; i < 10; ++i) {
         VLOG_NE(i) << "vlog " << i;
@@ -262,14 +262,14 @@ TEST_F(LoggingTest, vlog_sanity) {
     EXPECT_EQ("", LOG_STREAM(VERBOSE).content_str());
     EXPECT_EQ("vlog 0", LOG_STREAM(INFO).content_str());
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule", "").empty());
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule", "").empty());
     for (int i = 0; i < 10; ++i) {
         VLOG_NE(i) << "vlog " << i;
     }
     EXPECT_EQ("vlog 1", LOG_STREAM(VERBOSE).content_str());
     EXPECT_EQ("vlog 0", LOG_STREAM(INFO).content_str());
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule",
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule",
                                                "logg?ng_*=2").empty());
     for (int i = 0; i < 10; ++i) {
         VLOG_NE(i) << "vlog " << i;
@@ -277,7 +277,7 @@ TEST_F(LoggingTest, vlog_sanity) {
     EXPECT_EQ("vlog 1vlog 2", LOG_STREAM(VERBOSE).content_str());
     EXPECT_EQ("vlog 0", LOG_STREAM(INFO).content_str());
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule",
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule",
         "foo=3,logging_unittest=3, logg?ng_*=2 , logging_*=1 ").empty());
     for (int i = 0; i < 10; ++i) {
         VLOG_NE(i) << "vlog " << i;
@@ -290,7 +290,7 @@ TEST_F(LoggingTest, vlog_sanity) {
     }
     EXPECT_EQ("vlog 1vlog 3", LOG_STREAM(VERBOSE).content_str());
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption(
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption(
                      "vmodule",
                      "foo/bar0/0=2,foo/bar/1=3, 2=4, foo/*/3=5, */ba?/4=6,"
                      "/5=7,/foo/bar/6=8,foo2/bar/7=9,foo/bar/8=9").empty());
@@ -373,8 +373,8 @@ TEST_F(LoggingTest, debug_level) {
     DLOG(NOTICE) << foo(&run_foo);
     DLOG(DEBUG) << foo(&run_foo);
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("vmodule", "").empty());
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("v", "1").empty());
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("vmodule", "").empty());
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("v", "1").empty());
     DVLOG(1) << foo(&run_foo);
     DVLOG2("a/b/c", 1) << foo(&run_foo);
 
@@ -470,7 +470,7 @@ void CheckFunctionName() {
     ASSERT_NE(std::string::npos, log_str.find("specified_file.cc:12345 log_at"));
     ::logging::SetLogSink(old_sink);
 
-    EXPECT_FALSE(GFLAGS_NS::SetCommandLineOption("v", "1").empty());
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption("v", "1").empty());
     VLOG(100) << "test" << noflush;
     ASSERT_EQ(func_name, VLOG_STREAM(100).func());
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #2874

Problem Summary:

GFLAGS_NS的作用是兼容gflags不同版本的不同namespace，应该是gflags 2.0前后发生了变化。目前GFLAGS_NS是在编译bRPC库的时候动态生成的。如果GFLAGS_NS出现在用户使用的头文件中，就要求用户也要定义GFLAGS_NS，否则就会编译失败。

### What is changed and the side effects?

Changed:

1. 目前bRPC库要求gflags版本大于2.1，没有namespace兼容性问题，使用gflags库的GFLAGS_NAMESPACE替代GFLAGS_NS即可。
2. bthread、butil目录中的注册检验器的逻辑（除了string的检验器）使用BUTIL_VALIDATE_GFLAG代替。
3. GFLAGS_NS涉及的范围比较广，一次性改完的话，改动比较大。所以先改src和test目录，等这个PR合了之后，再改tool和example目录。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
