### PR TITLE
Make sure WeightedRandomizedLoadBalancer can traverse the whole server list

### DIFF
--- a/src/brpc/load_balancer.h
+++ b/src/brpc/load_balancer.h
@@ -184,6 +184,13 @@ inline Extension<const LoadBalancer>* LoadBalancerExtension() {
     return Extension<const LoadBalancer>::instance();
 }
 
+inline uint32_t GenRandomStride() {
+    uint32_t prime_offset[] = {
+        #include "bthread/offset_inl.list"
+    };
+    return prime_offset[butil::fast_rand_less_than(ARRAY_SIZE(prime_offset))];
+}
+
 } // namespace brpc
 
 

--- a/src/brpc/policy/dynpart_load_balancer.h
+++ b/src/brpc/policy/dynpart_load_balancer.h
@@ -33,14 +33,14 @@ namespace policy {
 
 class DynPartLoadBalancer : public LoadBalancer {
 public:
-    bool AddServer(const ServerId& id);
-    bool RemoveServer(const ServerId& id);
-    size_t AddServersInBatch(const std::vector<ServerId>& servers);
-    size_t RemoveServersInBatch(const std::vector<ServerId>& servers);
-    int SelectServer(const SelectIn& in, SelectOut* out);
-    DynPartLoadBalancer* New(const butil::StringPiece&) const;
-    void Destroy();
-    void Describe(std::ostream&, const DescribeOptions& options);
+    bool AddServer(const ServerId& id) override;
+    bool RemoveServer(const ServerId& id) override;
+    size_t AddServersInBatch(const std::vector<ServerId>& servers) override;
+    size_t RemoveServersInBatch(const std::vector<ServerId>& servers) override;
+    int SelectServer(const SelectIn& in, SelectOut* out) override;
+    DynPartLoadBalancer* New(const butil::StringPiece&) const override;
+    void Destroy() override;
+    void Describe(std::ostream&, const DescribeOptions& options) override;
 
 private:
     struct Servers {

--- a/src/brpc/policy/locality_aware_load_balancer.h
+++ b/src/brpc/policy/locality_aware_load_balancer.h
@@ -41,16 +41,16 @@ DECLARE_double(punish_inflight_ratio);
 class LocalityAwareLoadBalancer : public LoadBalancer {
 public:
     LocalityAwareLoadBalancer();
-    ~LocalityAwareLoadBalancer();
-    bool AddServer(const ServerId& id);
-    bool RemoveServer(const ServerId& id);
-    size_t AddServersInBatch(const std::vector<ServerId>& servers);
-    size_t RemoveServersInBatch(const std::vector<ServerId>& servers);
-    LocalityAwareLoadBalancer* New(const butil::StringPiece&) const;
-    void Destroy();
-    int SelectServer(const SelectIn& in, SelectOut* out);
-    void Feedback(const CallInfo& info);
-    void Describe(std::ostream& os, const DescribeOptions& options);
+    ~LocalityAwareLoadBalancer() override;
+    bool AddServer(const ServerId& id) override;
+    bool RemoveServer(const ServerId& id) override;
+    size_t AddServersInBatch(const std::vector<ServerId>& servers) override;
+    size_t RemoveServersInBatch(const std::vector<ServerId>& servers) override;
+    LocalityAwareLoadBalancer* New(const butil::StringPiece&) const override;
+    void Destroy() override;
+    int SelectServer(const SelectIn& in, SelectOut* out) override;
+    void Feedback(const CallInfo& info) override;
+    void Describe(std::ostream& os, const DescribeOptions& options) override;
 
 private:
     struct TimeInfo {

--- a/src/brpc/policy/randomized_load_balancer.cpp
+++ b/src/brpc/policy/randomized_load_balancer.cpp
@@ -25,14 +25,6 @@
 namespace brpc {
 namespace policy {
 
-const uint32_t prime_offset[] = {
-#include "bthread/offset_inl.list"
-};
-
-inline uint32_t GenRandomStride() {
-    return prime_offset[butil::fast_rand_less_than(ARRAY_SIZE(prime_offset))];
-}
-
 bool RandomizedLoadBalancer::Add(Servers& bg, const ServerId& id) {
     if (bg.server_list.capacity() < 128) {
         bg.server_list.reserve(128);

--- a/src/brpc/policy/randomized_load_balancer.h
+++ b/src/brpc/policy/randomized_load_balancer.h
@@ -33,14 +33,14 @@ namespace policy {
 // than RoundRobinLoadBalancer.
 class RandomizedLoadBalancer : public LoadBalancer {
 public:
-    bool AddServer(const ServerId& id);
-    bool RemoveServer(const ServerId& id);
-    size_t AddServersInBatch(const std::vector<ServerId>& servers);
-    size_t RemoveServersInBatch(const std::vector<ServerId>& servers);
-    int SelectServer(const SelectIn& in, SelectOut* out);
-    RandomizedLoadBalancer* New(const butil::StringPiece&) const;
-    void Destroy();
-    void Describe(std::ostream& os, const DescribeOptions&);
+    bool AddServer(const ServerId& id) override;
+    bool RemoveServer(const ServerId& id) override;
+    size_t AddServersInBatch(const std::vector<ServerId>& servers) override;
+    size_t RemoveServersInBatch(const std::vector<ServerId>& servers) override;
+    int SelectServer(const SelectIn& in, SelectOut* out) override;
+    RandomizedLoadBalancer* New(const butil::StringPiece&) const override;
+    void Destroy() override;
+    void Describe(std::ostream& os, const DescribeOptions&) override;
     
 private:
     struct Servers {

--- a/src/brpc/policy/round_robin_load_balancer.cpp
+++ b/src/brpc/policy/round_robin_load_balancer.cpp
@@ -25,14 +25,6 @@
 namespace brpc {
 namespace policy {
 
-const uint32_t prime_offset[] = {
-#include "bthread/offset_inl.list"
-};
-
-inline uint32_t GenRandomStride() {
-    return prime_offset[butil::fast_rand_less_than(ARRAY_SIZE(prime_offset))];
-}
-
 bool RoundRobinLoadBalancer::Add(Servers& bg, const ServerId& id) {
     if (bg.server_list.capacity() < 128) {
         bg.server_list.reserve(128);

--- a/src/brpc/policy/round_robin_load_balancer.h
+++ b/src/brpc/policy/round_robin_load_balancer.h
@@ -32,14 +32,14 @@ namespace policy {
 // at the same time) are very close.
 class RoundRobinLoadBalancer : public LoadBalancer {
 public:
-    bool AddServer(const ServerId& id);
-    bool RemoveServer(const ServerId& id);
-    size_t AddServersInBatch(const std::vector<ServerId>& servers);
-    size_t RemoveServersInBatch(const std::vector<ServerId>& servers);
-    int SelectServer(const SelectIn& in, SelectOut* out);
-    RoundRobinLoadBalancer* New(const butil::StringPiece&) const;
-    void Destroy();
-    void Describe(std::ostream&, const DescribeOptions& options);
+    bool AddServer(const ServerId& id) override;
+    bool RemoveServer(const ServerId& id) override;
+    size_t AddServersInBatch(const std::vector<ServerId>& servers) override;
+    size_t RemoveServersInBatch(const std::vector<ServerId>& servers) override;
+    int SelectServer(const SelectIn& in, SelectOut* out) override;
+    RoundRobinLoadBalancer* New(const butil::StringPiece&) const override;
+    void Destroy() override;
+    void Describe(std::ostream&, const DescribeOptions& options) override;
 
 private:
     struct Servers {

--- a/src/brpc/policy/weighted_randomized_load_balancer.cpp
+++ b/src/brpc/policy/weighted_randomized_load_balancer.cpp
@@ -139,11 +139,11 @@ int WeightedRandomizedLoadBalancer::SelectServer(const SelectIn& in, SelectOut* 
             std::lower_bound(s->server_list.begin(), s->server_list.end(),
                              random_server, server_compare);
         const SocketId id = server->id;
-        random_traversed.insert(id);
-        if (0 != IsServerAvailable(id, out->ptr)) {
+        if (ExcludedServers::IsExcluded(in.excluded, id)) {
             continue;
         }
-        if (!ExcludedServers::IsExcluded(in.excluded, id)) {
+        random_traversed.insert(id);
+        if (0 == IsServerAvailable(id, out->ptr)) {
             // An available server is found.
             return 0;
         }

--- a/src/brpc/policy/weighted_randomized_load_balancer.h
+++ b/src/brpc/policy/weighted_randomized_load_balancer.h
@@ -31,17 +31,18 @@ namespace policy {
 // Weight is got from tag of ServerId.
 class WeightedRandomizedLoadBalancer : public LoadBalancer {
 public:
-    bool AddServer(const ServerId& id);
-    bool RemoveServer(const ServerId& id);
-    size_t AddServersInBatch(const std::vector<ServerId>& servers);
-    size_t RemoveServersInBatch(const std::vector<ServerId>& servers);
-    int SelectServer(const SelectIn& in, SelectOut* out);
-    LoadBalancer* New(const butil::StringPiece&) const;
-    void Destroy();
-    void Describe(std::ostream& os, const DescribeOptions&);
+    bool AddServer(const ServerId& id) override;
+    bool RemoveServer(const ServerId& id) override;
+    size_t AddServersInBatch(const std::vector<ServerId>& servers) override;
+    size_t RemoveServersInBatch(const std::vector<ServerId>& servers) override;
+    int SelectServer(const SelectIn& in, SelectOut* out) override;
+    LoadBalancer* New(const butil::StringPiece&) const override;
+    void Destroy() override;
+    void Describe(std::ostream& os, const DescribeOptions&) override;
 
     struct Server {
-        Server(SocketId s_id = 0, uint32_t s_w = 0, uint64_t s_c_w_s = 0): id(s_id), weight(s_w), current_weight_sum(s_c_w_s) {}
+        Server(SocketId s_id = 0, uint32_t s_w = 0, uint64_t s_c_w_s = 0)
+            : id(s_id), weight(s_w), current_weight_sum(s_c_w_s) {}
         SocketId id;
         uint32_t weight;
         uint64_t current_weight_sum;
@@ -60,6 +61,7 @@ private:
     static bool Remove(Servers& bg, const ServerId& id);
     static size_t BatchAdd(Servers& bg, const std::vector<ServerId>& servers);
     static size_t BatchRemove(Servers& bg, const std::vector<ServerId>& servers);
+    static bool IsServerAvailable(SocketId id, SocketUniquePtr* out);
 
     butil::DoublyBufferedData<Servers> _db_servers;
 };

--- a/src/brpc/policy/weighted_round_robin_load_balancer.cpp
+++ b/src/brpc/policy/weighted_round_robin_load_balancer.cpp
@@ -58,8 +58,8 @@ uint64_t GetStride(const uint64_t weight_sum, const size_t num) {
       return 1;
     }
     uint32_t average_weight = weight_sum / num;
-    auto iter = std::lower_bound(prime_stride.begin(), prime_stride.end(),
-                                 average_weight);
+    auto iter = std::lower_bound(
+        prime_stride.begin(), prime_stride.end(), average_weight);
     while (iter != prime_stride.end()
            && !IsCoprime(weight_sum, *iter)) {
         ++iter;
@@ -197,7 +197,7 @@ int WeightedRoundRobinLoadBalancer::SelectServer(const SelectIn& in, SelectOut* 
             }
             filter.emplace(server_id);
             remain_weight -= (s->server_list[s->server_map.at(server_id)]).weight;
-            // Select from begining status.
+            // Select from beginning status.
             tls_temp.stride = GetStride(remain_weight, remain_servers);
             tls_temp.position = tls.position;
             tls_temp.remain_server = tls.remain_server;

--- a/src/brpc/policy/weighted_round_robin_load_balancer.h
+++ b/src/brpc/policy/weighted_round_robin_load_balancer.h
@@ -32,14 +32,14 @@ namespace policy {
 // Weight is got from tag of ServerId.
 class WeightedRoundRobinLoadBalancer : public LoadBalancer {
 public:
-    bool AddServer(const ServerId& id);
-    bool RemoveServer(const ServerId& id);
-    size_t AddServersInBatch(const std::vector<ServerId>& servers);
-    size_t RemoveServersInBatch(const std::vector<ServerId>& servers);
-    int SelectServer(const SelectIn& in, SelectOut* out);
-    LoadBalancer* New(const butil::StringPiece&) const;
-    void Destroy();
-    void Describe(std::ostream&, const DescribeOptions& options);
+    bool AddServer(const ServerId& id) override;
+    bool RemoveServer(const ServerId& id) override;
+    size_t AddServersInBatch(const std::vector<ServerId>& servers) override;
+    size_t RemoveServersInBatch(const std::vector<ServerId>& servers) override;
+    int SelectServer(const SelectIn& in, SelectOut* out) override;
+    LoadBalancer* New(const butil::StringPiece&) const override;
+    void Destroy() override;
+    void Describe(std::ostream&, const DescribeOptions& options) override;
 
 private:
     struct Server {

--- a/test/bthread_countdown_event_unittest.cpp
+++ b/test/bthread_countdown_event_unittest.cpp
@@ -36,6 +36,7 @@ void *signaler(void *arg) {
 }
 
 TEST(CountdonwEventTest, sanity) {
+    std::vector<bthread_t> tids;
     for (int n = 1; n < 10; ++n) {
         Arg a;
         a.num_sig = n;
@@ -43,9 +44,13 @@ TEST(CountdonwEventTest, sanity) {
         for (int i = 0; i < n; ++i) {
             bthread_t tid;
             ASSERT_EQ(0, bthread_start_urgent(&tid, NULL, signaler, &a));
+            tids.push_back(tid);
         }
         a.event.wait();
         ASSERT_EQ(0, a.num_sig.load(butil::memory_order_relaxed));
+    }
+    for (size_t i = 0; i < tids.size(); ++i) {
+        bthread_join(tids[i], NULL);
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

In n tries, some servers with small weights may not be selected.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
