### PR TITLE
fix: define fallback `GFLAGS_NS=google` in config headers and remove the need of passing the `-DGFLAGS_NS=google` flags

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,7 +29,6 @@ COPTS = [
     "-D__STDC_FORMAT_MACROS",
     "-D__STDC_LIMIT_MACROS",
     "-D__STDC_CONSTANT_MACROS",
-    "-DGFLAGS_NS=google",
 ] + select({
     "//bazel/config:brpc_with_glog": ["-DBRPC_WITH_GLOG=1"],
     "//conditions:default": ["-DBRPC_WITH_GLOG=0"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -104,6 +104,11 @@ genrule(
               "//conditions:default": "0",
           }) +
           """
+
+#ifndef GFLAGS_NS
+#define GFLAGS_NS google
+#endif
+
 #endif  // BUTIL_CONFIG_H
 EOF
     """,

--- a/config.h.in
+++ b/config.h.in
@@ -21,4 +21,8 @@
 #endif
 #cmakedefine BRPC_WITH_GLOG @WITH_GLOG_VAL@
 
+#ifndef GFLAGS_NS
+#define GFLAGS_NS google
+#endif
+
 #endif  // BUTIL_CONFIG_H

--- a/config_brpc.sh
+++ b/config_brpc.sh
@@ -493,7 +493,7 @@ fi
 append_to_output "CPPFLAGS=${CPPFLAGS}"
 append_to_output "# without the flag, linux+arm64 may crash due to folding on TLS.
 ifeq (\$(CC),gcc)
-  ifeq (\$(shell uname -p),aarch64) 
+  ifeq (\$(shell uname -p),aarch64)
     CPPFLAGS+=-fno-gcse
   endif
 endif
@@ -584,6 +584,10 @@ cat << EOF > src/butil/config.h
 #undef BRPC_WITH_GLOG
 #endif
 #define BRPC_WITH_GLOG $WITH_GLOG
+
+#ifndef GFLAGS_NS
+#define GFLAGS_NS google
+#endif
 
 #endif  // BUTIL_CONFIG_H
 EOF

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -28,7 +28,6 @@ COPTS = [
     "-fPIC",
     "-Wno-unused-parameter",
     "-fno-omit-frame-pointer",
-    "-DGFLAGS_NS=google",
 ] + select({
     "//bazel/config:brpc_with_glog": ["-DBRPC_WITH_GLOG=1"],
     "//conditions:default": ["-DBRPC_WITH_GLOG=0"],

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -29,7 +29,6 @@ COPTS = [
     "-fPIC",
     "-Wno-unused-parameter",
     "-fno-omit-frame-pointer",
-    "-DGFLAGS_NS=google",
     "-fno-access-control",
     "-DBAZEL_TEST=1",
     "-DBVAR_NOT_LINK_DEFAULT_VARIABLES",


### PR DESCRIPTION
### What problem does this PR solve?

seeing some regression build failure in https://github.com/Homebrew/homebrew-core/pull/204308

```
/opt/homebrew/Cellar/brpc/1.12.0/include/butil/reloadable_flags.h:63:9: error: use of undeclared identifier 'GFLAGS_NS'
   63 |     if (GFLAGS_NS::RegisterFlagValidator(flag, validate_fn)) {
      |         ^
```

It would be just better to define `GFLAGS_NS=google` in config headers

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
