### PR TITLE
Fix ParkingLot::signal does not modify _pending_signal when there is no waiter

### DIFF
--- a/src/brpc/event_dispatcher.cpp
+++ b/src/brpc/event_dispatcher.cpp
@@ -51,6 +51,7 @@ static void StopAndJoinGlobalDispatchers() {
     delete g_edisp_read_lantency;
     delete g_edisp_write_lantency;
 }
+
 void InitializeGlobalDispatchers() {
     g_edisp_read_lantency = new bvar::LatencyRecorder("event_dispatcher_read_latency");
     g_edisp_write_lantency = new bvar::LatencyRecorder("event_dispatcher_write_latency");

--- a/src/bthread/parking_lot.h
+++ b/src/bthread/parking_lot.h
@@ -45,10 +45,10 @@ public:
     // Wake up at most `num_task' workers.
     // Returns #workers woken up.
     int signal(int num_task) {
+        _pending_signal.fetch_add((num_task << 1), butil::memory_order_release);
         if (_waiter_num.load(butil::memory_order_relaxed) == 0) {
             return 0;
         }
-        _pending_signal.fetch_add((num_task << 1), butil::memory_order_release);
         return futex_wake_private(&_pending_signal, num_task);
     }
 

--- a/src/butil/file_util_posix.cc
+++ b/src/butil/file_util_posix.cc
@@ -601,7 +601,7 @@ bool CreateDirectoryAndGetError(const FilePath& full_path,
     if (mkdir(i->value().c_str(), 0755/*others can read the dir*/) == 0)
       continue;
     // Mkdir failed, but it might have failed with EEXIST, or some other error
-    // due to the the directory appearing out of thin air. This can occur if
+    // due to the directory appearing out of thin air. This can occur if
     // two processes are trying to create the same file system tree at the same
     // time. Check to see if it exists and make sure it is a directory.
     int saved_errno = errno;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

#2907 合入后，CI经常超时，都是发生在`EventDispatcherTest.dispatch_tasks`和`KeyTest.creating_key_in_parallel`。

原因：`signal`早于`wait`，`signal`没改`_pending_signal`，导致后续的`wait`不会立即返回。

### What is changed and the side effects?

Changed:

无论有无waiter，`signal`都要改`_pending_signal`。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
