### PR TITLE
Bugfix: LatencyRecorder::expose CHECK fails when save_series flag is false

### DIFF
--- a/src/bvar/latency_recorder.cpp
+++ b/src/bvar/latency_recorder.cpp
@@ -253,10 +253,12 @@ int LatencyRecorder::expose(const butil::StringPiece& prefix1,
     if (_latency_percentiles.expose_as(prefix, "latency_percentiles", DISPLAY_ON_HTML) != 0) {
         return -1;
     }
-    snprintf(namebuf, sizeof(namebuf), "%d%%,%d%%,%d%%,99.9%%",
-             (int)FLAGS_bvar_latency_p1, (int)FLAGS_bvar_latency_p2,
-             (int)FLAGS_bvar_latency_p3);
-    CHECK_EQ(0, _latency_percentiles.set_vector_names(namebuf));
+    if (FLAGS_save_series) {
+        snprintf(namebuf, sizeof(namebuf), "%d%%,%d%%,%d%%,99.9%%",
+                 (int)FLAGS_bvar_latency_p1, (int)FLAGS_bvar_latency_p2,
+                 (int)FLAGS_bvar_latency_p3);
+        CHECK_EQ(0, _latency_percentiles.set_vector_names(namebuf));
+    }
     return 0;
 }
 


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: resolve #3013

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
