### PR TITLE
Support a more safe read function and variadic functions of DoublyBufferedData

### DIFF
--- a/src/butil/containers/doubly_buffered_data.h
+++ b/src/butil/containers/doubly_buffered_data.h
@@ -127,7 +127,7 @@ public:
     // This function is not blocked by Read() and Modify() in other threads.
     // Returns 0 on success, otherwise on error.
     template<typename Fn>
-    int Read(Fn& fn);
+    int Read(Fn&& fn);
 
     // Modify background and foreground instances. fn(T&, ...) will be called
     // twice. Modify() from different threads are exclusive from each other.
@@ -578,12 +578,15 @@ int DoublyBufferedData<T, TLS, AllowBthreadSuspended>::Read(
 
 template <typename T, typename TLS, bool AllowBthreadSuspended>
 template <typename Fn>
-int DoublyBufferedData<T, TLS, AllowBthreadSuspended>::Read(Fn& fn) {
+int DoublyBufferedData<T, TLS, AllowBthreadSuspended>::Read(Fn&& fn) {
+    BAIDU_CASSERT((is_result_void<Fn, const T&>::value),
+                  "Fn must accept `const T&' and return void");
     ScopedPtr ptr;
     if (Read(&ptr) != 0) {
         return -1;
     }
-    return fn(*ptr);
+    fn(*ptr);
+    return 0;
 }
 
 template <typename T, typename TLS, bool AllowBthreadSuspended>

--- a/src/butil/containers/doubly_buffered_data.h
+++ b/src/butil/containers/doubly_buffered_data.h
@@ -572,7 +572,7 @@ size_t DoublyBufferedData<T, TLS, AllowBthreadSuspended>::Modify(Fn&& fn, Args&&
 template <typename T, typename TLS, bool AllowBthreadSuspended>
 template <typename Fn, typename... Args>
 size_t DoublyBufferedData<T, TLS, AllowBthreadSuspended>::ModifyWithForeground(Fn&& fn, Args&&... args) {
-    return Modify([this, fn](T& bg, Args&&... args) {
+    return Modify([this, &fn](T& bg, Args&&... args) {
         return fn(bg, (const T&)_data[&bg == _data], std::forward<Args>(args)...);
     }, std::forward<Args>(args)...);
 }

--- a/src/butil/type_traits.h
+++ b/src/butil/type_traits.h
@@ -99,7 +99,7 @@ template <class T> struct is_pod
                            std::is_trivial<T>::value)> {};
 #else
 template <class T> struct is_pod : std::is_pod<T> {};
-#endif
+#endif // __cplusplus
 
 #else
 // We can't get is_pod right without compiler help, so fail conservatively.
@@ -334,7 +334,7 @@ template<typename T>
 struct remove_cvref {
     typedef typename remove_cv<typename remove_reference<T>::type>::type type;
 };
-#endif
+#endif // __cplusplus
 
 // is_reference is false except for reference types.
 template<typename T> struct is_reference : false_type {};
@@ -378,7 +378,7 @@ template <typename F>
 using result_of = std::result_of<F>;
 #else
 #error Only C++11 or later is supported.
-#endif
+#endif // __cplusplus
 
 template <typename F>
 using result_of_t = typename result_of<F>::type;

--- a/test/brpc_load_balancer_unittest.cpp
+++ b/test/brpc_load_balancer_unittest.cpp
@@ -123,10 +123,14 @@ void test_doubly_buffered_data() {
     }
 
     d.Modify(AddN, 10);
+    d.Modify([](Foo& f, int n) -> size_t {
+        f.x += n;
+        return 1;
+    }, 10);
     {
         typename DBD::ScopedPtr ptr;
         ASSERT_EQ(0, d.Read(&ptr));
-        ASSERT_EQ(10, ptr->x);
+        ASSERT_EQ(20, ptr->x);
     }
 }
 

--- a/test/brpc_load_balancer_unittest.cpp
+++ b/test/brpc_load_balancer_unittest.cpp
@@ -80,6 +80,16 @@ bool AddN(Foo& f, int n) {
     return true;
 }
 
+void read_cb(const Foo& f) {
+    ASSERT_EQ(0, f.x);
+}
+
+struct CallableObj {
+    void operator()(const Foo& f) {
+        ASSERT_EQ(0, f.x);
+    }
+};
+
 template <typename DBD>
 void test_doubly_buffered_data() {
     // test doubly_buffered_data TLS limits
@@ -96,6 +106,15 @@ void test_doubly_buffered_data() {
         typename DBD::ScopedPtr ptr;
         ASSERT_EQ(0, d.Read(&ptr));
         ASSERT_EQ(0, ptr->x);
+    }
+    {
+        ASSERT_EQ(0, d.Read([](const Foo& f) {
+            ASSERT_EQ(0, f.x);
+        }));
+        ASSERT_EQ(0, d.Read(read_cb));
+        ASSERT_EQ(0, d.Read(CallableObj()));
+        CallableObj co;
+        ASSERT_EQ(0, d.Read(co));
     }
     {
         typename DBD::ScopedPtr ptr;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

DoublyBufferedData::Read要配合ScopedPtr使用，使用上需要理解成本，甚至有可能会用错，导致死锁等问题。

### What is changed and the side effects?

Changed:

1. 增加一个DoublyBufferedData::Read重载函数，用户只需要传入自定义函数，操作T就可以了。
2. 支持可变参数。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
