### PR TITLE
Optimize shared_ptr assignment in DoublyBufferedData

### DIFF
--- a/src/butil/containers/doubly_buffered_data.h
+++ b/src/butil/containers/doubly_buffered_data.h
@@ -484,17 +484,15 @@ int DoublyBufferedData<T, TLS, AllowBthreadSuspended>::Read(
         // foreground instance, so during the read process, there is
         // no need to lock mutex and bthread is allowed to be suspended.
         w->BeginRead();
-        int index = -1;
-        ptr->_data = UnsafeRead(index);
-        ptr->_index = index;
-        w->AddRef(index);
-        ptr->_w = w;
+        // UnsafeRead will update ptr->_index
+        ptr->_data = UnsafeRead(ptr->_index);
+        w->AddRef(ptr->_index);
         w->BeginReadRelease();
     } else {
         w->BeginRead();
         ptr->_data = UnsafeRead();
-        ptr->_w = w;
     }
+    ptr->_w.swap(w);
     return 0;
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Replaces std::shared_ptr copy assignment with swap in DoublyBufferedData to avoid unnecessary reference count manipulation.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
