### PR TITLE
chore: Enable GitHub Discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,3 +15,8 @@ github:
     comment_issue: "Re: [I] {title} ({repository})"
     close_issue: "Re: [I] {title} ({repository})"
     catchall: "[GH] {title} ({repository})"
+  features:
+    wiki: true
+    issues: true
+    projects: false
+    discussions: true


### PR DESCRIPTION
As per discussed in https://lists.apache.org/thread/wy1p69qg1154hddwyxlf43q3oqk6owh7

This PR enables GitHub Discussions so that we can:

> 3. When community members create an issue:
>   a. If it's a user question, move it to the 中文 Discussions forum and tell the reporter to use the 中文 category the next time.
>    b. If it's a dev item (task, feature request, bug report, etc.), urge the reporter to report it in English; or a committer should rework it in English.