### PR TITLE
Support channel level application health check options

### DIFF
--- a/docs/cn/client.md
+++ b/docs/cn/client.md
@@ -291,7 +291,7 @@ channel.Init("http://...", "random:min_working_instances=6 hold_seconds=10", &op
 | ------------------------- | ----- | ---------------------------------------- | ----------------------- |
 | health_check_interval （R） | 3     | seconds between consecutive health-checkings | src/brpc/socket_map.cpp |
 
-在默认的配置下，一旦server被连接上，它会恢复为可用状态；brpc还提供了应用层健康检查的机制，框架会发送一个HTTP GET请求到该server，请求路径通过-health\_check\_path设置（默认为空），只有当server返回200时，它才会恢复。在两种健康检查机制下，都可通过-health\_check\_timeout\_ms设置超时（默认500ms）。如果在隔离过程中，server从命名服务中删除了，brpc也会停止连接尝试。
+在默认的配置下，一旦server被连接上，它会恢复为可用状态,可通过-health\_check\_timeout\_ms设置超时（默认500ms）；brpc还提供了应用层健康检查的机制，框架会发送一个HTTP GET请求到该server，只有当server返回200时，它才会恢复，在这种机制下，既可通过-health\_check\_path（默认为空）和-health\_check\_timeout\_ms（默认500ms）分别设置全局的健康检查请求路径和超时，也可通过ChannelOptions中的health\_check\_path和health\_check\_timeout\_ms来对不同的channel设置不同的请求路径和超时，ChannelOptions设置的这俩参数优先级要高于gflag参数。如果在隔离过程中，server从命名服务中删除了，brpc也会停止连接尝试。
 
 # 发起访问
 

--- a/docs/cn/client.md
+++ b/docs/cn/client.md
@@ -291,7 +291,7 @@ channel.Init("http://...", "random:min_working_instances=6 hold_seconds=10", &op
 | ------------------------- | ----- | ---------------------------------------- | ----------------------- |
 | health_check_interval （R） | 3     | seconds between consecutive health-checkings | src/brpc/socket_map.cpp |
 
-在默认的配置下，一旦server被连接上，它会恢复为可用状态,可通过-health\_check\_timeout\_ms设置超时（默认500ms）；brpc还提供了应用层健康检查的机制，框架会发送一个HTTP GET请求到该server，只有当server返回200时，它才会恢复，在这种机制下，既可通过-health\_check\_path（默认为空）和-health\_check\_timeout\_ms（默认500ms）分别设置全局的健康检查请求路径和超时，也可通过ChannelOptions中的health\_check\_path和health\_check\_timeout\_ms来对不同的channel设置不同的请求路径和超时，ChannelOptions设置的这俩参数优先级要高于gflag参数。如果在隔离过程中，server从命名服务中删除了，brpc也会停止连接尝试。
+在默认的配置下，一旦server被连接上，它会恢复为可用状态,可通过-health\_check\_timeout\_ms设置超时（默认500ms）；brpc还提供了应用层健康检查的机制，框架会发送一个HTTP GET请求到该server，只有当server返回200时，它才会恢复，在这种机制下，既可通过-health\_check\_path（默认为空）和-health\_check\_timeout\_ms（默认500ms）分别设置全局的健康检查请求路径和超时，也可通过ChannelOptions中的hc_option成员变量来对不同的channel设置不同的请求路径和超时，ChannelOptions设置的健康检查参数优先级要高于gflag参数。如果在隔离过程中，server从命名服务中删除了，brpc也会停止连接尝试。
 
 # 发起访问
 

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -36,6 +36,7 @@
 #include "brpc/retry_policy.h"
 #include "brpc/backup_request_policy.h"
 #include "brpc/naming_service_filter.h"
+#include "brpc/socket.h"
 
 namespace brpc {
 
@@ -143,18 +144,10 @@ struct ChannelOptions {
     // Default: ""
     std::string connection_group;
 
-    // Set the health check path according to the channel granularity. 
-    // Its priority is higher than FLAGS_health_check_path
-    // When it is not set, FLAGS_health_check_path will take effect
-    // Default: ""
-    std::string health_check_path;
-
-    // Set the rpc health check timeout according to the channel granularity
-    // Its priority is higher than FLAGS_health_check_timeout_ms
-    // When it is smaller than -1, FLAGS_health_check_timeout_ms will take effect
-    // Default: -1
-    int32_t health_check_timeout_ms;
-
+    // Set the health check param according to the channel granularity. 
+    // Its priority is higher than FLAGS_health_check_path and FLAGS_health_check_timeout_ms.
+    // When it is not set, FLAGS_health_check_path and FLAGS_health_check_timeout_ms will take effect.
+    HealthCheckOption hc_option;
 private:
     // SSLOptions is large and not often used, allocate it on heap to
     // prevent ChannelOptions from being bloated in most cases.

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -36,7 +36,7 @@
 #include "brpc/retry_policy.h"
 #include "brpc/backup_request_policy.h"
 #include "brpc/naming_service_filter.h"
-#include "brpc/socket.h"
+#include "brpc/health_check_option.h"
 
 namespace brpc {
 

--- a/src/brpc/channel.h
+++ b/src/brpc/channel.h
@@ -143,6 +143,18 @@ struct ChannelOptions {
     // Default: ""
     std::string connection_group;
 
+    // Set the health check path according to the channel granularity. 
+    // Its priority is higher than FLAGS_health_check_path
+    // When it is not set, FLAGS_health_check_path will take effect
+    // Default: ""
+    std::string health_check_path;
+
+    // Set the rpc health check timeout according to the channel granularity
+    // Its priority is higher than FLAGS_health_check_timeout_ms
+    // When it is smaller than -1, FLAGS_health_check_timeout_ms will take effect
+    // Default: -1
+    int32_t health_check_timeout_ms;
+
 private:
     // SSLOptions is large and not often used, allocate it on heap to
     // prevent ChannelOptions from being bloated in most cases.

--- a/src/brpc/details/health_check.cpp
+++ b/src/brpc/details/health_check.cpp
@@ -31,14 +31,6 @@ namespace brpc {
 // Declared at socket.cpp
 extern SocketVarsCollector* g_vars;
 
-DEFINE_string(health_check_path, "", "Http path of health check call."
-        "By default health check succeeds if the server is connectable."
-        "If this flag is set, health check is not completed until a http "
-        "call to the path succeeds within -health_check_timeout_ms(to make "
-        "sure the server functions well).");
-DEFINE_int32(health_check_timeout_ms, 500, "The timeout for both establishing "
-        "the connection and the http call to -health_check_path over the connection");
-
 class HealthCheckChannel : public brpc::Channel {
 public:
     HealthCheckChannel() {}
@@ -65,6 +57,8 @@ public:
     SocketId id;
     int64_t interval_s;
     int64_t last_check_time_ms;
+    int32_t health_check_timeout_ms;
+    std::string health_check_path;
 };
 
 class HealthCheckManager {
@@ -81,15 +75,17 @@ void HealthCheckManager::StartCheck(SocketId id, int64_t check_interval_s) {
                  << " was abandoned during health checking";
         return;
     }
-    LOG(INFO) << "Checking path=" << ptr->remote_side() << FLAGS_health_check_path;
+    LOG(INFO) << "Checking path=" << ptr->remote_side() << ptr->health_check_path();
     OnAppHealthCheckDone* done = new OnAppHealthCheckDone;
     done->id = id;
     done->interval_s = check_interval_s;
+    done->health_check_timeout_ms = ptr->health_check_timeout_ms();
+    done->health_check_path = ptr->health_check_path();
     brpc::ChannelOptions options;
     options.protocol = PROTOCOL_HTTP;
     options.max_retry = 0;
     options.timeout_ms =
-        std::min((int64_t)FLAGS_health_check_timeout_ms, check_interval_s * 1000);
+        std::min((int64_t)(done->health_check_timeout_ms), check_interval_s * 1000);
     if (done->channel.Init(id, &options) != 0) {
         LOG(WARNING) << "Fail to init health check channel to SocketId=" << id;
         ptr->_ninflight_app_health_check.fetch_sub(
@@ -103,7 +99,7 @@ void HealthCheckManager::StartCheck(SocketId id, int64_t check_interval_s) {
 void* HealthCheckManager::AppCheck(void* arg) {
     OnAppHealthCheckDone* done = static_cast<OnAppHealthCheckDone*>(arg);
     done->cntl.Reset();
-    done->cntl.http_request().uri() = FLAGS_health_check_path;
+    done->cntl.http_request().uri() = done->health_check_path;
     ControllerPrivateAccessor(&done->cntl).set_health_check_call();
     done->last_check_time_ms = butil::gettimeofday_ms();
     done->channel.CallMethod(NULL, &done->cntl, NULL, NULL, done);
@@ -121,14 +117,14 @@ void OnAppHealthCheckDone::Run() {
     }
     if (!cntl.Failed() || ptr->Failed()) {
         LOG_IF(INFO, !cntl.Failed()) << "Succeeded to call "
-            << ptr->remote_side() << FLAGS_health_check_path;
+            << ptr->remote_side() << health_check_path;
         // if ptr->Failed(), previous SetFailed would trigger next round
         // of hc, just return here.
         ptr->_ninflight_app_health_check.fetch_sub(
                     1, butil::memory_order_relaxed);
         return;
     }
-    RPC_VLOG << "Fail to check path=" << FLAGS_health_check_path
+    RPC_VLOG << "Fail to check path=" << health_check_path
         << ", " << cntl.ErrorText();
 
     int64_t sleep_time_ms =
@@ -206,14 +202,14 @@ bool HealthCheckTask::OnTriggeringTask(timespec* next_abstime) {
         hc = ptr->CheckHealth();
     }
     if (hc == 0) {
-        if (!FLAGS_health_check_path.empty()) {
+        if (!ptr->health_check_path().empty()) {
             ptr->_ninflight_app_health_check.fetch_add(
                     1, butil::memory_order_relaxed);
         }
         // See comments above.
         ptr->Revive(2/*note*/);
         ptr->_hc_count = 0;
-        if (!FLAGS_health_check_path.empty()) {
+        if (!ptr->health_check_path().empty()) {
             HealthCheckManager::StartCheck(_id, ptr->_health_check_interval_s);
         }
         ptr->AfterHCCompleted();

--- a/src/brpc/details/naming_service_thread.cpp
+++ b/src/brpc/details/naming_service_thread.cpp
@@ -125,8 +125,11 @@ void NamingServiceThread::Actions::ResetServers(
         //       Socket. SocketMapKey may be passed through AddWatcher. Make sure
         //       to pick those Sockets with the right settings during OnAddedServers
         const SocketMapKey key(_added[i], _owner->_options.channel_signature);
+        HealthCheckOption hc_option;
+        hc_option.health_check_timeout_ms = _owner->_options.health_check_timeout_ms;
+        hc_option.health_check_path = _owner->_options.health_check_path;
         CHECK_EQ(0, SocketMapInsert(key, &tagged_id.id, _owner->_options.ssl_ctx,
-                                    _owner->_options.use_rdma));
+                                    _owner->_options.use_rdma, hc_option));
         _added_sockets.push_back(tagged_id);
     }
 

--- a/src/brpc/details/naming_service_thread.cpp
+++ b/src/brpc/details/naming_service_thread.cpp
@@ -125,11 +125,8 @@ void NamingServiceThread::Actions::ResetServers(
         //       Socket. SocketMapKey may be passed through AddWatcher. Make sure
         //       to pick those Sockets with the right settings during OnAddedServers
         const SocketMapKey key(_added[i], _owner->_options.channel_signature);
-        HealthCheckOption hc_option;
-        hc_option.health_check_timeout_ms = _owner->_options.health_check_timeout_ms;
-        hc_option.health_check_path = _owner->_options.health_check_path;
         CHECK_EQ(0, SocketMapInsert(key, &tagged_id.id, _owner->_options.ssl_ctx,
-                                    _owner->_options.use_rdma, hc_option));
+                                    _owner->_options.use_rdma, _owner->_options.hc_option));
         _added_sockets.push_back(tagged_id);
     }
 

--- a/src/brpc/details/naming_service_thread.h
+++ b/src/brpc/details/naming_service_thread.h
@@ -45,11 +45,14 @@ struct GetNamingServiceThreadOptions {
     GetNamingServiceThreadOptions()
         : succeed_without_server(false)
         , log_succeed_without_server(true)
-        , use_rdma(false) {}
+        , use_rdma(false) 
+        , health_check_timeout_ms(500) {}
     
     bool succeed_without_server;
     bool log_succeed_without_server;
     bool use_rdma;
+    int32_t health_check_timeout_ms;
+    std::string health_check_path;
     ChannelSignature channel_signature;
     std::shared_ptr<SocketSSLContext> ssl_ctx;
 };

--- a/src/brpc/details/naming_service_thread.h
+++ b/src/brpc/details/naming_service_thread.h
@@ -45,14 +45,12 @@ struct GetNamingServiceThreadOptions {
     GetNamingServiceThreadOptions()
         : succeed_without_server(false)
         , log_succeed_without_server(true)
-        , use_rdma(false) 
-        , health_check_timeout_ms(500) {}
+        , use_rdma(false) {}
     
     bool succeed_without_server;
     bool log_succeed_without_server;
     bool use_rdma;
-    int32_t health_check_timeout_ms;
-    std::string health_check_path;
+    HealthCheckOption hc_option;
     ChannelSignature channel_signature;
     std::shared_ptr<SocketSSLContext> ssl_ctx;
 };

--- a/src/brpc/health_check_option.h
+++ b/src/brpc/health_check_option.h
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef  BRPC_HEALTH_CHECK_OPTION_H
+#define  BRPC_HEALTH_CHECK_OPTION_H
+
+#include <string>
+
+namespace brpc {
+
+struct HealthCheckOption {
+    // Http path of health check call
+    std::string health_check_path;
+    // The timeout for both establishing the connection and the http call to health_check_path over the connection
+    int32_t health_check_timeout_ms{500};
+};
+
+}  // namespace brpc
+
+#endif  // BRPC_HEALTH_CHECK_OPTION_H

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -742,8 +742,7 @@ int Socket::OnCreated(const SocketOptions& options) {
     reset_parsing_context(options.initial_parsing_context);
     _correlation_id = 0;
     _health_check_interval_s = options.health_check_interval_s;
-    _health_check_path =  options.hc_option.health_check_path;
-    _health_check_timeout_ms = options.hc_option.health_check_timeout_ms;
+    _hc_option = options.hc_option;
     _is_hc_related_ref_held = false;
     _hc_started.store(false, butil::memory_order_relaxed);
     _ninprocess.store(1, butil::memory_order_relaxed);
@@ -2594,7 +2593,7 @@ int Socket::CheckHealth() {
         LOG(INFO) << "Checking " << *this;
     }
     const timespec duetime =
-        butil::milliseconds_from_now(_health_check_timeout_ms);
+        butil::milliseconds_from_now(_hc_option.health_check_timeout_ms);
     const int connected_fd = Connect(&duetime, NULL, NULL);
     if (connected_fd >= 0) {
         ::close(connected_fd);

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -742,8 +742,8 @@ int Socket::OnCreated(const SocketOptions& options) {
     reset_parsing_context(options.initial_parsing_context);
     _correlation_id = 0;
     _health_check_interval_s = options.health_check_interval_s;
-    _health_check_path =  options.health_check_path;
-    _health_check_timeout_ms = options.health_check_timeout_ms;
+    _health_check_path =  options.hc_option.health_check_path;
+    _health_check_timeout_ms = options.hc_option.health_check_timeout_ms;
     _is_hc_related_ref_held = false;
     _hc_started.store(false, butil::memory_order_relaxed);
     _ninprocess.store(1, butil::memory_order_relaxed);

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -242,6 +242,13 @@ struct SocketKeepaliveOptions {
     int keepalive_count{-1};
 };
 
+struct HealthCheckOption {
+    // Http path of health check call
+    std::string health_check_path;
+    // The timeout for both establishing the connection and the http call to health_check_path over the connection
+    int32_t health_check_timeout_ms{500};
+};
+
 // TODO: Comment fields
 struct SocketOptions {
     // If `fd' is non-negative, set `fd' to be non-blocking and take the
@@ -266,8 +273,6 @@ struct SocketOptions {
     // one thread at any time.
     void (*on_edge_triggered_events)(Socket*){NULL};
     int health_check_interval_s{-1};
-    std::string health_check_path;
-    int32_t health_check_timeout_ms{500};
     // Only accept ssl connection.
     bool force_ssl{false};
     std::shared_ptr<SocketSSLContext> initial_ssl_ctx;
@@ -287,6 +292,7 @@ struct SocketOptions {
     int tcp_user_timeout_ms{ -1};
     // Tag of this socket
     bthread_tag_t bthread_tag{bthread_self_tag()};
+    HealthCheckOption hc_option;
 };
 
 // Abstractions on reading from and writing into file descriptors.

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -41,6 +41,7 @@
 #include "brpc/http_method.h"
 #include "brpc/event_dispatcher.h"
 #include "brpc/versioned_ref_with_id.h"
+#include "brpc/health_check_option.h"
 
 namespace brpc {
 namespace policy {
@@ -242,13 +243,6 @@ struct SocketKeepaliveOptions {
     int keepalive_count{-1};
 };
 
-struct HealthCheckOption {
-    // Http path of health check call
-    std::string health_check_path;
-    // The timeout for both establishing the connection and the http call to health_check_path over the connection
-    int32_t health_check_timeout_ms{500};
-};
-
 // TODO: Comment fields
 struct SocketOptions {
     // If `fd' is non-negative, set `fd' to be non-blocking and take the
@@ -420,9 +414,9 @@ public:
     // Initialized by SocketOptions.health_check_interval_s.
     int health_check_interval() const { return _health_check_interval_s; }
 
-    const std::string& health_check_path() const { return _health_check_path; }
+    const std::string& health_check_path() const { return _hc_option.health_check_path; }
 
-    int32_t health_check_timeout_ms() const {return _health_check_timeout_ms; }
+    int32_t health_check_timeout_ms() const {return _hc_option.health_check_timeout_ms; }
 
     // True if health checking is enabled.
     bool HCEnabled() const {
@@ -992,8 +986,7 @@ private:
     int _tcp_user_timeout_ms;
 
     HttpMethod _http_request_method;
-    std::string _health_check_path;
-    int32_t _health_check_timeout_ms{500};
+    HealthCheckOption _hc_option;
 };
 
 } // namespace brpc

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -266,6 +266,8 @@ struct SocketOptions {
     // one thread at any time.
     void (*on_edge_triggered_events)(Socket*){NULL};
     int health_check_interval_s{-1};
+    std::string health_check_path;
+    int32_t health_check_timeout_ms{500};
     // Only accept ssl connection.
     bool force_ssl{false};
     std::shared_ptr<SocketSSLContext> initial_ssl_ctx;
@@ -411,6 +413,10 @@ public:
 
     // Initialized by SocketOptions.health_check_interval_s.
     int health_check_interval() const { return _health_check_interval_s; }
+
+    const std::string& health_check_path() const { return _health_check_path; }
+
+    int32_t health_check_timeout_ms() const {return _health_check_timeout_ms; }
 
     // True if health checking is enabled.
     bool HCEnabled() const {
@@ -980,6 +986,8 @@ private:
     int _tcp_user_timeout_ms;
 
     HttpMethod _http_request_method;
+    std::string _health_check_path;
+    int32_t _health_check_timeout_ms{500};
 };
 
 } // namespace brpc

--- a/src/brpc/socket_map.cpp
+++ b/src/brpc/socket_map.cpp
@@ -251,8 +251,7 @@ int SocketMap::Insert(const SocketMapKey& key, SocketId* id,
     opt.remote_side = key.peer.addr;
     opt.initial_ssl_ctx = ssl_ctx;
     opt.use_rdma = use_rdma;
-    opt.health_check_path = hc_option.health_check_path;
-    opt.health_check_timeout_ms = hc_option.health_check_timeout_ms;
+    opt.hc_option = hc_option;
     if (_options.socket_creator->CreateSocket(opt, &tmp_id) != 0) {
         PLOG(FATAL) << "Fail to create socket to " << key.peer;
         return -1;

--- a/src/brpc/socket_map.h
+++ b/src/brpc/socket_map.h
@@ -44,11 +44,6 @@ inline bool operator!=(const ChannelSignature& s1, const ChannelSignature& s2) {
     return !(s1 == s2);
 }
 
-struct HealthCheckOption {
-    std::string health_check_path;
-    int32_t health_check_timeout_ms = 500;
-};
-
 // The following fields uniquely define a Socket. In other word,
 // Socket can't be shared between 2 different SocketMapKeys
 struct SocketMapKey {

--- a/src/brpc/socket_map.h
+++ b/src/brpc/socket_map.h
@@ -44,6 +44,11 @@ inline bool operator!=(const ChannelSignature& s1, const ChannelSignature& s2) {
     return !(s1 == s2);
 }
 
+struct HealthCheckOption {
+    std::string health_check_path;
+    int32_t health_check_timeout_ms = 500;
+};
+
 // The following fields uniquely define a Socket. In other word,
 // Socket can't be shared between 2 different SocketMapKeys
 struct SocketMapKey {
@@ -81,16 +86,19 @@ struct SocketMapKeyHasher {
 // Return 0 on success, -1 otherwise.
 int SocketMapInsert(const SocketMapKey& key, SocketId* id,
                     const std::shared_ptr<SocketSSLContext>& ssl_ctx,
-                    bool use_rdma);
+                    bool use_rdma,
+                    const HealthCheckOption& hc_option);
 
 inline int SocketMapInsert(const SocketMapKey& key, SocketId* id,
                     const std::shared_ptr<SocketSSLContext>& ssl_ctx) {
-    return SocketMapInsert(key, id, ssl_ctx, false);
+    HealthCheckOption hc_option;
+    return SocketMapInsert(key, id, ssl_ctx, false, hc_option);
 }
 
 inline int SocketMapInsert(const SocketMapKey& key, SocketId* id) {
     std::shared_ptr<SocketSSLContext> empty_ptr;
-    return SocketMapInsert(key, id, empty_ptr, false);
+    HealthCheckOption hc_option;
+    return SocketMapInsert(key, id, empty_ptr, false, hc_option);
 }
 
 // Find the SocketId associated with `key'.
@@ -151,14 +159,18 @@ public:
     int Init(const SocketMapOptions&);
     int Insert(const SocketMapKey& key, SocketId* id,
                const std::shared_ptr<SocketSSLContext>& ssl_ctx,
-               bool use_rdma);
+               bool use_rdma,
+               const HealthCheckOption& hc_option);
+
     int Insert(const SocketMapKey& key, SocketId* id,
                const std::shared_ptr<SocketSSLContext>& ssl_ctx) {
-        return Insert(key, id, ssl_ctx, false);   
+        HealthCheckOption hc_option;
+        return Insert(key, id, ssl_ctx, false, hc_option);   
     }
     int Insert(const SocketMapKey& key, SocketId* id) {
         std::shared_ptr<SocketSSLContext> empty_ptr;
-        return Insert(key, id, empty_ptr, false);
+        HealthCheckOption hc_option;
+        return Insert(key, id, empty_ptr, false, hc_option);
     }
 
     void Remove(const SocketMapKey& key, SocketId expected_id);

--- a/test/brpc_load_balancer_unittest.cpp
+++ b/test/brpc_load_balancer_unittest.cpp
@@ -981,7 +981,7 @@ TEST_F(LoadBalancerTest, weighted_randomized) {
     brpc::SocketUniquePtr ptr;
     brpc::LoadBalancer::SelectIn in = { 0, false, false, 0u, NULL };
     brpc::LoadBalancer::SelectOut out(&ptr);
-    int run_times = configed_weight_sum * 10;
+    int run_times = configed_weight_sum * 100;
     std::vector<butil::EndPoint> select_servers;
     for (int i = 0; i < run_times; ++i) {
         EXPECT_EQ(0, wrlb.SelectServer(in, &out));


### PR DESCRIPTION
### What problem does this PR solve?
**Current Application-Layer Health Check Mechanism**
The current application-layer health check mechanism is configured via the -health_check_path flag. If this flag is left empty, the health check is disabled. However, since gflag is a global variable, once set, it enables the application-layer health check for all downstream services accessed by the service.

For complex services that may interact with dozens or even hundreds of downstream services (some of which might not be brpc-based and could instead be Go/Java services), not all downstream services necessarily support health check requests. Even for those that do, the health check request paths (URLs) may vary across services. Therefore, it is necessary to support channel-level configuration for application-layer health check parameters.

Issue Number:

Problem Summary:

### What is changed and the side effects?
no

Changed:
**About This PR**
This PR maintains backward compatibility with the existing gflag-based configuration for health check paths and timeouts while introducing support for setting health check parameters via members of ChannelOptions (hc_option). Parameters in ChannelOptions (hc_option) take precedence over the global gflag settings. If a parameter is not specified in ChannelOptions, the corresponding gflag value will be used as the fallback.

Side effects:
- Performance effects:  no
- Breaking backward compatibility:  no
---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
