### PR TITLE
fix batch create stream and make SetHostSocket thread safe

### DIFF
--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -1437,12 +1437,12 @@ void Controller::HandleStreamConnection(Socket *host_socket) {
     Stream* s = (Stream*)ptrs[0]->conn();
     s->SetConnected(_remote_stream_settings);
     if (stream_num > 1) {
-        const auto& extra_stream_ids = _remote_stream_settings->extra_stream_ids();
+        auto extra_stream_ids = std::move(*_remote_stream_settings->mutable_extra_stream_ids());
         _remote_stream_settings->clear_extra_stream_ids();
         for (size_t i = 1; i < stream_num; ++i) {
             Stream* extra_stream = (Stream *) ptrs[i]->conn();
             _remote_stream_settings->set_stream_id(extra_stream_ids[i - 1]);
-            s->ShareHostSocket(*extra_stream);
+            s->SetHostSocket(host_socket);
             extra_stream->SetConnected(_remote_stream_settings);
         }
     }

--- a/src/brpc/stream_impl.h
+++ b/src/brpc/stream_impl.h
@@ -19,6 +19,7 @@
 #ifndef  BRPC_STREAM_IMPL_H
 #define  BRPC_STREAM_IMPL_H
 
+#include <mutex>
 #include "bthread/bthread.h"
 #include "bthread/execution_queue.h"
 #include "brpc/socket.h"
@@ -67,7 +68,6 @@ public:
     __attribute__ ((__format__ (__printf__, 3, 4)));
     void Close(int error_code, const char* reason_fmt, ...)
         __attribute__ ((__format__ (__printf__, 3, 4)));
-    int ShareHostSocket(Stream& other_stream);
 
 private:
 friend void StreamWait(StreamId stream_id, const timespec *due_time,
@@ -134,6 +134,7 @@ friend struct butil::DefaultDeleter<Stream>;
     butil::IOBuf *_pending_buf;
     int64_t _start_idle_timer_us;
     bthread_timer_t _idle_timer;
+    std::once_flag _set_host_socket_flag;
 };
 
 } // namespace brpc


### PR DESCRIPTION
### What problem does this PR solve?

修复#2754 合入后发现的问题：

1. 有一处存在use after free；

2. SetHostSocket可能会并发调用，增加并发安全性；



### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):
无

- Breaking backward compatibility(向后兼容性): 
完全兼容

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
