### PR TITLE
Fix prometheus metric format (#2825)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -465,6 +465,7 @@ filegroup(
 proto_library(
     name = "brpc_idl_options_proto",
     srcs = [":brpc_idl_options_proto_srcs"],
+    strip_import_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:descriptor_proto",

--- a/src/brpc/builtin/prometheus_metrics_service.cpp
+++ b/src/brpc/builtin/prometheus_metrics_service.cpp
@@ -54,6 +54,8 @@ public:
     }
 
     bool dump(const std::string& name, const butil::StringPiece& desc) override;
+    bool dump_mvar(const std::string& name, const butil::StringPiece& desc) override;
+    bool dump_comment(const std::string& name, const std::string& type) override;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(PrometheusMetricsDumper);
@@ -105,6 +107,21 @@ bool PrometheusMetricsDumper::dump(const std::string& name,
     *_os << "# HELP " << metrics_name << '\n'
          << "# TYPE " << metrics_name << " gauge" << '\n'
          << name << " " << desc << '\n';
+    return true;
+}
+
+bool PrometheusMetricsDumper::dump_mvar(const std::string& name, const butil::StringPiece& desc) {
+    if (!desc.empty() && desc[0] == '"') {
+        // there is no necessary to monitor string in prometheus
+        return true;
+    }
+    *_os << name << " " << desc << "\n";
+    return true;
+}
+
+bool PrometheusMetricsDumper::dump_comment(const std::string& name, const std::string& type) {
+    *_os << "# HELP " << name << '\n'
+         << "# TYPE " << name << " " << type << '\n';
     return true;
 }
 

--- a/src/bvar/multi_dimension_inl.h
+++ b/src/bvar/multi_dimension_inl.h
@@ -252,7 +252,7 @@ size_t MultiDimension<T>::dump(Dumper* dumper, const DumpOptions* options) {
         bvar->describe(oss, options->quote_string);
         std::ostringstream oss_key;
         make_dump_key(oss_key, label_name);
-        if (!dumper->dump(oss_key.str(), oss.str())) {
+        if (!dumper->dump_mvar(oss_key.str(), oss.str())) {
             continue;
         }
         n++;
@@ -269,20 +269,20 @@ size_t MultiDimension<bvar::LatencyRecorder>::dump(Dumper* dumper, const DumpOpt
         return 0;
     }
     size_t n = 0;
+    // To meet prometheus specification, we must guarantee no second TYPE line for one metric name
+
+    // latency comment
+    dumper->dump_comment(name() + "_latency", METRIC_TYPE_GAUGE);
     for (auto &label_name : label_names) {
         bvar::LatencyRecorder* bvar = get_stats_impl(label_name);
         if (!bvar) {
             continue;
         }
 
-        // latency comment
-        if (!dumper->dump_comment(name() + "_latency", METRIC_TYPE_GAUGE)) {
-            continue;
-        }
         // latency
         std::ostringstream oss_latency_key;
         make_dump_key(oss_latency_key, label_name, "_latency");
-        if (dumper->dump(oss_latency_key.str(), std::to_string(bvar->latency()))) {
+        if (dumper->dump_mvar(oss_latency_key.str(), std::to_string(bvar->latency()))) {
             n++;
         }
         // latency_percentiles
@@ -291,53 +291,62 @@ size_t MultiDimension<bvar::LatencyRecorder>::dump(Dumper* dumper, const DumpOpt
         for (auto lp : latency_percentiles) {
             std::ostringstream oss_lp_key;
             make_dump_key(oss_lp_key, label_name, "_latency", lp);
-            if (dumper->dump(oss_lp_key.str(), std::to_string(bvar->latency_percentile(lp / 100.0)))) {
+            if (dumper->dump_mvar(oss_lp_key.str(), std::to_string(bvar->latency_percentile(lp / 100.0)))) {
                 n++;
             }
         }
         // 999
         std::ostringstream oss_p999_key;
         make_dump_key(oss_p999_key, label_name, "_latency", 999);
-        if (dumper->dump(oss_p999_key.str(), std::to_string(bvar->latency_percentile(0.999)))) {
+        if (dumper->dump_mvar(oss_p999_key.str(), std::to_string(bvar->latency_percentile(0.999)))) {
             n++;
         }
         // 9999
         std::ostringstream oss_p9999_key;
         make_dump_key(oss_p9999_key, label_name, "_latency", 9999);
-        if (dumper->dump(oss_p9999_key.str(), std::to_string(bvar->latency_percentile(0.9999)))) {
+        if (dumper->dump_mvar(oss_p9999_key.str(), std::to_string(bvar->latency_percentile(0.9999)))) {
             n++;
         }
+    }
 
-        // max_latency comment
-        if (!dumper->dump_comment(name() + "_max_latency", METRIC_TYPE_GAUGE)) {
+    // max_latency comment
+    dumper->dump_comment(name() + "_max_latency", METRIC_TYPE_GAUGE);
+    for (auto &label_name : label_names) {
+        bvar::LatencyRecorder* bvar = get_stats_impl(label_name);
+        if (!bvar) {
             continue;
         }
-        // max_latency
         std::ostringstream oss_max_latency_key;
         make_dump_key(oss_max_latency_key, label_name, "_max_latency");
-        if (dumper->dump(oss_max_latency_key.str(), std::to_string(bvar->max_latency()))) {
+        if (dumper->dump_mvar(oss_max_latency_key.str(), std::to_string(bvar->max_latency()))) {
             n++;
         }
-        
-        // qps comment
-        if (!dumper->dump_comment(name() + "_qps", METRIC_TYPE_GAUGE)) {
+    }
+
+    // qps comment
+    dumper->dump_comment(name() + "_qps", METRIC_TYPE_GAUGE);
+    for (auto &label_name : label_names) {
+        bvar::LatencyRecorder* bvar = get_stats_impl(label_name);
+        if (!bvar) {
             continue;
         }
-        // qps
         std::ostringstream oss_qps_key;
         make_dump_key(oss_qps_key, label_name, "_qps");
-        if (dumper->dump(oss_qps_key.str(), std::to_string(bvar->qps()))) {
+        if (dumper->dump_mvar(oss_qps_key.str(), std::to_string(bvar->qps()))) {
             n++;
         }
+    }
 
-        // qps comment
-        if (!dumper->dump_comment(name() + "_count", METRIC_TYPE_COUNTER)) {
+    // count comment
+    dumper->dump_comment(name() + "_count", METRIC_TYPE_COUNTER);
+    for (auto &label_name : label_names) {
+        bvar::LatencyRecorder* bvar = get_stats_impl(label_name);
+        if (!bvar) {
             continue;
         }
-        // count
         std::ostringstream oss_count_key;
         make_dump_key(oss_count_key, label_name, "_count");
-        if (dumper->dump(oss_count_key.str(), std::to_string(bvar->count()))) {
+        if (dumper->dump_mvar(oss_count_key.str(), std::to_string(bvar->count()))) {
             n++;
         }
     }

--- a/src/bvar/variable.h
+++ b/src/bvar/variable.h
@@ -53,6 +53,12 @@ public:
     virtual ~Dumper() { }
     virtual bool dump(const std::string& name,
                       const butil::StringPiece& description) = 0;
+    // Only for dumping value of multiple dimension var to prometheus service
+    virtual bool dump_mvar(const std::string& name,
+                           const butil::StringPiece& description) {
+        return true;
+    }
+    // Only for dumping comment of multiple dimension var to prometheus service
     virtual bool dump_comment(const std::string&, const std::string& /*type*/) {
         return true;
     }

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -154,11 +154,12 @@ proto_library(
         [
             "*.proto",
         ],
-        exclude = [
-            "echo.proto",
-        ],
     ),
+    strip_import_prefix = "/test",
     visibility = ["//visibility:public"],
+    deps = [
+        "//:brpc_idl_options_proto",
+    ]
 )
 
 cc_proto_library(
@@ -233,6 +234,23 @@ cc_test(
     ),
     copts = COPTS,
     deps = [
+        ":sstream_workaround",
+        "//:brpc",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "brpc_prometheus_test",
+    srcs = glob(
+        [
+            "brpc_prometheus_*_unittest.cpp",
+        ],
+    ),
+    copts = COPTS,
+    deps = [
+        ":cc_test_proto",
         ":sstream_workaround",
         "//:brpc",
         "@com_google_googletest//:gtest",

--- a/test/brpc_channel_unittest.cpp
+++ b/test/brpc_channel_unittest.cpp
@@ -40,11 +40,7 @@
 #include "brpc/selective_channel.h"
 #include "brpc/socket_map.h"
 #include "brpc/controller.h"
-#if BAZEL_TEST
-#include "test/echo.pb.h"
-#else
 #include "echo.pb.h"
-#endif   // BAZEL_TEST
 #include "brpc/options.pb.h"
 
 namespace brpc {

--- a/test/iobuf_unittest.cpp
+++ b/test/iobuf_unittest.cpp
@@ -32,11 +32,7 @@
 #include <butil/fd_guard.h>
 #include <butil/errno.h>
 #include <butil/fast_rand.h>
-#if BAZEL_TEST
-#include "test/iobuf.pb.h"
-#else
 #include "iobuf.pb.h"
-#endif   // BAZEL_TEST
 
 namespace butil {
 namespace iobuf {


### PR DESCRIPTION
 Fix PrometheusMetricsDumper to dump unique comment of a certain metric name to follow the prometheus specification.
 Also refine the prometheus ut case to support mvar output.

### What problem does this PR solve?

Issue Number:
#2825

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响): NO

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
