### PR TITLE
fix: Specifying the global namespace for bind and connect

### DIFF
--- a/src/butil/endpoint.cpp
+++ b/src/butil/endpoint.cpp
@@ -52,7 +52,7 @@ DEFINE_bool(reuse_uds_path, false, "remove unix domain socket file before listen
 __BEGIN_DECLS
 int BAIDU_WEAK bthread_connect(
     int sockfd, const struct sockaddr *serv_addr, socklen_t addrlen) {
-    return connect(sockfd, serv_addr, addrlen);
+    return ::connect(sockfd, serv_addr, addrlen);
 }
 
 int BAIDU_WEAK bthread_timed_connect(
@@ -577,7 +577,7 @@ int tcp_listen(EndPoint point) {
         ::unlink(((sockaddr_un*) &serv_addr)->sun_path);
     }
 
-    if (bind(sockfd, (struct sockaddr*)& serv_addr, serv_addr_size) != 0) {
+    if (::bind(sockfd, (struct sockaddr*)& serv_addr, serv_addr_size) != 0) {
         return -1;
     }
     if (listen(sockfd, 65535) != 0) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary: fix compile error in endpoint.cpp
**compile tools**: gcc 5.2 and bazel 7.2.0

![image](https://github.com/user-attachments/assets/b1b91c4f-5218-46f0-8e5c-0264ce95b7e5)
![image](https://github.com/user-attachments/assets/a64bb792-516f-4685-9347-36371bde14d8)


### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
