### PR TITLE
[#2913] fix link error if with glog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,8 +314,8 @@ endif()
 set(BRPC_PRIVATE_LIBS "-lgflags -lprotobuf -lleveldb -lprotoc -lssl -lcrypto -ldl -lz")
 
 if(WITH_GLOG)
-    set(DYNAMIC_LIB ${DYNAMIC_LIB} ${GLOG_LIB})
-    set(BRPC_PRIVATE_LIBS "${BRPC_PRIVATE_LIBS} -lglog")
+    set(DYNAMIC_LIB ${GLOG_LIB} ${DYNAMIC_LIB})
+    set(BRPC_PRIVATE_LIBS "-lglog ${BRPC_PRIVATE_LIBS}")
 endif()
 
 if(WITH_SNAPPY)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2913

Problem Summary:

glog 依赖 gflags，静态链接的时候，glfags 必须在 glog 后面，否则可能会链接错误

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
