### PR TITLE
iobuf support reserve_aligned

### DIFF
--- a/src/butil/iobuf.h
+++ b/src/butil/iobuf.h
@@ -489,6 +489,17 @@ private:
     Block* _block;
 };
 
+class IOReserveAlignedBuf : public IOBuf {
+public:
+    IOReserveAlignedBuf(size_t alignment)
+        : _alignment(alignment), _reserved(false) {}
+    Area reserve(size_t count);
+
+private:
+    size_t _alignment;
+    bool _reserved;
+};
+
 // Specialized utility to cut from IOBuf faster than using corresponding
 // methods in IOBuf.
 // Designed for efficiently parsing data from IOBuf.


### PR DESCRIPTION
### What problem does this PR solve?

IOBuf通过reserve_aligned(size_t n, size_t alignment)函数在IOBuf内部预分配一些符合对齐规则的内存，后续可以通过unsafe_assign函数或者IOBufAsZeroCopyInputStream等函数把这些内存段解析出来，让用户填充数据。
这样做的好处是，统一使用IOBuf的内存管理机制，典型的如RDMA这种内存需要注册的场景，用户自己去注册会比较麻烦，RDMA已经提供给IOBuf内存分配器，直接使用非常方便。

Issue Number:

#993

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
