### PR TITLE
use BAIDU_VOLATILE_THREAD_LOCAL to declare tls_bls to avoid error compiler optimization

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -372,12 +372,11 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
         // Clean tls variables, must be done before changing version_butex
         // otherwise another thread just joined this thread may not see side
         // effects of destructing tls variables.
-        LocalStorage* tls_bls_ptr = BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls);
-        KeyTable* kt = tls_bls_ptr->keytable;
+        KeyTable* kt = BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls)->keytable;
         if (kt != NULL) {
             return_keytable(m->attr.keytable_pool, kt);
             // After deletion: tls may be set during deletion.
-            tls_bls_ptr->keytable = NULL;
+            BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls)->keytable = NULL;
             m->local_storage.keytable = NULL; // optional
         }
 

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -373,7 +373,7 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
         // otherwise another thread just joined this thread may not see side
         // effects of destructing tls variables.
         LocalStorage* tls_bls_ptr = BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls);
-        KeyTable* kt = BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls)->keytable;
+        KeyTable* kt = tls_bls_ptr->keytable;
         if (kt != NULL) {
             return_keytable(m->attr.keytable_pool, kt);
             // After deletion: tls may be set during deletion.

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -372,11 +372,13 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
         // Clean tls variables, must be done before changing version_butex
         // otherwise another thread just joined this thread may not see side
         // effects of destructing tls variables.
+        LocalStorage* tls_bls_ptr = BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls);
         KeyTable* kt = BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls)->keytable;
         if (kt != NULL) {
             return_keytable(m->attr.keytable_pool, kt);
             // After deletion: tls may be set during deletion.
-            BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls)->keytable = NULL;
+            tls_bls_ptr = BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls);
+            tls_bls_ptr->keytable = NULL;
             m->local_storage.keytable = NULL; // optional
         }
 

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -58,7 +58,7 @@ BAIDU_VOLATILE_THREAD_LOCAL(TaskGroup*, tls_task_group, NULL);
 // Sync with TaskMeta::local_storage when a bthread is created or destroyed.
 // During running, the two fields may be inconsistent, use tls_bls as the
 // groundtruth.
-__thread LocalStorage tls_bls = BTHREAD_LOCAL_STORAGE_INITIALIZER;
+BAIDU_VOLATILE_THREAD_LOCAL(LocalStorage, tls_bls, BTHREAD_LOCAL_STORAGE_INITIALIZER);
 
 // defined in bthread/key.cpp
 extern void return_keytable(bthread_keytable_pool_t*, KeyTable*);
@@ -79,7 +79,7 @@ void* run_create_span_func() {
     if (g_create_span_func) {
         return g_create_span_func();
     }
-    return tls_bls.rpcz_parent_span;
+    return BAIDU_GET_VOLATILE_THREAD_LOCAL(tls_bls).rpcz_parent_span;
 }
 
 int TaskGroup::get_attr(bthread_t tid, bthread_attr_t* out) {
@@ -297,17 +297,6 @@ int TaskGroup::init(size_t runqueue_capacity) {
     return 0;
 }
 
-// use noinline to avoid read wrong tls due to compiler optimization
-// https://github.com/apache/brpc/issues/1776
-__attribute__((noinline)) void clean_tls_bls(TaskMeta* const m) {
-    KeyTable* kt = tls_bls.keytable;
-    if (kt != NULL) {
-        return_keytable(m->attr.keytable_pool, kt);
-        tls_bls.keytable = NULL;
-        m->local_storage.keytable = NULL; // optional
-    }
-}
-
 #ifdef BUTIL_USE_ASAN
 void TaskGroup::asan_task_runner(intptr_t) {
     // This is a new thread, and it doesn't have the fake stack yet. ASan will
@@ -383,7 +372,14 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
         // Clean tls variables, must be done before changing version_butex
         // otherwise another thread just joined this thread may not see side
         // effects of destructing tls variables.
-        clean_tls_bls(m);
+        LocalStorage* tls_bls_ptr = BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(tls_bls);
+        KeyTable* kt = tls_bls_ptr->keytable;
+        if (kt != NULL) {
+            return_keytable(m->attr.keytable_pool, kt);
+            // After deletion: tls may be set during deletion.
+            tls_bls_ptr->keytable = NULL;
+            m->local_storage.keytable = NULL; // optional
+        }
 
         // During running the function in TaskMeta and deleting the KeyTable in
         // return_KeyTable, the group is probably changed.
@@ -702,8 +698,8 @@ void TaskGroup::sched_to(TaskGroup** pg, TaskMeta* next_meta, bool cur_ending) {
     if (__builtin_expect(next_meta != cur_meta, 1)) {
         g->_cur_meta = next_meta;
         // Switch tls_bls
-        cur_meta->local_storage = tls_bls;
-        tls_bls = next_meta->local_storage;
+        cur_meta->local_storage = BAIDU_GET_VOLATILE_THREAD_LOCAL(tls_bls);
+        BAIDU_SET_VOLATILE_THREAD_LOCAL(tls_bls, next_meta->local_storage);
 
         // Logging must be done after switching the local storage, since the logging lib
         // use bthread local storage internally, or will cause memory leak.

--- a/src/butil/thread_local.h
+++ b/src/butil/thread_local.h
@@ -60,7 +60,7 @@
     extern void set_##var_name(type v)
 #else
 #define BAIDU_GET_VOLATILE_THREAD_LOCAL(var_name) var_name
-#define BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(var_name) &##var_name
+#define BAIDU_GET_PTR_VOLATILE_THREAD_LOCAL(var_name) &var_name
 #define BAIDU_SET_VOLATILE_THREAD_LOCAL(var_name, value) var_name = value
 #define EXTERN_BAIDU_VOLATILE_THREAD_LOCAL(type, var_name)                     \
     extern BAIDU_THREAD_LOCAL type var_name


### PR DESCRIPTION
What problem does this PR solve?
解决bthread_setspecific注册的变量，用bthread_getspecific可能会找不到的问题。
Problem Summary:
根据 https://github.com/apache/brpc/issues/1776 , https://github.com/apache/brpc/pull/2156 里的一些相关描述，我尝试将清理tls这段代码抽出来作为单独函数并声明为noinline，在我自己的场景下测试可以修复这个问题

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
