### PR TITLE
Nit enhance 25 03 05

### DIFF
--- a/src/brpc/adaptive_max_concurrency.cpp
+++ b/src/brpc/adaptive_max_concurrency.cpp
@@ -103,16 +103,6 @@ const std::string& AdaptiveMaxConcurrency::type() const {
     }
 }
 
-/*const std::string& AdaptiveMaxConcurrency::UNLIMITED() {
-    static const std::string s = "unlimited";
-    return s;
-}
-
-const std::string& AdaptiveMaxConcurrency::CONSTANT() {
-    static const std::string s = "constant";
-    return s;
-}*/
-
 bool operator==(const AdaptiveMaxConcurrency& adaptive_concurrency,
                 const butil::StringPiece& concurrency) {
     return CompareStringPieceWithoutCase(concurrency, 

--- a/src/brpc/adaptive_max_concurrency.cpp
+++ b/src/brpc/adaptive_max_concurrency.cpp
@@ -101,13 +101,13 @@ const std::string& AdaptiveMaxConcurrency::type() const {
 }
 
 const std::string& AdaptiveMaxConcurrency::UNLIMITED() {
-    static std::string* s = new std::string("unlimited");
-    return *s;
+    static const std::string s = "unlimited";
+    return s;
 }
 
 const std::string& AdaptiveMaxConcurrency::CONSTANT() {
-    static std::string* s = new std::string("constant");
-    return *s;
+    static const std::string s = "constant";
+    return s;
 }
 
 bool operator==(const AdaptiveMaxConcurrency& adaptive_concurrency,

--- a/src/brpc/adaptive_max_concurrency.cpp
+++ b/src/brpc/adaptive_max_concurrency.cpp
@@ -25,14 +25,14 @@
 namespace brpc {
 
 AdaptiveMaxConcurrency::AdaptiveMaxConcurrency()
-    : _value(UNLIMITED())
+    : _value(this.UNLIMITED)
     , _max_concurrency(0) {
 }
 
 AdaptiveMaxConcurrency::AdaptiveMaxConcurrency(int max_concurrency)
     : _max_concurrency(0) {
     if (max_concurrency <= 0) {
-        _value = UNLIMITED();
+        _value = this.UNLIMITED;
         _max_concurrency = 0;
     } else {
         _value = butil::string_printf("%d", max_concurrency);
@@ -76,7 +76,7 @@ void AdaptiveMaxConcurrency::operator=(const butil::StringPiece& value) {
 
 void AdaptiveMaxConcurrency::operator=(int max_concurrency) {
     if (max_concurrency <= 0) {
-        _value = UNLIMITED();
+        _value = this.UNLIMITED;
         _max_concurrency = 0;
     } else {
         _value = butil::string_printf("%d", max_concurrency);
@@ -92,15 +92,15 @@ void AdaptiveMaxConcurrency::operator=(const TimeoutConcurrencyConf& value) {
 
 const std::string& AdaptiveMaxConcurrency::type() const {
     if (_max_concurrency > 0) {
-        return CONSTANT();
+        return this.CONSTANT;
     } else if (_max_concurrency == 0) {
-        return UNLIMITED();
+        return this.UNLIMITED;
     } else {
         return _value;
     }
 }
 
-const std::string& AdaptiveMaxConcurrency::UNLIMITED() {
+/*const std::string& AdaptiveMaxConcurrency::UNLIMITED() {
     static const std::string s = "unlimited";
     return s;
 }
@@ -108,7 +108,7 @@ const std::string& AdaptiveMaxConcurrency::UNLIMITED() {
 const std::string& AdaptiveMaxConcurrency::CONSTANT() {
     static const std::string s = "constant";
     return s;
-}
+}*/
 
 bool operator==(const AdaptiveMaxConcurrency& adaptive_concurrency,
                 const butil::StringPiece& concurrency) {

--- a/src/brpc/adaptive_max_concurrency.cpp
+++ b/src/brpc/adaptive_max_concurrency.cpp
@@ -28,14 +28,14 @@ const std::string AdaptiveMaxConcurrency::UNLIMITED = "unlimited";
 const std::string AdaptiveMaxConcurrency::CONSTANT = "constant";
 
 AdaptiveMaxConcurrency::AdaptiveMaxConcurrency()
-    : _value(this.UNLIMITED)
+    : _value(UNLIMITED)
     , _max_concurrency(0) {
 }
 
 AdaptiveMaxConcurrency::AdaptiveMaxConcurrency(int max_concurrency)
     : _max_concurrency(0) {
     if (max_concurrency <= 0) {
-        _value = this.UNLIMITED;
+        _value = UNLIMITED;
         _max_concurrency = 0;
     } else {
         _value = butil::string_printf("%d", max_concurrency);
@@ -79,7 +79,7 @@ void AdaptiveMaxConcurrency::operator=(const butil::StringPiece& value) {
 
 void AdaptiveMaxConcurrency::operator=(int max_concurrency) {
     if (max_concurrency <= 0) {
-        _value = this.UNLIMITED;
+        _value = UNLIMITED;
         _max_concurrency = 0;
     } else {
         _value = butil::string_printf("%d", max_concurrency);
@@ -95,9 +95,9 @@ void AdaptiveMaxConcurrency::operator=(const TimeoutConcurrencyConf& value) {
 
 const std::string& AdaptiveMaxConcurrency::type() const {
     if (_max_concurrency > 0) {
-        return this.CONSTANT;
+        return CONSTANT;
     } else if (_max_concurrency == 0) {
-        return this.UNLIMITED;
+        return UNLIMITED;
     } else {
         return _value;
     }

--- a/src/brpc/adaptive_max_concurrency.cpp
+++ b/src/brpc/adaptive_max_concurrency.cpp
@@ -24,6 +24,9 @@
 
 namespace brpc {
 
+const std::string AdaptiveMaxConcurrency::UNLIMITED = "unlimited";
+const std::string AdaptiveMaxConcurrency::CONSTANT = "constant";
+
 AdaptiveMaxConcurrency::AdaptiveMaxConcurrency()
     : _value(this.UNLIMITED)
     , _max_concurrency(0) {

--- a/src/brpc/adaptive_max_concurrency.h
+++ b/src/brpc/adaptive_max_concurrency.h
@@ -65,8 +65,6 @@ public:
     const std::string& type() const;
 
     // Get strings filled with "unlimited" and "constant"
-    //static const std::string& UNLIMITED();
-    //static const std::string& CONSTANT();
     static const std::string UNLIMITED;// = "unlimited";
     static const std::string CONSTANT;// = "constant";
 

--- a/src/brpc/adaptive_max_concurrency.h
+++ b/src/brpc/adaptive_max_concurrency.h
@@ -67,8 +67,8 @@ public:
     // Get strings filled with "unlimited" and "constant"
     //static const std::string& UNLIMITED();
     //static const std::string& CONSTANT();
-    static const std::string UNLIMITED = "unlimited";
-    static const std::string CONSTANT = "constant";
+    static const std::string UNLIMITED;// = "unlimited";
+    static const std::string CONSTANT;// = "constant";
 
 private:
     std::string _value;

--- a/src/brpc/adaptive_max_concurrency.h
+++ b/src/brpc/adaptive_max_concurrency.h
@@ -65,8 +65,10 @@ public:
     const std::string& type() const;
 
     // Get strings filled with "unlimited" and "constant"
-    static const std::string& UNLIMITED();
-    static const std::string& CONSTANT();
+    //static const std::string& UNLIMITED();
+    //static const std::string& CONSTANT();
+    static const std::string UNLIMITED = "unlimited";
+    static const std::string CONSTANT = "constant";
 
 private:
     std::string _value;

--- a/src/brpc/policy/constant_concurrency_limiter.cpp
+++ b/src/brpc/policy/constant_concurrency_limiter.cpp
@@ -37,7 +37,7 @@ int ConstantConcurrencyLimiter::MaxConcurrency() {
 
 ConstantConcurrencyLimiter*
 ConstantConcurrencyLimiter::New(const AdaptiveMaxConcurrency& amc) const {
-    CHECK_EQ(amc.type(), AdaptiveMaxConcurrency::CONSTANT());
+    CHECK_EQ(amc.type(), AdaptiveMaxConcurrency.CONSTANT);
     return new ConstantConcurrencyLimiter(static_cast<int>(amc));
 }
 

--- a/src/brpc/policy/constant_concurrency_limiter.cpp
+++ b/src/brpc/policy/constant_concurrency_limiter.cpp
@@ -37,7 +37,7 @@ int ConstantConcurrencyLimiter::MaxConcurrency() {
 
 ConstantConcurrencyLimiter*
 ConstantConcurrencyLimiter::New(const AdaptiveMaxConcurrency& amc) const {
-    CHECK_EQ(amc.type(), AdaptiveMaxConcurrency.CONSTANT);
+    CHECK_EQ(amc.type(), AdaptiveMaxConcurrency::CONSTANT);
     return new ConstantConcurrencyLimiter(static_cast<int>(amc));
 }
 

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -738,7 +738,7 @@ static int get_port_from_fd(int fd) {
 
 bool Server::CreateConcurrencyLimiter(const AdaptiveMaxConcurrency& amc,
                                       ConcurrencyLimiter** out) {
-    if (amc.type() == AdaptiveMaxConcurrency.UNLIMITED) {
+    if (amc.type() == AdaptiveMaxConcurrency::UNLIMITED) {
         *out = NULL;
         return true;
     }
@@ -1086,7 +1086,7 @@ int Server::StartInternal(const butil::EndPoint& endpoint,
             it->second.status->SetConcurrencyLimiter(NULL);
         } else {
             const AdaptiveMaxConcurrency* amc = &it->second.max_concurrency;
-            if (amc->type() == AdaptiveMaxConcurrency.UNLIMITED) {
+            if (amc->type() == AdaptiveMaxConcurrency::UNLIMITED) {
                 amc = &_options.method_max_concurrency;
             }
             ConcurrencyLimiter* cl = NULL;

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -738,7 +738,7 @@ static int get_port_from_fd(int fd) {
 
 bool Server::CreateConcurrencyLimiter(const AdaptiveMaxConcurrency& amc,
                                       ConcurrencyLimiter** out) {
-    if (amc.type() == AdaptiveMaxConcurrency::UNLIMITED()) {
+    if (amc.type() == AdaptiveMaxConcurrency.UNLIMITED) {
         *out = NULL;
         return true;
     }
@@ -1086,7 +1086,7 @@ int Server::StartInternal(const butil::EndPoint& endpoint,
             it->second.status->SetConcurrencyLimiter(NULL);
         } else {
             const AdaptiveMaxConcurrency* amc = &it->second.max_concurrency;
-            if (amc->type() == AdaptiveMaxConcurrency::UNLIMITED()) {
+            if (amc->type() == AdaptiveMaxConcurrency.UNLIMITED) {
                 amc = &_options.method_max_concurrency;
             }
             ConcurrencyLimiter* cl = NULL;

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -716,7 +716,7 @@ friend class Controller;
     int SetServiceMaxConcurrency(T* service) {
         if (NULL != service) {
             const AdaptiveMaxConcurrency* amc = &service->_max_concurrency;
-            if (amc->type() == AdaptiveMaxConcurrency.UNLIMITED) {
+            if (amc->type() == AdaptiveMaxConcurrency::UNLIMITED) {
                 amc = &_options.method_max_concurrency;
             }
             ConcurrencyLimiter* cl = NULL;

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -716,7 +716,7 @@ friend class Controller;
     int SetServiceMaxConcurrency(T* service) {
         if (NULL != service) {
             const AdaptiveMaxConcurrency* amc = &service->_max_concurrency;
-            if (amc->type() == AdaptiveMaxConcurrency::UNLIMITED()) {
+            if (amc->type() == AdaptiveMaxConcurrency.UNLIMITED) {
                 amc = &_options.method_max_concurrency;
             }
             ConcurrencyLimiter* cl = NULL;

--- a/test/brpc_adaptive_class_unittest.cpp
+++ b/test/brpc_adaptive_class_unittest.cpp
@@ -31,13 +31,13 @@ const std::string kPooled = "PoOled";
 TEST(AdaptiveMaxConcurrencyTest, ShouldConvertCorrectly) {
     brpc::AdaptiveMaxConcurrency amc(0);
 
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::UNLIMITED(), amc.type());
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::UNLIMITED(), amc.value());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency.UNLIMITED, amc.type());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency.UNLIMITED, amc.value());
     EXPECT_EQ(0, int(amc));
-    EXPECT_TRUE(amc == brpc::AdaptiveMaxConcurrency::UNLIMITED());
+    EXPECT_TRUE(amc == brpc::AdaptiveMaxConcurrency.UNLIMITED);
 
     amc = 10;
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::CONSTANT(), amc.type());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency.CONSTANT, amc.type());
     EXPECT_EQ("10", amc.value());
     EXPECT_EQ(10, int(amc));
     EXPECT_EQ(amc, "10");

--- a/test/brpc_adaptive_class_unittest.cpp
+++ b/test/brpc_adaptive_class_unittest.cpp
@@ -31,13 +31,13 @@ const std::string kPooled = "PoOled";
 TEST(AdaptiveMaxConcurrencyTest, ShouldConvertCorrectly) {
     brpc::AdaptiveMaxConcurrency amc(0);
 
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency.UNLIMITED, amc.type());
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency.UNLIMITED, amc.value());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::UNLIMITED, amc.type());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::UNLIMITED, amc.value());
     EXPECT_EQ(0, int(amc));
-    EXPECT_TRUE(amc == brpc::AdaptiveMaxConcurrency.UNLIMITED);
+    EXPECT_TRUE(amc == brpc::AdaptiveMaxConcurrency::UNLIMITED);
 
     amc = 10;
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency.CONSTANT, amc.type());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::CONSTANT, amc.type());
     EXPECT_EQ("10", amc.value());
     EXPECT_EQ(10, int(amc));
     EXPECT_EQ(amc, "10");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:
n/A

Problem Summary:
A nit fix using const instead of static new, I am not C++ expert, but it seems we just have `static std::string*` with a fix value in previous implications of this PR. I suppose:
- static string with a fix value equals with const, as 1st commit.
- After 1st commit of this PR, I notice that if a function just returns a const string, in fact, we can use a const string replace.

as I am not C++ expert, I used another 3 commits to fix the compile issue.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):
I suppose those implements either previous impl for this PR or changes in this PR moves to compiler optimization.
I searched and learned through www,  I suppose there only difference between the memory location for static(previous) and const(this PR), but compiler optimization is out of my knowledge, as previous adding additional function stack....

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
