### PR TITLE
bugfix: extend block pool runtime

### DIFF
--- a/src/brpc/rdma/block_pool.h
+++ b/src/brpc/rdma/block_pool.h
@@ -73,7 +73,15 @@ typedef uint32_t (*RegisterCallback)(void*, size_t);
 // region. It should be the memory registration in brpc. However,
 // in block_pool, we just abstract it into a function to get region id.
 // Return the first region's address, NULL if failed and errno is set.
-void* InitBlockPool(RegisterCallback cb);
+bool InitBlockPool(RegisterCallback cb);
+
+// In scenarios where users need to manually specify memory regions (e.g., using
+// hugepages or custom memory pools), when
+// FLAGS_rdma_memory_pool_user_specified_memory is true, user is  responsibility
+// of extending memory blocks , this ensuring flexibility for advanced use
+// cases.
+void* ExtendBlockPoolByUser(void* region_base, size_t region_size,
+                            int block_type);
 
 // Allocate a buf with length at least @a size (require: size>0)
 // Return the address allocated, NULL if failed and errno is set.

--- a/src/brpc/rdma/rdma_helper.cpp
+++ b/src/brpc/rdma/rdma_helper.cpp
@@ -168,6 +168,11 @@ static void GlobalRelease() {
     }
 }
 
+void* UserExtendBlockPool(void* region_base, size_t region_size,
+                          int block_type) {
+    return ExtendBlockPoolByUser(region_base, region_size, block_type);
+}
+
 uint32_t RdmaRegisterMemory(void* buf, size_t size) {
     // Register the memory as callback in block_pool
     // The thread-safety should be guaranteed by the caller

--- a/test/brpc_block_pool_unittest.cpp
+++ b/test/brpc_block_pool_unittest.cpp
@@ -54,7 +54,7 @@ TEST_F(BlockPoolTest, single_thread) {
     FLAGS_rdma_memory_pool_increase_size_mb = 1024;
     FLAGS_rdma_memory_pool_max_regions = 16;
     FLAGS_rdma_memory_pool_buckets = 4;
-    EXPECT_TRUE(InitBlockPool(DummyCallback) != NULL);
+    EXPECT_TRUE(InitBlockPool(DummyCallback));
 
     size_t num = 1024;
     void* buf[num];
@@ -108,7 +108,7 @@ TEST_F(BlockPoolTest, multiple_thread) {
     FLAGS_rdma_memory_pool_increase_size_mb = 1024;
     FLAGS_rdma_memory_pool_max_regions = 16;
     FLAGS_rdma_memory_pool_buckets = 4;
-    EXPECT_TRUE(InitBlockPool(DummyCallback) != NULL);
+    EXPECT_TRUE(InitBlockPool(DummyCallback));
 
     uintptr_t thread_num = 32;
     bthread_t tid[thread_num];
@@ -130,7 +130,7 @@ TEST_F(BlockPoolTest, extend) {
     FLAGS_rdma_memory_pool_increase_size_mb = 64;
     FLAGS_rdma_memory_pool_max_regions = 16;
     FLAGS_rdma_memory_pool_buckets = 1;
-    EXPECT_TRUE(InitBlockPool(DummyCallback) != NULL);
+    EXPECT_TRUE(InitBlockPool(DummyCallback));
 
     EXPECT_EQ(1, GetRegionNum());
     size_t num = 15 * 64 * 1024 * 1024 / GetBlockSize(2);
@@ -153,7 +153,7 @@ TEST_F(BlockPoolTest, memory_not_enough) {
     FLAGS_rdma_memory_pool_increase_size_mb = 64;
     FLAGS_rdma_memory_pool_max_regions = 2;
     FLAGS_rdma_memory_pool_buckets = 1;
-    EXPECT_TRUE(InitBlockPool(DummyCallback) != NULL);
+    EXPECT_TRUE(InitBlockPool(DummyCallback));
 
     EXPECT_EQ(1, GetRegionNum());
     size_t num = 64 * 1024 * 1024 / GetBlockSize(2);
@@ -179,7 +179,7 @@ TEST_F(BlockPoolTest, invalid_use) {
     FLAGS_rdma_memory_pool_increase_size_mb = 64;
     FLAGS_rdma_memory_pool_max_regions = 2;
     FLAGS_rdma_memory_pool_buckets = 1;
-    EXPECT_TRUE(InitBlockPool(DummyCallback) != NULL);
+    EXPECT_TRUE(InitBlockPool(DummyCallback));
 
     void* buf = AllocBlock(0);
     EXPECT_EQ(NULL, buf);
@@ -201,7 +201,7 @@ TEST_F(BlockPoolTest, dump_info) {
     FLAGS_rdma_memory_pool_increase_size_mb = 64;
     FLAGS_rdma_memory_pool_max_regions = 2;
     FLAGS_rdma_memory_pool_buckets = 4;
-    EXPECT_TRUE(InitBlockPool(DummyCallback) != NULL);
+    EXPECT_TRUE(InitBlockPool(DummyCallback));
     DumpMemoryPoolInfo(std::cout);
     void* buf = AllocBlock(8192);
     DumpMemoryPoolInfo(std::cout);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

rdma block pool runtime ExtendBlockPool has some error:
1. a region may has many buckets, extend a region not hold all bucket locks, will case race condition, disable runtime extend a region when buckets greater than 1.
2. when new region created, link the region to idle_list case link list break.
3. add feature, in scenarios where users need to manually specify memory regions (e.g., using hugepages or custom memory pools), when FLAGS_rdma_memory_pool_user_specified_memory is true, user is  responsibility of extending memory blocks , this ensuring flexibility for advanced use cases.
### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
