### PR TITLE
Fix race condition that causes TimerThread to hang during shutdown

### DIFF
--- a/src/bthread/timer_thread.cpp
+++ b/src/bthread/timer_thread.cpp
@@ -347,9 +347,9 @@ void TimerThread::run() {
         // would run the consumed tasks.
         {
             BAIDU_SCOPED_LOCK(_mutex);
-            if (__builtin_expect(_nearest_run_time == -1, 0)) {
-                // If _nearest_run_time is -1, it means that stop_and_join() was called
-                CHECK(_stop.load(butil::memory_order_relaxed));
+            // This check of _stop ensures we won't miss the reset of _nearest_run_time
+            // to 0 in stop_and_join, avoiding potential race conditions.
+            if (BAIDU_UNLIKELY(_stop.load(butil::memory_order_relaxed))) {
                 break;
             }
             _nearest_run_time = std::numeric_limits<int64_t>::max();
@@ -447,7 +447,7 @@ void TimerThread::stop_and_join() {
         {
             BAIDU_SCOPED_LOCK(_mutex);
              // trigger pull_again and wakeup TimerThread
-            _nearest_run_time = -1;
+            _nearest_run_time = 0;
             ++_nsignals;
         }
         if (pthread_self() != _thread) {

--- a/src/bthread/timer_thread.cpp
+++ b/src/bthread/timer_thread.cpp
@@ -347,8 +347,8 @@ void TimerThread::run() {
         // would run the consumed tasks.
         {
             BAIDU_SCOPED_LOCK(_mutex);
-            if (__builtin_expect(_nearest_run_time == 0, 0)) {
-                // If _nearest_run_time is 0, it means that stop_and_join() was called
+            if (__builtin_expect(_nearest_run_time == -1, 0)) {
+                // If _nearest_run_time is -1, it means that stop_and_join() was called
                 CHECK(_stop.load(butil::memory_order_relaxed));
                 break;
             }
@@ -447,7 +447,7 @@ void TimerThread::stop_and_join() {
         {
             BAIDU_SCOPED_LOCK(_mutex);
              // trigger pull_again and wakeup TimerThread
-            _nearest_run_time = 0;
+            _nearest_run_time = -1;
             ++_nsignals;
         }
         if (pthread_self() != _thread) {

--- a/src/bthread/timer_thread.cpp
+++ b/src/bthread/timer_thread.cpp
@@ -347,6 +347,11 @@ void TimerThread::run() {
         // would run the consumed tasks.
         {
             BAIDU_SCOPED_LOCK(_mutex);
+            if (__builtin_expect(_nearest_run_time == 0, 0)) {
+                // If _nearest_run_time is 0, it means that stop_and_join() was called
+                CHECK(_stop.load(butil::memory_order_relaxed));
+                break;
+            }
             _nearest_run_time = std::numeric_limits<int64_t>::max();
         }
         


### PR DESCRIPTION
### What problem does this PR solve?

### Problem Summary:

During shutdown, `stop_and_join()` sets `_stop = true`, sets `_nearest_run_time = 0`, and calls `futex_wake_private()` to wake up the timer thread. However, due to a race condition, the timer thread may:

1. See `_stop == false` and enter the loop.
2. Block on acquiring `_mutex` while `stop_and_join()` holds it.
3. After `stop_and_join()` releases the mutex, the timer thread acquires it and sets `_nearest_run_time = int64_max`, **overwriting the earlier** `_nearest_run_time = 0`.
4. Miss the wake-up signal because at the time `stop_and_join()` called `futex_wake_private()`, the timer thread had not yet entered futex wait.

As a result, after finishing all remaining tasks, the timer thread may enter futex wait **with no further wake-up**, causing the program to hang on `pthread_join`.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
