### PR TITLE
Opt log function name

### DIFF
--- a/src/butil/logging.h
+++ b/src/butil/logging.h
@@ -326,9 +326,9 @@ public:
     virtual bool OnLogMessage(int severity, const char* file, int line,
                               const butil::StringPiece& log_content) = 0;
     virtual bool OnLogMessage(int severity, const char* file,
-                              int line, const char* func,
+                              int line, const char* /*func*/,
                               const butil::StringPiece& log_content) {
-        return true;
+        return OnLogMessage(severity, file, line, log_content);
     }
 private:
     DISALLOW_COPY_AND_ASSIGN(LogSink);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed: No need for gflag, just implement the function version of OnLogMessage to print the function name.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
