### PR TITLE
add gflag max_multi_dimension_stats_count

### DIFF
--- a/src/bvar/multi_dimension.h
+++ b/src/bvar/multi_dimension.h
@@ -29,8 +29,6 @@
 
 namespace bvar {
 
-constexpr uint64_t MAX_MULTI_DIMENSION_STATS_COUNT = 20000;
-
 template <typename  T>
 class MultiDimension : public MVariable {
 public:

--- a/src/bvar/multi_dimension_inl.h
+++ b/src/bvar/multi_dimension_inl.h
@@ -27,6 +27,7 @@ namespace bvar {
 DECLARE_int32(bvar_latency_p1);
 DECLARE_int32(bvar_latency_p2);
 DECLARE_int32(bvar_latency_p3);
+DECLARE_uint32(max_multi_dimension_stats_count);
 
 static const std::string ALLOW_UNUSED METRIC_TYPE_COUNTER = "counter";
 static const std::string ALLOW_UNUSED METRIC_TYPE_SUMMARY = "summary";
@@ -37,7 +38,7 @@ template <typename T>
 inline
 MultiDimension<T>::MultiDimension(const key_type& labels)
     : Base(labels)
-    , _max_stats_count(MAX_MULTI_DIMENSION_STATS_COUNT)
+    , _max_stats_count(FLAGS_max_multi_dimension_stats_count)
 {
     _metric_map.Modify(init_flatmap);
 }

--- a/src/bvar/mvariable.cpp
+++ b/src/bvar/mvariable.cpp
@@ -60,6 +60,17 @@ DEFINE_int32(bvar_max_dump_multi_dimension_metric_number, 1024,
 BUTIL_VALIDATE_GFLAG(bvar_max_dump_multi_dimension_metric_number,
                      validator_bvar_max_dump_multi_dimension_metric_number);
 
+static bool validator_max_multi_dimension_stats_count(const char*, uint32_t v) {
+    if (v < 1) {
+        LOG(ERROR) << "Invalid max_multi_dimension_stats_count=" << v;
+        return false;
+    }
+    return true;
+}
+DEFINE_uint32(max_multi_dimension_stats_count, 20000, "Max stats count of a multi dimension metric.");
+BUTIL_VALIDATE_GFLAG(max_multi_dimension_stats_count,
+                     validator_max_multi_dimension_stats_count);
+
 class MVarEntry {
 public:
     MVarEntry() : var(NULL) {}


### PR DESCRIPTION
### What problem does this PR solve?

Add a new gflag to set max stats count of a multi dimension.

Problem Summary:

### What is changed and the side effects?

Changed: add new gflag max_multi_dimension_stats_count

Side effects:
- Performance effects(性能影响):
no
- Breaking backward compatibility(向后兼容性): 
no
