### PR TITLE
Support generics for MultiDimension APIs

### DIFF
--- a/src/brpc/builtin/prometheus_metrics_service.cpp
+++ b/src/brpc/builtin/prometheus_metrics_service.cpp
@@ -232,7 +232,7 @@ int DumpPrometheusMetricsToIOBuf(butil::IOBuf* output) {
 
     if (bvar::FLAGS_bvar_max_dump_multi_dimension_metric_number > 0) {
         PrometheusMetricsDumper dumper_md(&os, g_server_info_prefix);
-        const int ndump_md = bvar::MVariable::dump_exposed(&dumper_md, NULL);
+        const int ndump_md = bvar::MVariableBase::dump_exposed(&dumper_md, NULL);
         if (ndump_md < 0) {
             return -1;
         }

--- a/src/butil/containers/flat_map.h
+++ b/src/butil/containers/flat_map.h
@@ -199,12 +199,12 @@ public:
     // Remove |key| and all associated value
     // Returns: 1 on erased, 0 otherwise.
     template <typename K2, bool Multi = _Multi>
-    typename std::enable_if<!Multi, size_t >::type
+    typename std::enable_if<!Multi, size_t>::type
     erase(const K2& key, mapped_type* old_value = NULL);
     // For `_Multi=true'.
     // Returns: num of value on erased, 0 otherwise.
     template <typename K2, bool Multi = _Multi>
-    typename std::enable_if<Multi, size_t >::type
+    typename std::enable_if<Multi, size_t>::type
     erase(const K2& key, std::vector<mapped_type>* old_values = NULL);
 
     // Remove all items. Allocated spaces are NOT returned by system.

--- a/src/butil/containers/flat_map_inl.h
+++ b/src/butil/containers/flat_map_inl.h
@@ -592,7 +592,6 @@ typename std::enable_if<!Multi, _T&>::type
 FlatMap<_K, _T, _H, _E, _S, _A, _M>::operator[](const key_type& key) {
     const size_t index = flatmap_mod(_hashfn(key), _nbucket);
     Bucket& first_node = _buckets[index];
-    // LOG(INFO) << "index=" << index;
     if (!first_node.is_valid()) {
         ++_size;
         if (_S) {

--- a/src/butil/strings/string_piece.h
+++ b/src/butil/strings/string_piece.h
@@ -32,6 +32,9 @@
 
 #include <iosfwd>
 #include <string>
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif // __cplusplus >= 201703L
 
 #include "butil/base_export.h"
 #include "butil/basictypes.h"
@@ -182,6 +185,11 @@ template <typename STRING_TYPE> class BasicStringPiece {
   BasicStringPiece(const value_type* str)
       : ptr_(str),
         length_((str == NULL) ? 0 : STRING_TYPE::traits_type::length(str)) {}
+#if __cplusplus >= 201703L
+  BasicStringPiece(
+    const std::basic_string_view<value_type, typename STRING_TYPE::traits_type>& str)
+      : ptr_(str.data()), length_(str.size()) {}
+#endif // __cplusplus >= 201703L
   BasicStringPiece(const STRING_TYPE& str)
       : ptr_(str.data()), length_(str.size()) {}
   BasicStringPiece(const value_type* offset, size_type len)
@@ -368,6 +376,14 @@ template <typename STRING_TYPE> class BasicStringPiece {
   BasicStringPiece substr(size_type pos,
                           size_type n = BasicStringPiece::npos) const {
     return internal::substr(*this, pos, n);
+  }
+
+  // Converts to `std::basic_string`.
+  explicit operator STRING_TYPE() const {
+    if (NULL == data()) {
+      return {};
+    }
+    return STRING_TYPE(data(), size());
   }
 
  protected:

--- a/src/bvar/multi_dimension.h
+++ b/src/bvar/multi_dimension.h
@@ -25,39 +25,54 @@
 #include "butil/scoped_lock.h"                       // BAIDU_SCOPE_LOCK
 #include "butil/containers/doubly_buffered_data.h"   // DBD
 #include "butil/containers/flat_map.h"               // butil::FlatMap
+#include "butil/strings/string_piece.h"
 #include "bvar/mvariable.h"
 
 namespace bvar {
 
-template <typename  T>
-class MultiDimension : public MVariable {
+// KeyType requirements:
+// 1. KeyType must be a container type with iterator, e.g. std::vector, std::list, std::set.
+// 2. KeyType::value_type must be std::string.
+// 3. KeyType::size() returns the number of labels.
+// 4. KeyType::push_back() adds a label to the end of the container.
+template <typename T, typename KeyType = std::list<std::string>>
+class MultiDimension : public MVariable<KeyType> {
 public:
-
     enum STATS_OP {
         READ_ONLY,
         READ_OR_INSERT,
     };
 
-    typedef MVariable Base;
-    typedef std::list<std::string> key_type;
+    typedef KeyType key_type;
     typedef T value_type;
     typedef T* value_ptr_type;
+    typedef MVariable<key_type> Base;
 
     struct KeyHash {
-        size_t operator() (const key_type& key) const {
+        template <typename K>
+        size_t operator() (const K& key) const {
             size_t hash_value = 0;
-            for (auto &k : key) {
-                hash_value += std::hash<std::string>()(k);
+            for (auto& k : key) {
+                hash_value += BUTIL_HASH_NAMESPACE::hash<butil::StringPiece>()(
+                    butil::StringPiece(k));
             }
             return hash_value;
         }
     };
+
+    struct KeyEqualTo {
+        template <typename K>
+        bool operator()(const key_type& k1, const K& k2) const {
+            return k1.size() == k2.size() &&
+                   std::equal(k1.cbegin(), k1.cend(), k2.cbegin());
+        }
+    };
     
     typedef value_ptr_type op_value_type;
-    typedef typename butil::FlatMap<key_type, op_value_type, KeyHash> MetricMap;
+    typedef butil::FlatMap<key_type, op_value_type, KeyHash, KeyEqualTo> MetricMap;
 
     typedef typename MetricMap::const_iterator MetricMapConstIterator;
-    typedef typename butil::DoublyBufferedData<MetricMap> MetricMapDBD;
+    typedef butil::DoublyBufferedData<MetricMap> MetricMapDBD;
     typedef typename MetricMapDBD::ScopedPtr MetricMapScopedPtr;
     
     explicit MultiDimension(const key_type& labels);
@@ -69,28 +84,39 @@ public:
                    const butil::StringPiece& name,
                    const key_type& labels);
 
-    ~MultiDimension();
+    ~MultiDimension() override;
 
     // Implement this method to print the variable into ostream.
-    void describe(std::ostream& os);
+    void describe(std::ostream& os) override;
 
-    // Dump real bvar pointer 
-    size_t dump(Dumper* dumper, const DumpOptions* options);
+    // Dump real bvar pointer
+    size_t dump(Dumper* dumper, const DumpOptions* options) override {
+        return dump_impl(dumper, options);
+    }
 
     // Get real bvar pointer object
     // Return real bvar pointer on success, NULL otherwise.
-    T* get_stats(const key_type& labels_value) {
+    // K requirements:
+    // 1. K must be a container type with iterator,
+    //    e.g. std::vector, std::list, std::set, std::array.
+    // 2. K::value_type must be able to convert to std::string and butil::StringPiece
+    //    through operator std::string() function and operator butil::StringPiece() function.
+    // 3. K::value_type must be able to compare with std::string.
+    template <typename K = key_type>
+    T* get_stats(const K& labels_value) {
         return get_stats_impl(labels_value, READ_OR_INSERT);
     }
 
     // Remove stat so those not count and dump
-    void delete_stats(const key_type& labels_value);
+    template <typename K = key_type>
+    void delete_stats(const K& labels_value);
 
     // Remove all stat
     void clear_stats();
 
     // True if bvar pointer exists
-    bool has_stats(const key_type& labels_value);
+    template <typename K = key_type>
+    bool has_stats(const K& labels_value);
 
     // Get number of stats
     size_t count_stats();
@@ -102,33 +128,61 @@ public:
     // Get real bvar pointer object 
     // Return real bvar pointer if labels_name exist, NULL otherwise.
     // CAUTION!!! Just For Debug!!!
-    T* get_stats_read_only(const key_type& labels_value) {
+    template <typename K = key_type>
+    T* get_stats_read_only(const K& labels_value) {
         return get_stats_impl(labels_value);
     }
 
     // Get real bvar pointer object 
     // Return real bvar pointer if labels_name exist, otherwise(not exist) create bvar pointer.
     // CAUTION!!! Just For Debug!!!
-    T* get_stats_read_or_insert(const key_type& labels_value, bool* do_write = NULL) {
+    template <typename K = key_type>
+    T* get_stats_read_or_insert(const K& labels_value, bool* do_write = NULL) {
         return get_stats_impl(labels_value, READ_OR_INSERT, do_write);
     }
 #endif
 
 private:
-    T* get_stats_impl(const key_type& labels_value);
+    template <typename K>
+    T* get_stats_impl(const K& labels_value);
 
-    T* get_stats_impl(const key_type& labels_value, STATS_OP stats_op, bool* do_write = NULL);
+    template <typename K>
+    T* get_stats_impl(const K& labels_value, STATS_OP stats_op, bool* do_write = NULL);
 
-    void make_dump_key(std::ostream& os, 
-                       const key_type& labels_value, 
-                       const std::string& suffix = "", 
-                       const int quantile = 0);
+    template <typename K>
+    static typename std::enable_if<butil::is_same<K, key_type>::value>::type
+    insert_metrics_map(MetricMap& bg, const K& labels_value, op_value_type metric) {
+        bg.insert(labels_value, metric);
+    }
 
-    void make_labels_kvpair_string(std::ostream& os, 
-                       const key_type& labels_value, 
-                       const int quantile);
+    template <typename K>
+    static typename std::enable_if<!butil::is_same<K, key_type>::value>::type
+    insert_metrics_map(MetricMap& bg, const K& labels_value, op_value_type metric) {
+        key_type labels_value_str;
+        for (auto& label : labels_value) {
+            // key_type::value_type must be able to convert to std::string.
+            labels_value_str.push_back(std::string(label));
+        }
+        bg.insert(labels_value_str, metric);
+    }
 
-    bool is_valid_lables_value(const key_type& labels_value) const;
+    template <typename U = T>
+    typename std::enable_if<!butil::is_same<LatencyRecorder, U>::value, size_t>::type
+    dump_impl(Dumper* dumper, const DumpOptions* options);
+
+    template <typename U = T>
+    typename std::enable_if<butil::is_same<LatencyRecorder, U>::value, size_t>::type
+    dump_impl(Dumper* dumper, const DumpOptions* options);
+
+    void make_dump_key(std::ostream& os, const key_type& labels_value,
+                       const std::string& suffix = "",  int quantile = 0);
+
+    void make_labels_kvpair_string(
+        std::ostream& os, const key_type& labels_value, int quantile);
+
+
+    template <typename K>
+    bool is_valid_lables_value(const K& labels_value) const;
     
     // Remove all stats so those not count and dump
     void delete_stats();
@@ -139,7 +193,6 @@ private:
     
     static size_t init_flatmap(MetricMap& bg);
     
-private:
     size_t _max_stats_count;
     MetricMapDBD _metric_map;
 };

--- a/src/bvar/mvariable.cpp
+++ b/src/bvar/mvariable.cpp
@@ -137,7 +137,7 @@ std::string MVariableBase::describe_exposed(const std::string& name) {
 }
 
 int MVariableBase::expose_impl(const butil::StringPiece& prefix,
-                           const butil::StringPiece& name) {
+                               const butil::StringPiece& name) {
     if (name.empty()) {
         LOG(ERROR) << "Parameter[name] is empty";
         return -1;

--- a/src/bvar/mvariable.h
+++ b/src/bvar/mvariable.h
@@ -32,11 +32,11 @@ namespace bvar {
 class Dumper;
 struct DumpOptions;
 
-class MVariable {
+class MVariableBase {
 public:
-    explicit MVariable(const std::list<std::string>& labels);
+    MVariableBase() = default;
 
-    virtual ~MVariable();
+    virtual ~MVariableBase();
 
     // Implement this method to print the mvariable info into ostream.
     virtual void describe(std::ostream&) = 0;
@@ -46,12 +46,6 @@ public:
    
     // Get mvariable name
     const std::string& name() const { return _name; }
-    
-    // Get mvariable labels
-    const std::list<std::string>& labels() const { return _labels; }
-
-    // Get number of mvariable labels
-    size_t count_labels() const { return _labels.size(); }
 
     // Expose this mvariable globally so that it's counted in following
     // functions:
@@ -113,11 +107,28 @@ protected:
 
 protected:
     std::string _name;
-    std::list<std::string>  _labels;
 
     // mbvar uses bvar, bvar uses TLS, thus copying/assignment need to copy TLS stuff as well,
     // which is heavy. We disable copying/assignment now. 
-    DISALLOW_COPY_AND_ASSIGN(MVariable);
+    DISALLOW_COPY_AND_ASSIGN(MVariableBase);
+};
+
+template <typename KeyType>
+class MVariable : public MVariableBase {
+public:
+    explicit MVariable(const KeyType& labels) : _labels(labels.cbegin(), labels.cend()) {
+        static_assert(std::is_same<typename KeyType::value_type, std::string>::value,
+                      "value_type of KeyType must be std::string");
+    }
+
+    // Get mvariable labels
+    const KeyType& labels() const { return _labels; }
+
+    // Get number of mvariable labels
+    size_t count_labels() const { return _labels.size(); }
+
+protected:
+    KeyType  _labels;
 };
 
 } // namespace bvar

--- a/src/bvar/variable.cpp
+++ b/src/bvar/variable.cpp
@@ -833,7 +833,7 @@ static void* dumping_thread(void*) {
             } else if ("prometheus" == mbvar_format) {
                 dumper = new PrometheusFileDumper(mbvar_filename, mbvar_prefix);
             }
-            int nline = MVariable::dump_exposed(dumper, &options);
+            int nline = MVariableBase::dump_exposed(dumper, &options);
             if (nline < 0) {
                 LOG(ERROR) << "Fail to dump mvars into " << filename;
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -188,10 +188,12 @@ endif()
 # bthread_* functions are used in logging.cc, and they need to be marked as
 # weak symbols explicitly in Darwin system.
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-                    "-Wl,-U,_bthread_getspecific"
-                    "-Wl,-U,_bthread_setspecific"
-                    "-Wl,-U,_bthread_key_create")
+    set(DYNAMIC_LIB ${DYNAMIC_LIB} "-Wl,-U,_bthread_getspecific"
+                                   "-Wl,-U,_bthread_setspecific"
+                                   "-Wl,-U,_bthread_key_create"
+                                   "-Wl,-U,_bthread_self"
+                                   "-Wl,-U,_bthread_timed_connect"
+    )
 endif()
 
 add_library(BUTIL_DEBUG_LIB OBJECT ${BUTIL_SOURCES})

--- a/test/bvar_mvariable_unittest.cpp
+++ b/test/bvar_mvariable_unittest.cpp
@@ -17,12 +17,16 @@
 
 // Date 2021/11/17 14:57:49
 
+// #if __cplusplus >= 201703L
+#include <string_view>
+// #endif // __cplusplus >= 201703L
 #include <pthread.h>                                // pthread_*
 #include <cstddef>
 #include <memory>
 #include <iostream>
 #include <set>
 #include <string>
+#include <array>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include "butil/time.h"
@@ -30,20 +34,7 @@
 #include "bvar/bvar.h"
 #include "bvar/multi_dimension.h"
 
-static const int num_thread = 24;
-
-static const int idc_count = 20;
-static const int method_count = 20;
-static const int status_count = 50;
-static const int labels_count = idc_count * method_count * status_count;
-
 static const std::list<std::string> labels = {"idc", "method", "status"};
-
-struct thread_perf_data {
-    bvar::MVariable* mbvar;
-    bvar::Variable*  rbvar;
-    bvar::Variable*  wbvar;
-};
 
 class MVariableTest : public testing::Test {
 protected:
@@ -66,9 +57,9 @@ TEST_F(MVariableTest, expose) {
     std::vector<std::string> list_exposed_vars;
     std::list<std::string> labels_value1 {"bj", "get", "200"};
     bvar::MultiDimension<bvar::Adder<int> > my_madder1(labels);
-    ASSERT_EQ(0UL, bvar::MVariable::count_exposed());
+    ASSERT_EQ(0UL, bvar::MVariableBase::count_exposed());
     my_madder1.expose("request_count_madder");
-    ASSERT_EQ(1UL, bvar::MVariable::count_exposed());
+    ASSERT_EQ(1UL, bvar::MVariableBase::count_exposed());
     bvar::Adder<int>* my_adder1 = my_madder1.get_stats(labels_value1);
     ASSERT_TRUE(my_adder1);
     ASSERT_STREQ("request_count_madder", my_madder1.name().c_str());
@@ -102,54 +93,138 @@ TEST_F(MVariableTest, expose) {
     list_exposed_vars.push_back("request_count_madder");
 
     ASSERT_EQ(1UL, my_madder1.count_stats());
-    ASSERT_EQ(1UL, bvar::MVariable::count_exposed());
+    ASSERT_EQ(1UL, bvar::MVariableBase::count_exposed());
 
     std::list<std::string> labels2 {"user", "url", "cost"};
     bvar::MultiDimension<bvar::Adder<int> > my_madder2("client_url", labels2);
-    ASSERT_EQ(2UL, bvar::MVariable::count_exposed());
+    ASSERT_EQ(2UL, bvar::MVariableBase::count_exposed());
     list_exposed_vars.push_back("client_url");
 
     std::list<std::string> labels3 {"product", "system", "module"};
     bvar::MultiDimension<bvar::Adder<int> > my_madder3("request_from", labels3);
     list_exposed_vars.push_back("request_from");
-    ASSERT_EQ(3UL, bvar::MVariable::count_exposed());
+    ASSERT_EQ(3UL, bvar::MVariableBase::count_exposed());
 
     std::vector<std::string> exposed_vars;
-    bvar::MVariable::list_exposed(&exposed_vars);
+    bvar::MVariableBase::list_exposed(&exposed_vars);
     ASSERT_EQ(3, exposed_vars.size());
 
     my_madder3.hide();
-    ASSERT_EQ(2UL, bvar::MVariable::count_exposed());
+    ASSERT_EQ(2UL, bvar::MVariableBase::count_exposed());
     list_exposed_vars.pop_back();
     exposed_vars.clear();
-    bvar::MVariable::list_exposed(&exposed_vars);
+    bvar::MVariableBase::list_exposed(&exposed_vars);
     ASSERT_EQ(2, exposed_vars.size());
 }
 
-TEST_F(MVariableTest, labels) {
-    std::list<std::string> labels_value1 {"bj", "get", "200"};
-    bvar::MultiDimension<bvar::Adder<int> > my_madder1("request_count_madder", labels);
+class MyStringView {
+public:
+    MyStringView() : _ptr(NULL), _len(0) {}
+    MyStringView(const char* str)
+        : _ptr(str),
+          _len(str == NULL ? 0 : strlen(str)) {}
+#if __cplusplus >= 201703L
+    MyStringView(const std::string_view& str)
+        : _ptr(str.data()), _len(str.size()) {}
+#endif // __cplusplus >= 201703L
+    MyStringView(const std::string& str)
+        : _ptr(str.data()), _len(str.size()) {}
+    MyStringView(const char* offset, size_t len)
+        : _ptr(offset), _len(len) {}
 
-    ASSERT_EQ(labels.size(), my_madder1.count_labels());
-    ASSERT_STREQ("request_count_madder", my_madder1.name().c_str());
+    const char* data() const { return _ptr; }
+    size_t size() const { return _len; }
 
-    ASSERT_EQ(labels, my_madder1.labels());
-
-    std::list<std::string> labels_too_long;
-    std::list<std::string> labels_max;
-    int labels_too_long_count = 15;
-    for (int i = 0; i < labels_too_long_count; ++i) {
-        std::ostringstream os;
-        os << "label" << i;
-        labels_too_long.push_back(os.str());
-        if (i < 10) {
-            labels_max.push_back(os.str());
+    // Converts to `std::basic_string`.
+    explicit operator std::string() const {
+        if (NULL == _ptr) {
+            return {};
         }
+        return {_ptr, size()};
     }
-    ASSERT_EQ(labels_too_long_count, labels_too_long.size());
-    bvar::MultiDimension<bvar::Adder<int> > my_madder2("request_labels_too_long", labels_too_long);
-    ASSERT_EQ(10, my_madder2.count_labels());
-    ASSERT_EQ(labels_max, my_madder2.labels());
+
+    // Converts to butil::StringPiece.
+    explicit operator butil::StringPiece() const {
+        if (NULL == _ptr) {
+            return {};
+        }
+        return {_ptr, size()};
+    }
+
+private:
+    const char* _ptr;
+    size_t _len;
+};
+
+bool operator==(const MyStringView& x, const std::string& y) {
+    if (x.size() != y.size())
+        return false;
+
+    return butil::StringPiece::wordmemcmp(x.data(), y.data(), x.size()) == 0;
+}
+
+bool operator==(const std::string& x, const MyStringView& y) {
+    if (x.size() != y.size())
+        return false;
+
+    return butil::StringPiece::wordmemcmp(x.data(), y.data(), x.size()) == 0;
+}
+
+static int g_exposed_count = 0;
+
+template <typename KeyType, typename ValueType>
+static void TestLabels() {
+    std::string mbvar_name = butil::string_printf("my_madder_%d", g_exposed_count);
+    KeyType labels{"idc", "method", "status"};
+    bvar::MultiDimension<bvar::Adder<int>, KeyType> my_madder(mbvar_name, labels);
+    ASSERT_EQ(labels.size(), my_madder.count_labels());
+    ASSERT_STREQ(mbvar_name.c_str(), my_madder.name().c_str());
+    ASSERT_EQ(labels, my_madder.labels());
+
+    using ItemType = typename ValueType::value_type;
+    ValueType labels_value{ItemType("cv"), ItemType("post"), ItemType("200")};
+    bvar::Adder<int>* adder = my_madder.get_stats(labels_value);
+    ASSERT_NE(nullptr, adder);
+    ASSERT_TRUE(my_madder.has_stats(labels_value));
+    ASSERT_EQ((size_t)1, my_madder.count_stats());
+    {
+        // Compatible with old API.
+        bvar::Adder<int>* temp = my_madder.get_stats({"cv", "post", "200"});
+        ASSERT_EQ(adder, temp);
+    }
+    *adder << g_exposed_count;
+    ASSERT_EQ(g_exposed_count, adder->get_value());
+    my_madder.delete_stats(labels_value);
+    ASSERT_FALSE(my_madder.has_stats(labels_value));
+    ASSERT_EQ((size_t)0, my_madder.count_stats());
+}
+
+TEST_F(MVariableTest, labels) {
+    TestLabels<std::list<std::string>, std::list<std::string>>();
+    TestLabels<std::list<std::string>, std::vector<std::string>>();
+    TestLabels<std::list<std::string>, std::array<std::string, 3>>();
+
+    TestLabels<std::vector<std::string>, std::list<std::string>>();
+    TestLabels<std::vector<std::string>, std::vector<std::string>>();
+    TestLabels<std::vector<std::string>, std::array<std::string, 3>>();
+
+#if __cplusplus >= 201703L
+    TestLabels<std::list<std::string>, std::list<std::string_view>>();
+    TestLabels<std::list<std::string>, std::vector<std::string_view>>();
+    TestLabels<std::list<std::string>, std::array<std::string_view, 3>>();
+#endif // __cplusplus >= 201703L
+
+    TestLabels<std::vector<std::string>, std::list<butil::StringPiece>>();
+    TestLabels<std::vector<std::string>, std::vector<butil::StringPiece>>();
+    TestLabels<std::vector<std::string>, std::array<butil::StringPiece, 3>>();
+
+    TestLabels<std::list<std::string>, std::list<MyStringView>>();
+    TestLabels<std::list<std::string>, std::vector<MyStringView>>();
+    TestLabels<std::list<std::string>, std::array<MyStringView, 3>>();
+
+    TestLabels<std::vector<std::string>, std::list<MyStringView>>();
+    TestLabels<std::vector<std::string>, std::vector<MyStringView>>();
+    TestLabels<std::vector<std::string>, std::array<MyStringView, 3>>();
 }
 
 TEST_F(MVariableTest, dump) {
@@ -229,9 +304,9 @@ TEST_F(MVariableTest, test_describe_exposed) {
     std::string bvar_name("request_count_describe");
     bvar::MultiDimension<bvar::Adder<int> > my_madder1(bvar_name, labels);
 
-    std::string describe_str = bvar::MVariable::describe_exposed(bvar_name);
+    std::string describe_str = bvar::MVariableBase::describe_exposed(bvar_name);
 
     std::ostringstream describe_oss;
-    ASSERT_EQ(0, bvar::MVariable::describe_exposed(bvar_name, describe_oss));
+    ASSERT_EQ(0, bvar::MVariableBase::describe_exposed(bvar_name, describe_oss));
     ASSERT_STREQ(describe_str.c_str(), describe_oss.str().c_str());
 }

--- a/test/bvar_mvariable_unittest.cpp
+++ b/test/bvar_mvariable_unittest.cpp
@@ -157,15 +157,17 @@ private:
 };
 
 bool operator==(const MyStringView& x, const std::string& y) {
-    if (x.size() != y.size())
+    if (x.size() != y.size()) {
         return false;
+    }
 
     return butil::StringPiece::wordmemcmp(x.data(), y.data(), x.size()) == 0;
 }
 
 bool operator==(const std::string& x, const MyStringView& y) {
-    if (x.size() != y.size())
+    if (x.size() != y.size()) {
         return false;
+    }
 
     return butil::StringPiece::wordmemcmp(x.data(), y.data(), x.size()) == 0;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

The current mbvar get/set operation APIs all require the construction of std::list<std::string>, which requires the allocation of memory and the copying of strings, resulting in noticeable performance overhead.

### What is changed and the side effects?

Changed:

The bvar get/set operation API supports more data structures through generics, thus achieving zero copy. Using `Container<const char* / std::string_view / butil::StringPieces>` can avoid string copying, where Container can be a container such as `std::vector`, `std::set`, `std::map`, etc. Furthermore, `std::array` and `absl::InlinedVector` can be used to avoid dynamic heap memory allocation.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
