### PR TITLE
Make unit tests runnable on macOS

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -21,6 +21,11 @@ include ../config.mk
 CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -Dprivate=public -Dprotected=public -DBVAR_NOT_LINK_DEFAULT_VARIABLES --include sstream_workaround.h
 CXXFLAGS+=$(CPPFLAGS) -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -std=c++0x
 
+# On Darwin, only gtest library is needed, other libraries have been linked in `brpc.dbg.dylib`
+ifeq ($(SYSTEM),Darwin)
+  GTEST_STATIC_LINKINGS := $(filter %libgtest.a %libgtest_main.a,$(STATIC_LINKINGS))
+endif
+
 #required by butil/crc32.cc to boost performance for 10x
 ifeq ($(shell test $(GCC_VERSION) -ge 40400; echo $$?),0)
   ifeq ($(shell uname -p),i386)  #note: i386 is processor family type, not the 32-bit x86 arch
@@ -210,7 +215,7 @@ test_butil:$(TEST_BUTIL_OBJS) | libbrpc.dbg.$(SOEXT)
 ifeq ($(SYSTEM),Linux)
 	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) -Xlinker "-(" $^ -Xlinker "-)" $(STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
 else ifeq ($(SYSTEM),Darwin)
-	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) $^ $(STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
+	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) $^ $(GTEST_STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
 endif
 
 test_bvar:libbvar.dbg.a $(TEST_BVAR_OBJS)
@@ -226,7 +231,7 @@ bthread%unittest:bthread%unittest.o | libbrpc.dbg.$(SOEXT)
 ifeq ($(SYSTEM),Linux)
 	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) -Xlinker "-(" $^ -Xlinker "-)" $(STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
 else ifeq ($(SYSTEM),Darwin)
-	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) $^ $(STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
+	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) $^ $(GTEST_STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
 endif
 
 brpc_%_unittest:$(TEST_PROTO_OBJS) brpc_%_unittest.o | libbrpc.dbg.$(SOEXT)
@@ -234,7 +239,7 @@ brpc_%_unittest:$(TEST_PROTO_OBJS) brpc_%_unittest.o | libbrpc.dbg.$(SOEXT)
 ifeq ($(SYSTEM),Linux)
 	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) -Xlinker "-(" $^ -Xlinker "-)" $(STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
 else ifeq ($(SYSTEM),Darwin)
-	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) $^ $(STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
+	$(CXX) -o $@ $(LIBPATHS) $(SOPATHS) $^ $(GTEST_STATIC_LINKINGS) $(UT_DYNAMIC_LINKINGS)
 endif
 
 %.pb.cc %.pb.h:%.proto


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
When running brpc unit tests binaries (e.g., test_butil) on macOS, the program exits with an error from gflags:
```
Ignoring RegisterValidateFunction() for flag pointer 0x10961d842: no flag found at that address
```

After investigating, I found that the error occurs at the point where a validator is registered for a flag:
```
DEFINE_bool(crash_on_fatal_log, false,
            "Crash process when a FATAL log is printed");
BUTIL_VALIDATE_GFLAG(crash_on_fatal_log, butil::PassValidate);
```

Using lldb to debug the test binary, I discovered that the `DEFINE_bool` and `BUTIL_VALIDATE_GFLAG` access different instances of gflags:
- `DEFINE_bool` accesses the gflags instance in `test_butil`
- `BUTIL_VALIDATE_GFLAG` accesses the gflags instance in `libbrpc.dbg.dylib`

On macOS, the test binary links against:
- `libbrpc.dbg.dylib` (which already statically links to `libgflags.a`)
- `libgflags.a`

Because macOS uses a two-level namespace model, symbols from separate static libraries are not unified across dynamic libraries and executables. As a result, there are two isolated instances of gflags — one in the test binary, and one in the dylib. Consequently, the flag is registered in one instance, but the validator is registered in the other, leading to registration failure.

To resolve this, we should avoid linking `libgflags.a` (and other static dependencies like protobuf) into the test binary if they are already linked inside `libbrpc.dbg.dylib`. This ensures that all gflags-related macros operate on a single shared instance, and the validator registration works as expected.



### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
