### PR TITLE
Fix UT compilation errors with GCC 13 due to missing <cstdint> includes

### DIFF
--- a/src/bthread/list_of_abafree_id.h
+++ b/src/bthread/list_of_abafree_id.h
@@ -24,7 +24,7 @@
 
 #include <deque>
 #include <vector>
-
+#include <cstdint>
 #include "butil/macros.h"
 
 namespace bthread {

--- a/test/baidu_thread_local_unittest.cpp
+++ b/test/baidu_thread_local_unittest.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <errno.h>
+#include <cstdint>
 #include "butil/thread_local.h"
 
 namespace {


### PR DESCRIPTION
GCC 13 no longer transitively includes <cstdint> from other standard library headers. This causes compilation failures for code using types like uint32_t and uintptr_t without explicitly including <cstdint>.

This commit Fix UT compilation errors with GCC 13 due to missing <cstdint> includes

The errors were:
- error: 'uintptr_t' was not declared in this scope
- error: 'uint32_t' does not name a type

This change ensures compatibility with GCC 13 while maintaining backward compatibility with older compiler versions.

Reference: https://gcc.gnu.org/gcc-13/porting_to.html

### What problem does this PR solve?

cmake building error under gcc13.3

```
 cmake -B build -DBUILD_UNIT_TESTS=ON && cmake --build build -j16
```


```
/home/yxc/code/2505/brpc/test/baidu_thread_local_unittest.cpp: In function ‘void {anonymous}::fun3(void*)’:
/home/yxc/code/2505/brpc/test/baidu_thread_local_unittest.cpp:169:30: error: ‘uintptr_t’ was not declared in this scope
  169 |     get_oss() << "fun3(" << (uintptr_t)arg << ")" << std::endl;
      |                              ^~~~~~~~~
/home/yxc/code/2505/brpc/test/baidu_thread_local_unittest.cpp:21:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   20 | #include "butil/thread_local.h"
  +++ |+#include <cstdint>
   21 |
/home/yxc/code/2505/brpc/test/baidu_thread_local_unittest.cpp: In function ‘void {anonymous}::fun4(void*)’:
/home/yxc/code/2505/brpc/test/baidu_thread_local_unittest.cpp:173:30: error: ‘uintptr_t’ was not declared in this scope
  173 |     get_oss() << "fun4(" << (uintptr_t)arg << ")" << std::endl;
      |                              ^~~~~~~~~
```

```
In file included from /home/yxc/code/2505/brpc/test/abalist_unittest.cc:9:
/home/yxc/code/2505/brpc/src/bthread/list_of_abafree_id.h:94:9: error: ‘uint32_t’ does not name a type
   94 |         uint32_t index;
      |         ^~~~~~~~
/home/yxc/code/2505/brpc/src/bthread/list_of_abafree_id.h:29:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   28 | #include "butil/macros.h"
  +++ |+#include <cstdint>
   29 |
/home/yxc/code/2505/brpc/src/bthread/list_of_abafree_id.h:95:9: error: ‘uint32_t’ does not name a type
   95 |         uint32_t nblock;
      |         ^~~~~~~~

```


### What is changed and the side effects?

Changed:

 adds the missing #include <cstdint> directives to:
- test/baidu_thread_local_unittest.cpp
- src/bthread/list_of_abafree_id.h


