### PR TITLE
add headers to sub cntl.

### DIFF
--- a/src/brpc/selective_channel.cpp
+++ b/src/brpc/selective_channel.cpp
@@ -334,10 +334,7 @@ int Sender::IssueRPC(int64_t start_realtime_us) {
     sub_cntl->set_request_code(_main_cntl->request_code());
     // Forward request attachment to the subcall
     sub_cntl->request_attachment().append(_main_cntl->request_attachment());
-    for (auto iter = _main_cntl->http_request().HeaderBegin();
-           iter != _main_cntl->http_request().HeaderEnd(); ++iter) {
-        sub_cntl->http_request().SetHeader(iter->first, iter->second);
-    }
+    sub_cntl->http_request() = _main_cntl->http_request();
 
     sel_out.channel()->CallMethod(_main_cntl->_method,
                                   &r.sub_done->_cntl,

--- a/src/brpc/selective_channel.cpp
+++ b/src/brpc/selective_channel.cpp
@@ -334,7 +334,11 @@ int Sender::IssueRPC(int64_t start_realtime_us) {
     sub_cntl->set_request_code(_main_cntl->request_code());
     // Forward request attachment to the subcall
     sub_cntl->request_attachment().append(_main_cntl->request_attachment());
-    
+    for (auto iter = _main_cntl->http_request().HeaderBegin();
+           iter != _main_cntl->http_request().HeaderEnd(); ++iter) {
+        sub_cntl->http_request().SetHeader(iter->first, iter->second);
+    }
+
     sel_out.channel()->CallMethod(_main_cntl->_method,
                                   &r.sub_done->_cntl,
                                   _request,


### PR DESCRIPTION
### What problem does this PR solve?
Fixed the issue that when using SelectiveChannel, the header could not be transparently transmitted to the subchannel.
Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
