### PR TITLE
Bugfix: bthread_worker_usage could exceed bthread_worker_count

### DIFF
--- a/src/brpc/load_balancer.h
+++ b/src/brpc/load_balancer.h
@@ -184,13 +184,6 @@ inline Extension<const LoadBalancer>* LoadBalancerExtension() {
     return Extension<const LoadBalancer>::instance();
 }
 
-inline uint32_t GenRandomStride() {
-    uint32_t prime_offset[] = {
-        #include "bthread/offset_inl.list"
-    };
-    return prime_offset[butil::fast_rand_less_than(ARRAY_SIZE(prime_offset))];
-}
-
 } // namespace brpc
 
 

--- a/src/brpc/policy/randomized_load_balancer.cpp
+++ b/src/brpc/policy/randomized_load_balancer.cpp
@@ -18,6 +18,7 @@
 
 #include "butil/macros.h"
 #include "butil/fast_rand.h"
+#include "bthread/prime_offset.h"
 #include "brpc/socket.h"
 #include "brpc/policy/randomized_load_balancer.h"
 #include "butil/strings/string_number_conversions.h"
@@ -118,7 +119,7 @@ int RandomizedLoadBalancer::SelectServer(const SelectIn& in, SelectOut* out) {
             return 0;
         }
         if (stride == 0) {
-            stride = GenRandomStride();
+            stride = bthread::prime_offset();
         }
         // If `Address' failed, use `offset+stride' to retry so that
         // this failed server won't be visited again inside for

--- a/src/brpc/policy/round_robin_load_balancer.cpp
+++ b/src/brpc/policy/round_robin_load_balancer.cpp
@@ -18,6 +18,7 @@
 
 #include "butil/macros.h"
 #include "butil/fast_rand.h"
+#include "bthread/prime_offset.h"
 #include "brpc/socket.h"
 #include "brpc/policy/round_robin_load_balancer.h"
 
