### PR TITLE
Fix libunwind linked by default on x86_64 cpu when building via bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,7 +51,7 @@ COPTS = [
     "//bazel/config:brpc_with_debug_lock": ["-DBRPC_DEBUG_LOCK=1"],
     "//conditions:default": ["-DBRPC_DEBUG_LOCK=0"],
 }) + select({
-    "@platforms//cpu:x86_64": ["-DBRPC_BTHREAD_TRACER"],
+    "//bazel/config:brpc_with_bthread_tracer": ["-DBRPC_BTHREAD_TRACER"],
     "//conditions:default": [],
 }) + select({
     "//bazel/config:brpc_with_asan": ["-fsanitize=address"],
@@ -412,7 +412,7 @@ cc_library(
         ":butil",
         ":bvar",
     ] + select({
-        "@platforms//cpu:x86_64": ["@com_github_libunwind_libunwind//:libunwind"],
+        "//bazel/config:brpc_with_bthread_tracer": ["@com_github_libunwind_libunwind//:libunwind"],
         "//conditions:default": [],
     }),
 )

--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -127,3 +127,13 @@ config_setting(
     define_values = {"with_asan": "true"},
     visibility = ["//visibility:public"],
 )
+
+config_setting(
+    name = "brpc_with_bthread_tracer",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+    ],
+    define_values = {
+        "with_bthread_tracer": "true",
+    },
+)

--- a/docs/cn/getting_started.md
+++ b/docs/cn/getting_started.md
@@ -392,7 +392,7 @@ brpc会自动检测valgrind（然后注册bthread的栈）。不支持老版本�
 
 ## libunwind: 1.3-1.8.1
 
-bRPC默认**不**链接 [libunwind](https://github.com/libunwind/libunwind)。用户需要追踪bthread功能则链接libunwind，可以给config_brpc.sh增加`--with-bthread-tracer`选项或者给cmake增加`-DWITH_BTHREAD_TRACER=ON`选项。
+bRPC默认**不**链接 [libunwind](https://github.com/libunwind/libunwind)。用户需要追踪bthread功能则链接libunwind，可以给config_brpc.sh增加`--with-bthread-tracer`选项或者给cmake增加`-DWITH_BTHREAD_TRACER=ON`选项，如果是用 bazel 构建，请添加 `--define with_bthread_tracer=true` 选项。
 
 建议使用最新版本的libunwind。
 

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -385,7 +385,7 @@ brpc detects valgrind automatically (and registers stacks of bthread). Older val
 
 ## libunwind: 1.3-1.8.1
 
-brpc does **not** link [libunwind](https://github.com/libunwind/libunwind) by default. Users link libunwind on-demand by adding `--with-glog` to config_brpc.sh or adding `-DWITH_GLOG=ON` to cmake.
+brpc does **not** link [libunwind](https://github.com/libunwind/libunwind) by default. Users link libunwind on-demand by adding `--with-bthread-tracer` to config_brpc.sh or adding `-DWITH_BTHREAD_TRACER=ON` to cmake.
 
 It is recommended to use the latest possible version of libunwind.
 

--- a/docs/en/getting_started.md
+++ b/docs/en/getting_started.md
@@ -385,7 +385,7 @@ brpc detects valgrind automatically (and registers stacks of bthread). Older val
 
 ## libunwind: 1.3-1.8.1
 
-brpc does **not** link [libunwind](https://github.com/libunwind/libunwind) by default. Users link libunwind on-demand by adding `--with-bthread-tracer` to config_brpc.sh or adding `-DWITH_BTHREAD_TRACER=ON` to cmake.
+brpc does **not** link [libunwind](https://github.com/libunwind/libunwind) by default. Users link libunwind on-demand by adding `--with-bthread-tracer` to config_brpc.sh or adding `-DWITH_BTHREAD_TRACER=ON` to cmake, if building with Bazel, please add the `--define with_bthread_tracer=true` option.
 
 It is recommended to use the latest possible version of libunwind.
 


### PR DESCRIPTION
### What problem does this PR solve?

Fix libunwind linked by default on x86_64 cpu when building via bazel.

Issue Number:

Problem Summary:

libunwind is linked by default on x86_64 cpu when build via bazel, even though the user did not specify any flags.

### What is changed and the side effects?

Changed: 

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
