### PR TITLE
Fix double free messages in baidu-std

### DIFF
--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -646,7 +646,6 @@ void ProcessRpcRequest(InputMessageBase* msg_base) {
                 cntl->SetFailed(EREQUEST, "Fail to parse request message, "
                                           "CompressType=%s, request_size=%d",
                                 CompressTypeToCStr(req_cmp_type), req_size);
-                server->options().rpc_pb_message_factory->Return(messages);
                 break;
             }
             req_buf.clear();

--- a/test/brpc_socket_unittest.cpp
+++ b/test/brpc_socket_unittest.cpp
@@ -1238,10 +1238,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         ASSERT_GT(sockfd, 0);
         brpc::SocketOptions options;
         options.fd = sockfd;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckNoKeepalive(ptr->fd());
     }
 
@@ -1252,10 +1252,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         ASSERT_GT(sockfd, 0);
         brpc::SocketOptions options;
         options.fd = sockfd;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckKeepalive(ptr->fd(), true, default_keepalive_idle,
                        default_keepalive_interval, default_keepalive_count);
     }
@@ -1267,10 +1267,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         ASSERT_GT(sockfd, 0);
         brpc::SocketOptions options;
         options.fd = sockfd;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckKeepalive(ptr->fd(), true, brpc::FLAGS_socket_keepalive_idle_s,
                        default_keepalive_interval, default_keepalive_count);
     }
@@ -1282,10 +1282,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         ASSERT_GT(sockfd, 0);
         brpc::SocketOptions options;
         options.fd = sockfd;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckKeepalive(ptr->fd(), true, brpc::FLAGS_socket_keepalive_idle_s,
                        brpc::FLAGS_socket_keepalive_interval_s, default_keepalive_count);
     }
@@ -1297,10 +1297,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         ASSERT_GT(sockfd, 0);
         brpc::SocketOptions options;
         options.fd = sockfd;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckKeepalive(ptr->fd(), true, brpc::FLAGS_socket_keepalive_idle_s,
                        brpc::FLAGS_socket_keepalive_interval_s,
                        brpc::FLAGS_socket_keepalive_count);
@@ -1317,10 +1317,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         options.fd = sockfd;
         options.keepalive_options = std::make_shared<brpc::SocketKeepaliveOptions>();
         options.keepalive_options->keepalive_idle_s = keepalive_idle;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckKeepalive(ptr->fd(), true, keepalive_idle,
                        brpc::FLAGS_socket_keepalive_interval_s,
                        brpc::FLAGS_socket_keepalive_count);
@@ -1333,10 +1333,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         options.fd = sockfd;
         options.keepalive_options = std::make_shared<brpc::SocketKeepaliveOptions>();
         options.keepalive_options->keepalive_interval_s = keepalive_interval;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckKeepalive(ptr->fd(), true, brpc::FLAGS_socket_keepalive_idle_s,
                        keepalive_interval, brpc::FLAGS_socket_keepalive_count);
     }
@@ -1348,10 +1348,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         options.fd = sockfd;
         options.keepalive_options = std::make_shared<brpc::SocketKeepaliveOptions>();
         options.keepalive_options->keepalive_count = keepalive_count;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckKeepalive(ptr->fd(), true, brpc::FLAGS_socket_keepalive_idle_s,
                        brpc::FLAGS_socket_keepalive_interval_s, keepalive_count);
     }
@@ -1365,10 +1365,10 @@ TEST_F(SocketTest, keepalive_input_message) {
         options.keepalive_options->keepalive_idle_s = keepalive_idle;
         options.keepalive_options->keepalive_interval_s = keepalive_interval;
         options.keepalive_options->keepalive_count = keepalive_count;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckKeepalive(ptr->fd(), true, keepalive_idle,
                        keepalive_interval, keepalive_count);
     }
@@ -1388,10 +1388,10 @@ TEST_F(SocketTest, tcp_user_timeout) {
         ASSERT_GT(sockfd, 0);
         brpc::SocketOptions options;
         options.fd = sockfd;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::Socket::Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckTCPUserTimeout(ptr->fd(), 0);
     }
 
@@ -1402,10 +1402,10 @@ TEST_F(SocketTest, tcp_user_timeout) {
         brpc::SocketOptions options;
         options.fd = sockfd;
         options.tcp_user_timeout_ms = tcp_user_timeout_ms;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::Socket::Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckTCPUserTimeout(ptr->fd(), tcp_user_timeout_ms);
     }
 
@@ -1415,10 +1415,10 @@ TEST_F(SocketTest, tcp_user_timeout) {
         ASSERT_GT(sockfd, 0);
         brpc::SocketOptions options;
         options.fd = sockfd;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckTCPUserTimeout(ptr->fd(), brpc::FLAGS_socket_tcp_user_timeout_ms);
     }
     {
@@ -1428,10 +1428,10 @@ TEST_F(SocketTest, tcp_user_timeout) {
         brpc::SocketOptions options;
         options.fd = sockfd;
         options.tcp_user_timeout_ms = tcp_user_timeout_ms;
-        brpc::SocketId id;
+        brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
         CheckTCPUserTimeout(ptr->fd(), tcp_user_timeout_ms);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

SendRpcResponse中会统一归还messages，不需要在ProcessRpcRequest中提前归还。

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
