### PR TITLE
Chore: minimize dependence to avoid depends on protoc_lib

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -445,7 +445,7 @@ cc_library(
     deps = [
         ":brpc_idl_options_cc_proto",
         ":butil",
-        "@com_google_protobuf//:protoc_lib",
+        "@com_google_protobuf//src/google/protobuf/compiler:code_generator",
     ],
 )
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number:

Problem Summary:

在最新的 protobuf 版本里，protoc_lib 包含 main 函数，而 `//:brpc`  --> `//:mcpack2pb` --> `@com_google_protobuf//:protoc_lib`，导致所有依赖 brpc 的 gtest 且没有显式写 main 函数的测试，实际上运行的是 protoc 的程序。比如issue https://github.com/protocolbuffers/protobuf/issues/12887

这个 PR 尝试解决这个问题，将 `//:mcpack2pb` 的依赖最小化。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):
NO
- Breaking backward compatibility(向后兼容性):  NO compatibility issue.

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
