### PR TITLE
keep session info in RedisConnContext

### DIFF
--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -123,3 +123,14 @@ cc_binary(
         "//:brpc",
     ],
 )
+
+cc_binary(
+    name = "redis_c++_server",
+    srcs = [
+        "redis_c++/redis_server.cpp",
+    ],
+    copts = COPTS,
+    deps = [
+        "//:brpc",
+    ],
+)

--- a/example/redis_c++/redis_server.cpp
+++ b/example/redis_c++/redis_server.cpp
@@ -30,22 +30,38 @@
 #include <butil/time.h>
 
 DEFINE_int32(port, 6379, "TCP Port of this server");
-
 class RedisServiceImpl : public brpc::RedisService {
 public:
-    bool Set(const std::string& key, const std::string& value) {
+    RedisServiceImpl() {
+        _user_password["db1"] = "123456";
+        _user_password["db2"] = "123456";
+        _db_map["db1"].resize(kHashSlotNum);
+        _db_map["db2"].resize(kHashSlotNum);
+    }
+    bool Set(const std::string& db_name, const std::string& key, const std::string& value) {
         int slot = butil::crc32c::Value(key.c_str(), key.size()) % kHashSlotNum;
         _mutex[slot].lock();
-        _map[slot][key] = value;
+        auto& kv = _db_map[db_name];
+        kv[slot][key] = value;
         _mutex[slot].unlock();
         return true;
     }
-
-    bool Get(const std::string& key, std::string* value) {
+    bool Auth(const std::string& db_name, const std::string& password) {
+        if (_user_password.find(db_name) == _user_password.end()) {
+            return false;
+        } else {
+            if (_user_password[db_name] != password) {
+                return false;
+            }
+        }
+        return true;
+    }
+    bool Get(const std::string& db_name, const std::string& key, std::string* value) {
         int slot = butil::crc32c::Value(key.c_str(), key.size()) % kHashSlotNum;
         _mutex[slot].lock();
-        auto it = _map[slot].find(key);
-        if (it == _map[slot].end()) {
+        auto& kv = _db_map[db_name];
+        auto it = kv[slot].find(key);
+        if (it == kv[slot].end()) {
             _mutex[slot].unlock();
             return false;
         }
@@ -56,7 +72,9 @@ public:
 
 private:
     const static int kHashSlotNum = 32;
-    std::unordered_map<std::string, std::string> _map[kHashSlotNum];
+    typedef std::unordered_map<std::string, std::string> KVStore;
+    std::unordered_map<std::string, std::vector<KVStore>> _db_map;
+    std::unordered_map<std::string, std::string> _user_password;
     butil::Mutex _mutex[kHashSlotNum];
 };
 
@@ -65,16 +83,20 @@ public:
     explicit GetCommandHandler(RedisServiceImpl* rsimpl)
         : _rsimpl(rsimpl) {}
 
-    brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args,
+    brpc::RedisCommandHandlerResult Run(brpc::RedisConnContext* ctx, const std::vector<butil::StringPiece>& args,
                                         brpc::RedisReply* output,
                                         bool /*flush_batched*/) override {
+        if (ctx->user_name.empty()) {
+            output->FormatError("No user name");
+            return brpc::REDIS_CMD_HANDLED;
+        }
         if (args.size() != 2ul) {
             output->FormatError("Expect 1 arg for 'get', actually %lu", args.size()-1);
             return brpc::REDIS_CMD_HANDLED;
         }
         const std::string key(args[1].data(), args[1].size());
         std::string value;
-        if (_rsimpl->Get(key, &value)) {
+        if (_rsimpl->Get(ctx->user_name, key, &value)) {
             output->SetString(value);
         } else {
             output->SetNullString();
@@ -91,22 +113,55 @@ public:
     explicit SetCommandHandler(RedisServiceImpl* rsimpl)
         : _rsimpl(rsimpl) {}
 
-    brpc::RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args,
+    brpc::RedisCommandHandlerResult Run(brpc::RedisConnContext* ctx, const std::vector<butil::StringPiece>& args,
                                         brpc::RedisReply* output,
                                         bool /*flush_batched*/) override {
+        if (ctx->user_name.empty()) {
+            output->FormatError("No user name");
+            return brpc::REDIS_CMD_HANDLED;
+        }                                            
         if (args.size() != 3ul) {
             output->FormatError("Expect 2 args for 'set', actually %lu", args.size()-1);
             return brpc::REDIS_CMD_HANDLED;
         }
         const std::string key(args[1].data(), args[1].size());
         const std::string value(args[2].data(), args[2].size());
-        _rsimpl->Set(key, value);
+        _rsimpl->Set(ctx->user_name, key, value);
         output->SetStatus("OK");
         return brpc::REDIS_CMD_HANDLED;
 	}
 
 private:
-   	RedisServiceImpl* _rsimpl;
+    RedisServiceImpl* _rsimpl;
+};
+
+class AuthCommandHandler : public brpc::RedisCommandHandler {
+public:
+    explicit AuthCommandHandler(RedisServiceImpl* rsimpl)
+        : _rsimpl(rsimpl) {}
+    brpc::RedisCommandHandlerResult Run(brpc::RedisConnContext* ctx, const std::vector<butil::StringPiece>& args,
+                                        brpc::RedisReply* output,
+                                        bool /*flush_batched*/) override {
+        if (args.size() != 3ul) {
+            output->FormatError("Expect 2 args for 'auth', actually %lu", args.size()-1);
+            return brpc::REDIS_CMD_HANDLED;
+        }
+        
+        const std::string db_name(args[1].data(), args[1].size());
+        const std::string password(args[2].data(), args[2].size());
+        
+        if (_rsimpl->Auth(db_name, password)) {
+            output->SetStatus("OK");
+            ctx->user_name = db_name;
+            ctx->password = password;
+        } else {
+            output->FormatError("Invalid password for database '%s'", db_name.c_str());
+        }
+        return brpc::REDIS_CMD_HANDLED;
+    }
+
+private:
+    RedisServiceImpl* _rsimpl;
 };
 
 int main(int argc, char* argv[]) {
@@ -114,9 +169,11 @@ int main(int argc, char* argv[]) {
     RedisServiceImpl *rsimpl = new RedisServiceImpl;
     auto get_handler =std::unique_ptr<GetCommandHandler>(new GetCommandHandler(rsimpl));
     auto set_handler =std::unique_ptr<SetCommandHandler>( new SetCommandHandler(rsimpl));
+    auto auth_handler = std::unique_ptr<AuthCommandHandler>(new AuthCommandHandler(rsimpl));
     rsimpl->AddCommandHandler("get", get_handler.get());
     rsimpl->AddCommandHandler("set", set_handler.get());
-
+    rsimpl->AddCommandHandler("auth", auth_handler.get());
+    
     brpc::Server server;
     brpc::ServerOptions server_options;
     server_options.redis_service = rsimpl;

--- a/example/redis_c++/redis_server.cpp
+++ b/example/redis_c++/redis_server.cpp
@@ -104,7 +104,12 @@ public:
                                         const std::vector<butil::StringPiece>& args,
                                         brpc::RedisReply* output,
                                         bool /*flush_batched*/) override {
-        AuthSession* session = static_cast<AuthSession*>(ctx->session);
+
+        AuthSession* session = static_cast<AuthSession*>(ctx->get_session());
+        if (session == nullptr) {
+            output->FormatError("No auth session");
+            return brpc::REDIS_CMD_HANDLED;
+        }
         if (session->_user_name.empty()) {
             output->FormatError("No user name");
             return brpc::REDIS_CMD_HANDLED;
@@ -136,7 +141,11 @@ public:
                                         const std::vector<butil::StringPiece>& args,
                                         brpc::RedisReply* output,
                                         bool /*flush_batched*/) override {
-        AuthSession* session = static_cast<AuthSession*>(ctx->session);
+        AuthSession* session = static_cast<AuthSession*>(ctx->get_session());
+        if (session == nullptr) {
+            output->FormatError("No auth session");
+            return brpc::REDIS_CMD_HANDLED;
+        }
         if (session->_user_name.empty()) {
             output->FormatError("No user name");
             return brpc::REDIS_CMD_HANDLED;
@@ -177,7 +186,7 @@ public:
         if (_rsimpl->Auth(db_name, password)) {
             output->SetStatus("OK");
             auto auth_session = new AuthSession(db_name, password);
-            ctx->session = auth_session;
+            ctx->reset_session(auth_session);
         } else {
             output->FormatError("Invalid password for database '%s'", db_name.c_str());
         }

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -114,8 +114,6 @@ int ConsumeCommand(RedisConnContext* ctx,
 }
 
 
-// ========== impl of RedisConnContext ==========
-
 ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
                               bool read_eof, const void* arg) {
     if (read_eof || source->empty()) {

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -54,27 +54,6 @@ struct InputResponse : public InputMessageBase {
     }
 };
 
-// This class is as parsing_context in socket.
-class RedisConnContext : public Destroyable  {
-public:
-    explicit RedisConnContext(const RedisService* rs)
-        : redis_service(rs)
-        , batched_size(0) {}
-
-    ~RedisConnContext();
-    // @Destroyable
-    void Destroy() override;
-
-    const RedisService* redis_service;
-    // If user starts a transaction, transaction_handler indicates the
-    // handler pointer that runs the transaction command.
-    std::unique_ptr<RedisCommandHandler> transaction_handler;
-    // >0 if command handler is run in batched mode.
-    int batched_size;
-
-    RedisCommandParser parser;
-    butil::Arena arena;
-};
 
 int ConsumeCommand(RedisConnContext* ctx,
                    const std::vector<butil::StringPiece>& args,
@@ -83,7 +62,7 @@ int ConsumeCommand(RedisConnContext* ctx,
     RedisReply output(&ctx->arena);
     RedisCommandHandlerResult result = REDIS_CMD_HANDLED;
     if (ctx->transaction_handler) {
-        result = ctx->transaction_handler->Run(args, &output, flush_batched);
+        result = ctx->transaction_handler->Run(ctx, args, &output, flush_batched);
         if (result == REDIS_CMD_HANDLED) {
             ctx->transaction_handler.reset(NULL);
         } else if (result == REDIS_CMD_BATCHED) {
@@ -97,7 +76,7 @@ int ConsumeCommand(RedisConnContext* ctx,
             snprintf(buf, sizeof(buf), "ERR unknown command `%s`", args[0].as_string().c_str());
             output.SetError(buf);
         } else {
-            result = ch->Run(args, &output, flush_batched);
+            result = ch->Run(ctx, args, &output, flush_batched);
             if (result == REDIS_CMD_CONTINUE) {
                 if (ctx->batched_size != 0) {
                     LOG(ERROR) << "CONTINUE should not be returned in a batched process.";
@@ -134,13 +113,6 @@ int ConsumeCommand(RedisConnContext* ctx,
     return 0;
 }
 
-// ========== impl of RedisConnContext ==========
-
-RedisConnContext::~RedisConnContext() { }
-
-void RedisConnContext::Destroy() {
-    delete this;
-}
 
 // ========== impl of RedisConnContext ==========
 

--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -369,9 +369,14 @@ RedisCommandHandler* RedisCommandHandler::NewTransactionHandler() {
     LOG(ERROR) << "NewTransactionHandler is not implemented";
     return NULL;
 }
+
 // ========== impl of RedisConnContext ==========
 RedisConnContext::~RedisConnContext() { }
+
 void RedisConnContext::Destroy() {
+    if (session) {
+        session->Destroy();
+    }
     delete this;
 }
 } // namespace brpc

--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -369,5 +369,9 @@ RedisCommandHandler* RedisCommandHandler::NewTransactionHandler() {
     LOG(ERROR) << "NewTransactionHandler is not implemented";
     return NULL;
 }
-
+// ========== impl of RedisConnContext ==========
+RedisConnContext::~RedisConnContext() { }
+void RedisConnContext::Destroy() {
+    delete this;
+}
 } // namespace brpc

--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -379,4 +379,12 @@ void RedisConnContext::Destroy() {
     }
     delete this;
 }
+
+void RedisConnContext::reset_session(Destroyable* s){
+    if (session) {
+        session->Destroy();
+    }
+    session = s;
+}
+
 } // namespace brpc

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -21,8 +21,10 @@
 
 #include <unordered_map>
 
+#include "brpc/destroyable.h"
 #include "brpc/nonreflectable_message.h"
 #include "brpc/parse_result.h"
+#include "brpc/redis_command.h"
 #include "brpc/pb_compat.h"
 #include "brpc/redis_reply.h"
 #include "butil/arena.h"
@@ -209,7 +211,31 @@ enum RedisCommandHandlerResult {
     REDIS_CMD_CONTINUE = 1,
     REDIS_CMD_BATCHED = 2,
 };
+class RedisCommandParser;
+// This class is as parsing_context in socket.
+class RedisConnContext : public Destroyable  {
+public:
+    explicit RedisConnContext(const RedisService* rs)
+        : redis_service(rs)
+        , batched_size(0) {}
 
+    ~RedisConnContext();
+    // @Destroyable
+    void Destroy() override;
+
+    const RedisService* redis_service;
+    // If user starts a transaction, transaction_handler indicates the
+    // handler pointer that runs the transaction command.
+    std::unique_ptr<RedisCommandHandler> transaction_handler;
+    // >0 if command handler is run in batched mode.
+    int batched_size;
+    // If user is authenticated, user_name and password are set.
+    // Keep auth info in RedisConnContext to distinguish diffrent users( or diffrent db).
+    std::string user_name;
+    std::string password;
+    RedisCommandParser parser;
+    butil::Arena arena;
+};
 // The Command handler for a redis request. User should impletement Run().
 class RedisCommandHandler {
 public:
@@ -235,8 +261,14 @@ public:
     // it returns REDIS_CMD_HANDLED. Read the comment below.
     virtual RedisCommandHandlerResult Run(const std::vector<butil::StringPiece>& args,
                                           brpc::RedisReply* output,
-                                          bool flush_batched) = 0;
-
+                                          bool flush_batched) {
+        return REDIS_CMD_HANDLED;                                    
+    };
+    virtual RedisCommandHandlerResult Run(RedisConnContext* ctx, const std::vector<butil::StringPiece>& args,
+                                          brpc::RedisReply* output,
+                                          bool flush_batched) {
+        return Run(args, output, flush_batched);
+    }
     // The Run() returns CONTINUE for "multi", which makes brpc call this method to
     // create a transaction_handler to process following commands until transaction_handler
     // returns OK. For example, for command "multi; set k1 v1; set k2 v2; set k3 v3;

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -219,11 +219,15 @@ class RedisConnContext : public Destroyable  {
 public:
     explicit RedisConnContext(const RedisService* rs)
         : redis_service(rs)
-        , batched_size(0) {}
+        , batched_size(0)
+        , session(nullptr) {}
 
     ~RedisConnContext();
     // @Destroyable
     void Destroy() override;
+    void reset_session(Destroyable* s);
+
+    Destroyable* get_session() { return session; }
 
     const RedisService* redis_service;
     // If user starts a transaction, transaction_handler indicates the
@@ -231,11 +235,14 @@ public:
     std::unique_ptr<RedisCommandHandler> transaction_handler;
     // >0 if command handler is run in batched mode.
     int batched_size;
+
+    RedisCommandParser parser;
+    butil::Arena arena;
+
+private:
     // If user is authenticated, session is set.
     // Keep auth session info in RedisConnContext to distinguish diffrent users( or diffrent db).
     Destroyable* session;
-    RedisCommandParser parser;
-    butil::Arena arena;
 };
 
 // The Command handler for a redis request. User should impletement Run().

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -211,7 +211,9 @@ enum RedisCommandHandlerResult {
     REDIS_CMD_CONTINUE = 1,
     REDIS_CMD_BATCHED = 2,
 };
+
 class RedisCommandParser;
+
 // This class is as parsing_context in socket.
 class RedisConnContext : public Destroyable  {
 public:
@@ -229,13 +231,13 @@ public:
     std::unique_ptr<RedisCommandHandler> transaction_handler;
     // >0 if command handler is run in batched mode.
     int batched_size;
-    // If user is authenticated, user_name and password are set.
-    // Keep auth info in RedisConnContext to distinguish diffrent users( or diffrent db).
-    std::string user_name;
-    std::string password;
+    // If user is authenticated, session is set.
+    // Keep auth session info in RedisConnContext to distinguish diffrent users( or diffrent db).
+    Destroyable* session;
     RedisCommandParser parser;
     butil::Arena arena;
 };
+
 // The Command handler for a redis request. User should impletement Run().
 class RedisCommandHandler {
 public:
@@ -264,7 +266,8 @@ public:
                                           bool flush_batched) {
         return REDIS_CMD_HANDLED;                                    
     };
-    virtual RedisCommandHandlerResult Run(RedisConnContext* ctx, const std::vector<butil::StringPiece>& args,
+    virtual RedisCommandHandlerResult Run(RedisConnContext* ctx, 
+                                          const std::vector<butil::StringPiece>& args,
                                           brpc::RedisReply* output,
                                           bool flush_batched) {
         return Run(args, output, flush_batched);

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -193,6 +193,21 @@ cc_test(
 )
 
 cc_test(
+    name = "brpc_redis_test",
+    srcs = glob(
+        [
+            "brpc_redis_unittest.cpp",
+        ],
+    ),
+    copts = COPTS,
+    deps = [
+        ":sstream_workaround",
+        "//:brpc",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
     name = "bvar_test",
     srcs = glob(
         [

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -192,20 +192,6 @@ cc_test(
     ],
 )
 
-cc_test(
-    name = "brpc_redis_test",
-    srcs = glob(
-        [
-            "brpc_redis_unittest.cpp",
-        ],
-    ),
-    copts = COPTS,
-    deps = [
-        ":sstream_workaround",
-        "//:brpc",
-        "@com_google_googletest//:gtest",
-    ],
-)
 
 cc_test(
     name = "bvar_test",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/apache/brpc/issues/2901

Problem Summary:  RedisConnContext 添加auth信息支持多租户场景

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响): 无

- Breaking backward compatibility(向后兼容性):  兼容

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