@@ -108,7 +109,7 @@ int RoundRobinLoadBalancer::SelectServer(const SelectIn& in, SelectOut* out) {
     }
     TLS tls = s.tls();
     if (tls.stride == 0) {
-        tls.stride = GenRandomStride();
+        tls.stride = bthread::prime_offset();
         // use random at first time, for the case of
         // use rr lb every time in new thread
         tls.offset = butil::fast_rand_less_than(n);

--- a/src/brpc/policy/weighted_randomized_load_balancer.cpp
+++ b/src/brpc/policy/weighted_randomized_load_balancer.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 
 #include "butil/fast_rand.h"
+#include "bthread/prime_offset.h"
 #include "brpc/socket.h"
 #include "brpc/policy/weighted_randomized_load_balancer.h"
 #include "butil/strings/string_number_conversions.h"
@@ -152,7 +153,7 @@ int WeightedRandomizedLoadBalancer::SelectServer(const SelectIn& in, SelectOut* 
     if (random_traversed.size() == n) {
         // Try to traverse the remaining servers to find an available server.
         uint32_t offset = butil::fast_rand_less_than(n);
-        uint32_t stride = GenRandomStride();
+        uint32_t stride = bthread::prime_offset();
         for (size_t i = 0; i < n; ++i) {
             offset = (offset + stride) % n;
             SocketId id = s->server_list[offset].id;

--- a/src/bthread/prime_offset.h
+++ b/src/bthread/prime_offset.h
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef BTHREAD_PRIME_OFFSET_H
+#define BTHREAD_PRIME_OFFSET_H
+
+#include "butil/fast_rand.h"
+#include "butil/macros.h"
+
+namespace bthread {
+// Prime number offset for hash function.
+inline size_t prime_offset(size_t seed) {
+    uint32_t offsets[] = {
+        #include "bthread/offset_inl.list"
+    };
+    return offsets[seed % ARRAY_SIZE(offsets)];
+}
+
+inline size_t prime_offset() {
+    return prime_offset(butil::fast_rand());
+}
+}
+
+
+#endif // BTHREAD_PRIME_OFFSET_H

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -33,13 +33,6 @@
 #include "bthread/timer_thread.h"         // global_timer_thread
 #include <gflags/gflags.h>
 #include "bthread/log.h"
-#ifdef __x86_64__
-#include <x86intrin.h>
-#endif // __x86_64__
-
-#ifdef __ARM_NEON
-#include <arm_neon.h>
-#endif // __ARM_NEON
 
 DEFINE_int32(task_group_delete_delay, 1,
              "delay deletion of TaskGroup for so many seconds");

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -80,7 +80,6 @@ public:
 
     double get_cumulated_worker_time();
     double get_cumulated_worker_time(bthread_tag_t tag);
-    double get_cumulated_worker_time(TaskGroup* g);
     int64_t get_cumulated_switch_count();
     int64_t get_cumulated_signal_count();
 

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -79,7 +79,8 @@ public:
     void print_rq_sizes(std::ostream& os);
 
     double get_cumulated_worker_time();
-    double get_cumulated_worker_time_with_tag(bthread_tag_t tag);
+    double get_cumulated_worker_time(bthread_tag_t tag);
+    double get_cumulated_worker_time(TaskGroup* g);
     int64_t get_cumulated_switch_count();
     int64_t get_cumulated_signal_count();
 
@@ -160,9 +161,6 @@ private:
     std::vector<WorkStealingQueue<bthread_t>> _priority_queues;
 
     std::vector<TaggedParkingLot> _pl;
-
-    // The last time of getting cumulated time.
-    int64_t _last_get_cumulated_time_ns;
 
 #ifdef BRPC_BTHREAD_TRACER
     TaskTracer _task_tracer;

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -161,6 +161,9 @@ private:
 
     std::vector<TaggedParkingLot> _pl;
 
+    // The last time of getting cumulated time.
+    int64_t _last_get_cumulated_time_ns;
+
 #ifdef BRPC_BTHREAD_TRACER
     TaskTracer _task_tracer;
 #endif // BRPC_BTHREAD_TRACER

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -48,6 +48,35 @@ private:
     void* _value;
 };
 
+// Refer to https://rigtorp.se/isatomic/, On the modern CPU microarchitectures
+// (Skylake and Zen 2) AVX/AVX2 128b/256b aligned loads and stores are atomic
+// even though Intel and AMD officially doesn’t guarantee this.
+// On X86, SSE instructions can ensure atomic loads and stores.
+// Starting from Armv8.4-A, neon can ensure atomic loads and stores.
+// Otherwise, use mutex to guarantee atomicity.
+class AtomicInteger128 {
+public:
+    struct Value {
+        int64_t v1;
+        int64_t v2;
+    };
+
+    AtomicInteger128() = default;
+    explicit AtomicInteger128(Value value) : _value(value) {}
+
+    Value load() const;
+    Value load_unsafe() const {
+        return _value;
+    }
+
+    void store(Value value);
+
+private:
+    Value BAIDU_CACHELINE_ALIGNMENT _value{};
+    // Used to protect `_cpu_time_stat' when __x86_64__ and __ARM_NEON is not defined.
+    FastPthreadMutex _mutex;
+};
+
 // Thread-local group of tasks.
 // Notice that most methods involving context switching are static otherwise
 // pointer `this' may change after wakeup. The **pg parameters in following
@@ -149,9 +178,7 @@ public:
     { return _cur_meta->stack == _main_stack; }
 
     // Active time in nanoseconds spent by this TaskGroup.
-    int64_t cumulated_cputime_ns() const {
-        return _cpu_time_stat.cumulated_cputime_ns;
-    }
+    int64_t cumulated_cputime_ns() const;
 
     // Push a bthread into the runqueue
     void ready_to_run(TaskMeta* meta, bool nosignal = false);
@@ -206,12 +233,68 @@ public:
 private:
 friend class TaskControl;
 
-    struct CPUTimeStat {
-        // Last scheduling time.
-        // If this value is negative,
-        // it means that it is the main task.
-        int64_t last_run_ns;
-        int64_t cumulated_cputime_ns;
+    // Last scheduling time, task type and cumulated CPU time.
+    class CPUTimeStat {
+        static constexpr int64_t LAST_SCHEDULING_TIME_MASK = 0x7FFFFFFFFFFFFFFFLL;
+        static constexpr int64_t TASK_TYPE_MASK = 0x8000000000000000LL;
+    public:
+        CPUTimeStat() : _last_run_ns_and_type(0), _cumulated_cputime_ns(0) {}
+        CPUTimeStat(AtomicInteger128::Value value)
+            : _last_run_ns_and_type(value.v1), _cumulated_cputime_ns(value.v2) {}
+
+        // Convert to AtomicInteger128::Value for atomic operations.
+        explicit operator AtomicInteger128::Value() const {
+            return {_last_run_ns_and_type, _cumulated_cputime_ns};
+        }
+
+        void set_last_run_ns(int64_t last_run_ns, bool main_task) {
+            _last_run_ns_and_type = (last_run_ns & LAST_SCHEDULING_TIME_MASK) |
+                                    (static_cast<int64_t>(main_task) << 63);
+        }
+        int64_t last_run_ns() const {
+            return _last_run_ns_and_type & LAST_SCHEDULING_TIME_MASK;
+        }
+        int64_t last_run_ns_and_type() const {
+            return _last_run_ns_and_type;
+        }
+
+        bool is_main_task() const {
+            return _last_run_ns_and_type & TASK_TYPE_MASK;
+        }
+
+        void add_cumulated_cputime_ns(int64_t cputime_ns, bool main_task) {
+            if (main_task) {
+                return;
+            }
+            _cumulated_cputime_ns += cputime_ns;
+        }
+        int64_t cumulated_cputime_ns() const {
+            return _cumulated_cputime_ns;
+        }
+
+    private:
+        // The higher bit for task type, main task is 1, otherwise 0.
+        // Lowest 63 bits for last scheduling time.
+        int64_t _last_run_ns_and_type;
+        // Cumulated CPU time in nanoseconds.
+        int64_t _cumulated_cputime_ns;
+    };
+
+    class AtomicCPUTimeStat {
+    public:
+        CPUTimeStat load() const {
+            return  _cpu_time_stat.load();
+        }
+        CPUTimeStat load_unsafe() const {
+            return _cpu_time_stat.load_unsafe();
+        }
+
+        void store(CPUTimeStat cpu_time_stat) {
+            _cpu_time_stat.store(AtomicInteger128::Value(cpu_time_stat));
+        }
+
+    private:
+        AtomicInteger128 _cpu_time_stat;
     };
 
     // You shall use TaskControl::create_group to create new instance.
@@ -259,15 +342,17 @@ friend class TaskControl;
 
     void set_pl(ParkingLot* pl) { _pl = pl; }
 
+    static bool is_main_task(TaskGroup* g, bthread_t tid) {
+        return g->_main_tid == tid;
+    }
+
     TaskMeta* _cur_meta{NULL};
     
     // the control that this group belongs to
     TaskControl* _control{NULL};
     int _num_nosignal{0};
     int _nsignaled{0};
-    // Used to protect `_cpu_time_stat' when __x86_64__ and __ARM_NEON is not defined.
-    FastPthreadMutex _cpu_time_stat_mutex;
-    BAIDU_CACHELINE_ALIGNMENT CPUTimeStat _cpu_time_stat{0, 0};
+    AtomicCPUTimeStat _cpu_time_stat;
     // last thread cpu clock
     int64_t _last_cpu_clock_ns{0};
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #1231 , resolve #2640 , resolve #2972

Problem Summary:

### What is changed and the side effects?

Changed:

`bthread_worker_usage` should consist of `_cumulated_cputime_ns` and the CPU time of the task currently run by the worker.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
