### PR TITLE
Bugfix/make bthread tag defaut right

### DIFF
--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -284,7 +284,7 @@ struct SocketOptions {
     // Only linux supports TCP_USER_TIMEOUT.
     int tcp_user_timeout_ms{ -1};
     // Tag of this socket
-    bthread_tag_t bthread_tag{BTHREAD_TAG_DEFAULT};
+    bthread_tag_t bthread_tag{bthread_self_tag()};
 };
 
 // Abstractions on reading from and writing into file descriptors.


### PR DESCRIPTION
### What problem does this PR solve?

bRPC内部创建Socket地方比较多，SocketOptions里面的bthread_tag比较容易漏掉或者搞错，所以将bthread_tag字段的默认值改为bthread_self_tag()，这样默认就是期望的值。

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
