### PR TITLE
Optimize zero copy of http body

### DIFF
--- a/test/brpc_http_message_unittest.cpp
+++ b/test/brpc_http_message_unittest.cpp
@@ -224,8 +224,10 @@ TEST(HttpMessageTest, parse_from_iobuf) {
             "Content-Length: %lu\r\n"
             "\r\n",
             content_length);
-    std::string content;
-    for (size_t i = 0; i < content_length; ++i) content.push_back('2');
+    butil::IOBuf content;
+    for (size_t i = 0; i < content_length; ++i) {
+        content.push_back('2');
+    }
     butil::IOBuf request;
     request.append(header);
     request.append(content);
@@ -233,6 +235,7 @@ TEST(HttpMessageTest, parse_from_iobuf) {
     brpc::HttpMessage http_message;
     ASSERT_TRUE(http_message.ParseFromIOBuf(request) >= 0);
     ASSERT_TRUE(http_message.Completed());
+    ASSERT_EQ(content, http_message.body());
     ASSERT_EQ(content, http_message.body().to_string());
     ASSERT_EQ("text/plain", http_message.header().content_type());
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

http body不需要拷贝数据，与收包IOBuf共享数据即可——zero copy。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
