### PR TITLE
Bugfix: Socket without health check was abnormally recycled

### DIFF
--- a/src/brpc/selective_channel.cpp
+++ b/src/brpc/selective_channel.cpp
@@ -197,8 +197,13 @@ int ChannelBalancer::AddChannel(ChannelBase* sub_channel,
     }
     SocketUniquePtr ptr;
     int rc = Socket::AddressFailedAsWell(sock_id, &ptr);
-    if (rc < 0 || (rc > 0 && !ptr->HCEnabled())) {
-        LOG(FATAL) << "Fail to address SocketId=" << sock_id;
+    if (rc < 0) {
+        LOG(ERROR) << "Fail to address SocketId=" << sock_id;
+        return -1;
+    }
+    if (rc > 0 && !ptr->HCEnabled()) {
+        LOG(ERROR) << "Health check of SocketId="
+                   << sock_id << " is disabled";
         return -1;
     }
     if (!AddServer(ServerId(sock_id))) {

--- a/src/brpc/socket_map.h
+++ b/src/brpc/socket_map.h
@@ -177,6 +177,7 @@ public:
 private:
     void RemoveInternal(const SocketMapKey& key, SocketId id,
                         bool remove_orphan);
+    static void ReleaseReference(Socket* s);
     void ListOrphans(int64_t defer_us, std::vector<SocketMapKey>* out);
     void WatchConnections();
     static void* RunWatchConnections(void*);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #2998

Problem Summary:

When the health check is turned off, the SocketMap does not hold a reference to the Socket, so the Socket will be abnormally recycled when the connection is closed.

### What is changed and the side effects?

Changed:

Regardless of whether the health check is enabled, SocketMap must hold a reference to the socket.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
