### PR TITLE
Support ProtoJson formatted http body

### DIFF
--- a/src/brpc/extension.h
+++ b/src/brpc/extension.h
@@ -48,7 +48,7 @@ public:
     void List(std::ostream& os, char separator);
 
 private:
-friend class butil::GetLeakySingleton<Extension<T> >;
+template <typename U> friend U* butil::create_leaky_singleton_obj();
     Extension() = default;
     butil::CaseIgnoredFlatMap<T*> _instance_map;
     butil::Mutex _map_mutex;

--- a/src/brpc/policy/http_rpc_protocol.h
+++ b/src/brpc/policy/http_rpc_protocol.h
@@ -149,6 +149,7 @@ enum HttpContentType {
     HTTP_CONTENT_JSON = 1,
     HTTP_CONTENT_PROTO = 2,
     HTTP_CONTENT_PROTO_TEXT = 3,
+    HTTP_CONTENT_PROTO_JSON = 4,
 };
 
 // Parse from the textual content type. One type may have more than one literals.

--- a/src/bthread/key.cpp
+++ b/src/bthread/key.cpp
@@ -222,8 +222,7 @@ private:
 class BAIDU_CACHELINE_ALIGNMENT KeyTableList {
 public:
     KeyTableList() :
-        _head(NULL), _tail(NULL), _length(0) {
-    }
+        _head(NULL), _tail(NULL), _length(0) {}
 
     ~KeyTableList() {
         TaskGroup* g = BAIDU_GET_VOLATILE_THREAD_LOCAL(tls_task_group);
@@ -305,7 +304,7 @@ public:
         return count;
     }
 
-    inline uint32_t get_length() {
+    inline uint32_t get_length() const {
         return _length;
     }
 

--- a/src/butil/logging.cc
+++ b/src/butil/logging.cc
@@ -395,7 +395,7 @@ bool InitializeLogFileHandle() {
 #elif defined(OS_POSIX)
         log_file = fopen(log_file_name->c_str(), "a");
         if (log_file == NULL) {
-            fprintf(stderr, "Fail to fopen %s", log_file_name->c_str());
+            fprintf(stderr, "Fail to fopen %s: %s", log_file_name->c_str(), berror());
             return false;
         }
 #endif

--- a/src/butil/memory/singleton_on_pthread_once.h
+++ b/src/butil/memory/singleton_on_pthread_once.h
@@ -25,7 +25,13 @@
 
 namespace butil {
 
-template <typename T> class GetLeakySingleton {
+template <typename T>
+T* create_leaky_singleton_obj() {
+    return new T();
+}
+
+template <typename T>
+class GetLeakySingleton {
 public:
     static butil::subtle::AtomicWord g_leaky_singleton_untyped;
     static pthread_once_t g_create_leaky_singleton_once;
@@ -39,7 +45,7 @@ pthread_once_t GetLeakySingleton<T>::g_create_leaky_singleton_once = PTHREAD_ONC
 
 template <typename T>
 void GetLeakySingleton<T>::create_leaky_singleton() {
-    T* obj = new T;
+    T* obj = create_leaky_singleton_obj<T>();
     butil::subtle::Release_Store(
         &g_leaky_singleton_untyped,
         reinterpret_cast<butil::subtle::AtomicWord>(obj));

--- a/src/json2pb/json_to_pb.cpp
+++ b/src/json2pb/json_to_pb.cpp
@@ -27,14 +27,14 @@
 #include "butil/strings/string_number_conversions.h"
 #include "butil/third_party/rapidjson/error/error.h"
 #include "butil/third_party/rapidjson/rapidjson.h"
-#include "json_to_pb.h"
-#include "zero_copy_stream_reader.h"       // ZeroCopyStreamReader
-#include "encode_decode.h"
+#include "json2pb/json_to_pb.h"
+#include "json2pb/zero_copy_stream_reader.h"       // ZeroCopyStreamReader
+#include "json2pb/encode_decode.h"
+#include "json2pb/protobuf_map.h"
+#include "json2pb/rapidjson.h"
+#include "json2pb/protobuf_type_resolver.h"
 #include "butil/base64.h"
-#include "butil/string_printf.h"
-#include "protobuf_map.h"
-#include "rapidjson.h"
-
+#include "butil/iobuf.h"
 
 #ifdef __GNUC__
 // Ignore -Wnonnull for `(::google::protobuf::Message*)nullptr' of J2PERROR by design.
@@ -712,6 +712,40 @@ bool JsonToProtoMessage(google::protobuf::io::ZeroCopyInputStream *stream,
                         std::string* error) {
     return JsonToProtoMessage(stream, message, Json2PbOptions(), error, nullptr);
 }
+
+bool ProtoJsonToProtoMessage(google::protobuf::io::ZeroCopyInputStream* json,
+                             google::protobuf::Message* message,
+                             const ProtoJson2PbOptions& options,
+                             std::string* error) {
+    TypeResolverUniqueptr type_resolver = GetTypeResolver(*message);
+    butil::IOBuf buf;
+    butil::IOBufAsZeroCopyOutputStream output_stream(&buf);
+    std::string type_url = GetTypeUrl(*message);
+    auto st = google::protobuf::util::JsonToBinaryStream(
+        type_resolver.get(), type_url, json, &output_stream, options);
+
+    butil::IOBufAsZeroCopyInputStream input_stream(buf);
+    google::protobuf::io::CodedInputStream decoder(&input_stream);
+    if (!st.ok()) {
+        if (NULL != error) {
+            *error = st.ToString();
+        }
+        return false;
+    }
+
+    bool ok = message->ParseFromCodedStream(&decoder);
+    if (!ok && NULL != error) {
+        *error = "Fail to ParseFromCodedStream";
+    }
+    return ok;
+}
+
+bool ProtoJsonToProtoMessage(const std::string& json, google::protobuf::Message* message,
+                             const ProtoJson2PbOptions& options, std::string* error) {
+    google::protobuf::io::ArrayInputStream input_stream(json.data(), json.size());
+    return ProtoJsonToProtoMessage(&input_stream, message, options, error);
+}
+
 } //namespace json2pb
 
 #undef J2PERROR

--- a/src/json2pb/json_to_pb.h
+++ b/src/json2pb/json_to_pb.h
@@ -23,6 +23,7 @@
 #include "json2pb/zero_copy_stream_reader.h"
 #include <google/protobuf/message.h>
 #include <google/protobuf/io/zero_copy_stream.h>    // ZeroCopyInputStream
+#include <google/protobuf/util/json_util.h>
 
 namespace json2pb {
 
@@ -43,7 +44,7 @@ struct Json2PbOptions {
     bool allow_remaining_bytes_after_parsing;
 };
 
-// Convert `json' to protobuf `message'.
+// Convert `json' to protobuf `message' according to `options'.
 // Returns true on success. `error' (if not NULL) will be set with error
 // message on failure.
 //
@@ -58,18 +59,18 @@ bool JsonToProtoMessage(const std::string& json,
                         size_t* parsed_offset = nullptr);
 
 // Use ZeroCopyInputStream as input instead of std::string.
-bool JsonToProtoMessage(google::protobuf::io::ZeroCopyInputStream *json,
-                        google::protobuf::Message *message,
-                        const Json2PbOptions &options,
-                        std::string *error = nullptr,
-                        size_t *parsed_offset = nullptr);
+bool JsonToProtoMessage(google::protobuf::io::ZeroCopyInputStream* json,
+                        google::protobuf::Message* message,
+                        const Json2PbOptions& options,
+                        std::string* error = nullptr,
+                        size_t* parsed_offset = nullptr);
 
 // Use ZeroCopyStreamReader as input instead of std::string.
 // If you need to parse multiple jsons from IOBuf, you should use this
 // overload instead of the ZeroCopyInputStream one which bases on this
 // and recreates a ZeroCopyStreamReader internally that can't be reused
 // between continuous calls.
-bool JsonToProtoMessage(ZeroCopyStreamReader *json,
+bool JsonToProtoMessage(ZeroCopyStreamReader* json,
                         google::protobuf::Message* message,
                         const Json2PbOptions& options,
                         std::string* error = nullptr,
@@ -83,6 +84,20 @@ bool JsonToProtoMessage(const std::string& json,
 bool JsonToProtoMessage(google::protobuf::io::ZeroCopyInputStream* stream,
                         google::protobuf::Message* message,
                         std::string* error = nullptr);
+
+// See <google/protobuf/util/json_util.h> for details.
+using ProtoJson2PbOptions = google::protobuf::util::JsonParseOptions;
+
+// Convert ProtoJSON formatted `json' to protobuf `message' according to `options'.
+// See https://protobuf.dev/programming-guides/json/ for details.
+bool ProtoJsonToProtoMessage(google::protobuf::io::ZeroCopyInputStream* json,
+                             google::protobuf::Message* message,
+                             const ProtoJson2PbOptions& options,
+                             std::string* error = NULL);
+// Use default GoogleJson2PbOptions.
+bool ProtoJsonToProtoMessage(const std::string& json, google::protobuf::Message* message,
+                             const ProtoJson2PbOptions& options, std::string* error = NULL);
+
 } // namespace json2pb
 
 #endif // BRPC_JSON2PB_JSON_TO_PB_H

--- a/src/json2pb/pb_to_json.h
+++ b/src/json2pb/pb_to_json.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <google/protobuf/message.h>
 #include <google/protobuf/io/zero_copy_stream.h> // ZeroCopyOutputStream
+#include <google/protobuf/util/json_util.h>
 
 namespace json2pb {
 
@@ -79,7 +80,7 @@ bool ProtoMessageToJson(const google::protobuf::Message& message,
                         std::string* error = NULL);
 // send output to ZeroCopyOutputStream instead of std::string.
 bool ProtoMessageToJson(const google::protobuf::Message& message,
-                        google::protobuf::io::ZeroCopyOutputStream *json,
+                        google::protobuf::io::ZeroCopyOutputStream* json,
                         const Pb2JsonOptions& options,
                         std::string* error = NULL);
 
@@ -90,6 +91,18 @@ bool ProtoMessageToJson(const google::protobuf::Message& message,
 bool ProtoMessageToJson(const google::protobuf::Message& message,
                         google::protobuf::io::ZeroCopyOutputStream* json,
                         std::string* error = NULL);
+
+// See <google/protobuf/util/json_util.h> for details.
+using Pb2ProtoJsonOptions = google::protobuf::util::JsonOptions;
+
+// Convert protobuf `messge' to `json' in ProtoJSON format according to `options'.
+// See https://protobuf.dev/programming-guides/json/ for details.
+bool ProtoMessageToProtoJson(const google::protobuf::Message& message,
+                             google::protobuf::io::ZeroCopyOutputStream* json,
+                             const Pb2ProtoJsonOptions& options, std::string* error = NULL);
+// Using default GooglePb2JsonOptions.
+bool ProtoMessageToProtoJson(const google::protobuf::Message& message, std::string* json,
+                             const Pb2ProtoJsonOptions& options, std::string* error = NULL);
 } // namespace json2pb
 
 #endif // BRPC_JSON2PB_PB_TO_JSON_H

--- a/src/json2pb/protobuf_type_resolver.cpp
+++ b/src/json2pb/protobuf_type_resolver.cpp
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "json2pb/protobuf_type_resolver.h"
+
+namespace json2pb {
+
+using google::protobuf::DescriptorPool;
+using google::protobuf::util::TypeResolver;
+using google::protobuf::util::NewTypeResolverForDescriptorPool;
+
+TypeResolverUniqueptr GetTypeResolver(const google::protobuf::Message& message) {
+    auto pool = message.GetDescriptor()->file()->pool();
+    bool is_generated_pool = pool == DescriptorPool::generated_pool();
+    TypeResolver* resolver = is_generated_pool
+        ? butil::get_leaky_singleton<TypeResolver>()
+        : NewTypeResolverForDescriptorPool(PROTOBUF_TYPE_URL_PREFIX, pool);
+    return { resolver, TypeResolverDeleter(is_generated_pool) };
+}
+
+} // namespace json2pb
+

--- a/src/json2pb/protobuf_type_resolver.h
+++ b/src/json2pb/protobuf_type_resolver.h
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef BRPC_PROTOBUF_TYPE_RESOLVER_H
+#define BRPC_PROTOBUF_TYPE_RESOLVER_H
+
+#include <string>
+#include <memory>
+#include <google/protobuf/message.h>
+#include <google/protobuf/util/type_resolver.h>
+#include <google/protobuf/util/type_resolver_util.h>
+#include "butil/string_printf.h"
+#include "butil/memory/singleton_on_pthread_once.h"
+
+namespace json2pb {
+
+#define PROTOBUF_TYPE_URL_PREFIX "type.googleapis.com"
+
+inline std::string GetTypeUrl(const google::protobuf::Message& message) {
+    return butil::string_printf(PROTOBUF_TYPE_URL_PREFIX"/%s",
+                                message.GetDescriptor()->full_name().c_str());
+}
+
+class TypeResolverDeleter {
+public:
+    explicit TypeResolverDeleter(bool is_generated_pool)
+        : _is_generated_pool(is_generated_pool) {}
+
+    void operator()(google::protobuf::util::TypeResolver* resolver) const {
+        if (!_is_generated_pool) {
+            delete resolver;
+        }
+    }
+private:
+    bool _is_generated_pool;
+};
+
+using TypeResolverUniqueptr = std::unique_ptr<
+    google::protobuf::util::TypeResolver, TypeResolverDeleter>;
+
+TypeResolverUniqueptr GetTypeResolver(const google::protobuf::Message& message);
+
+} // namespace json2pb
+
+namespace butil {
+
+// Customized singleton object creation for google::protobuf::util::TypeResolver.
+template<>
+inline google::protobuf::util::TypeResolver*
+create_leaky_singleton_obj<google::protobuf::util::TypeResolver>() {
+    return google::protobuf::util::NewTypeResolverForDescriptorPool(
+        PROTOBUF_TYPE_URL_PREFIX, google::protobuf::DescriptorPool::generated_pool());
+}
+
+} // namespace butil
+
+#endif // BRPC_PROTOBUF_TYPE_RESOLVER_H

--- a/test/addressbook_map.proto
+++ b/test/addressbook_map.proto
@@ -52,6 +52,16 @@ message AddressComplex {
     repeated FriendEntry friends = 2;
 }
 
+message AddressIntMapStd {
+    required string addr = 1;
+    map<string, int32> numbers = 2;
+}
+
+message AddressStringMapStd {
+    required string addr = 1;
+    map<string, string> contacts = 2;
+}
+
 message haha {
     repeated int32 a = 1;
 }

--- a/test/brpc_builtin_service_unittest.cpp
+++ b/test/brpc_builtin_service_unittest.cpp
@@ -839,8 +839,10 @@ void* dummy_bthread(void*) {
 
 
 #ifdef BRPC_BTHREAD_TRACER
+bool g_bthread_trace_start = false;
 bool g_bthread_trace_stop = false;
 void* bthread_trace(void*) {
+    g_bthread_trace_start = true;
     while (!g_bthread_trace_stop) {
         bthread_usleep(1000 * 100);
     }
@@ -884,6 +886,9 @@ TEST_F(BuiltinServiceTest, bthreads) {
     {
         bthread_t th;
         EXPECT_EQ(0, bthread_start_background(&th, NULL, bthread_trace, NULL));
+        while (!g_bthread_trace_start) {
+            bthread_usleep(1000 * 10);
+        }
         ClosureChecker done;
         brpc::Controller cntl;
         std::string id_string;

--- a/test/brpc_protobuf_json_unittest.cpp
+++ b/test/brpc_protobuf_json_unittest.cpp
@@ -1638,4 +1638,107 @@ TEST_F(ProtobufJsonTest, parse_multiple_json_error) {
     ASSERT_EQ(47ul, offset);
 }
 
+TEST_F(ProtobufJsonTest, proto_json_to_pb) {
+    std::string error;
+    json2pb::ProtoJson2PbOptions options;
+
+    std::string json1 = R"({"addr":"baidu.com",)"
+                        R"("numbers":[{"key":"tel","value":123456},{"key":"cell","value":654321}]})";
+    AddressIntMapStd aims;
+    ASSERT_FALSE(json2pb::ProtoJsonToProtoMessage(json1, &aims, options, &error));
+    LOG(INFO) << "Fail to ProtoJsonToProtoMessage: " << error;
+
+    error.clear();
+    butil::IOBuf json_buf1;
+    json_buf1.append(json1);
+    butil::IOBufAsZeroCopyInputStream input_stream1(json_buf1);
+    ASSERT_FALSE(json2pb::ProtoJsonToProtoMessage(&input_stream1, &aims, options, &error));
+    LOG(INFO) << "Fail to ProtoJsonToProtoMessage: " << error;
+    error.clear();
+
+    std::string json2 = R"({"addr":"baidu.com",)"
+                        R"("numbers":{"tel":123456,"cell":654321}})";
+    ASSERT_TRUE(json2pb::ProtoJsonToProtoMessage(json2, &aims, options, &error)) << error;
+    ASSERT_TRUE(aims.has_addr());
+    ASSERT_EQ(aims.addr(), "baidu.com");
+    ASSERT_EQ(aims.numbers_size(), 2);
+    ASSERT_EQ(aims.numbers().at("tel"), 123456);
+    ASSERT_EQ(aims.numbers().at("cell"), 654321);
+
+    aims.Clear();
+    butil::IOBuf json_buf2;
+    json_buf2.append(json2);
+    butil::IOBufAsZeroCopyInputStream input_stream2(json_buf2);
+    ASSERT_TRUE(json2pb::ProtoJsonToProtoMessage(&input_stream2, &aims, options, &error)) << error;
+    ASSERT_TRUE(aims.has_addr());
+    ASSERT_EQ(aims.addr(), "baidu.com");
+    ASSERT_EQ(aims.numbers_size(), 2);
+    ASSERT_EQ(aims.numbers().at("tel"), 123456);
+    ASSERT_EQ(aims.numbers().at("cell"), 654321);
+
+    std::string json3 = R"({"addr":"baidu.com",)"
+                        R"("contacts":{"email":"frank@apache.org","office":"Shanghai"}})";
+    AddressStringMapStd asms;
+    ASSERT_TRUE(json2pb::ProtoJsonToProtoMessage(json3, &asms, options, &error)) << error;
+    ASSERT_TRUE(asms.has_addr());
+    ASSERT_EQ(asms.addr(), "baidu.com");
+    ASSERT_EQ(asms.contacts().size(), 2);
+    ASSERT_EQ(asms.contacts().at("email"), "frank@apache.org");
+    ASSERT_EQ(asms.contacts().at("office"), "Shanghai");
+
+    asms.Clear();
+    butil::IOBuf json_buf3;
+    json_buf3.append(json3);
+    butil::IOBufAsZeroCopyInputStream input_stream3(json_buf3);
+    ASSERT_TRUE(json2pb::ProtoJsonToProtoMessage(&input_stream3, &asms, options, &error)) << error;
+    ASSERT_TRUE(asms.has_addr());
+    ASSERT_EQ(asms.addr(), "baidu.com");
+    ASSERT_EQ(asms.contacts().size(), 2);
+    ASSERT_EQ(asms.contacts().at("email"), "frank@apache.org");
+    ASSERT_EQ(asms.contacts().at("office"), "Shanghai");
+}
+
+TEST_F(ProtobufJsonTest, pb_to_proto_json) {
+    std::string error;
+    json2pb::Pb2ProtoJsonOptions options;
+
+    AddressIntMapStd aims;
+    aims.set_addr("baidu.com");
+    (*aims.mutable_numbers())["tel"] = 123456;
+    (*aims.mutable_numbers())["cell"] = 654321;
+    std::string json1;
+    ASSERT_TRUE(json2pb::ProtoMessageToJson(aims, &json1)) << error;
+    ASSERT_NE(json1.find(R"("addr":"baidu.com")"), std::string::npos);
+    ASSERT_NE(json1.find(R"("cell":654321)"), std::string::npos);
+    ASSERT_NE(json1.find(R"("tel":123456)"), std::string::npos);
+
+    butil::IOBuf json_buf1;
+    json_buf1.append(json1);
+    butil::IOBufAsZeroCopyOutputStream output_stream1(&json_buf1);
+    ASSERT_TRUE(json2pb::ProtoMessageToJson(aims, &output_stream1, &error)) << error;
+    json1 = json_buf1.to_string();
+    ASSERT_NE(json1.find(R"("addr":"baidu.com")"), std::string::npos);
+    ASSERT_NE(json1.find(R"("cell":654321)"), std::string::npos);
+    ASSERT_NE(json1.find(R"("tel":123456)"), std::string::npos);
+
+    AddressStringMapStd asms;
+    asms.set_addr("baidu.com");
+    (*asms.mutable_contacts())["email"] = "frank@apache.org";
+    (*asms.mutable_contacts())["office"] = "Shanghai";
+    std::string json2;
+    ASSERT_TRUE(json2pb::ProtoMessageToJson(asms, &json2)) << error;
+    ASSERT_NE(json2.find(R"("addr":"baidu.com")"), std::string::npos);
+    ASSERT_NE(json2.find(R"("email":"frank@apache.org")"), std::string::npos);
+    ASSERT_NE(json2.find(R"("office":"Shanghai")"), std::string::npos);
+
+    butil::IOBuf json_buf2;
+    json_buf2.append(json2);
+    butil::IOBufAsZeroCopyOutputStream output_stream2(&json_buf2);
+    ASSERT_TRUE(json2pb::ProtoMessageToJson(asms, &output_stream2, &error)) << error;
+    json2 = json_buf2.to_string();
+    ASSERT_NE(json2.find(R"("addr":"baidu.com")"), std::string::npos);
+    ASSERT_NE(json2.find(R"("email":"frank@apache.org")"), std::string::npos);
+    ASSERT_NE(json2.find(R"("office":"Shanghai")"), std::string::npos);
+}
+
 } // namespace

--- a/test/bthread_rwlock_unittest.cpp
+++ b/test/bthread_rwlock_unittest.cpp
@@ -26,9 +26,9 @@ int c = 0;
 void* rdlocker(void* arg) {
     auto rw = (bthread_rwlock_t*)arg;
     bthread_rwlock_rdlock(rw);
-    LOG(INFO) <<butil::string_printf("[%" PRIu64 "] I'm rdlocker, %d, %" PRId64 "ms\n",
-        pthread_numeric_id(), ++c,
-        butil::cpuwide_time_ms() - start_time);
+    LOG(INFO) << butil::string_printf("[%" PRIu64 "] I'm rdlocker, %d, %" PRId64 "ms\n",
+                                      pthread_numeric_id(), ++c,
+                                      butil::cpuwide_time_ms() - start_time);
     bthread_usleep(10000);
     bthread_rwlock_unlock(rw);
     return NULL;
@@ -38,8 +38,8 @@ void* wrlocker(void* arg) {
     auto rw = (bthread_rwlock_t*)arg;
     bthread_rwlock_wrlock(rw);
     LOG(INFO) << butil::string_printf("[%" PRIu64 "] I'm wrlocker, %d, %" PRId64 "ms\n",
-        pthread_numeric_id(), ++c,
-        butil::cpuwide_time_ms() - start_time);
+                                      pthread_numeric_id(), ++c,
+                                      butil::cpuwide_time_ms() - start_time);
     bthread_usleep(10000);
     bthread_rwlock_unlock(rw);
     return NULL;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

bRPC内部的json2pb要求map json的格式是`[{"key": ..., "value": ...}, {...}]`，跟习惯用法`{"key": value}`不一样，不利于多语言接入。

### What is changed and the side effects?

Changed:

使用Protobuf提供的json2pb能力， 支持Protobuf的ProtoJson格式http body，方便多语言接入。

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
