### PR TITLE
Bugfix: SignalTrace mode has memory access problem

### DIFF
--- a/src/bthread/task_tracer.h
+++ b/src/bthread/task_tracer.h
@@ -87,12 +87,11 @@ private:
 
     // For signal trace.
     struct SignalSync : public butil::SharedObject {
-        explicit SignalSync(Result* result) : result(result) {}
         ~SignalSync() override;
         bool Init();
 
         int pipe_fds[2]{-1, -1};
-        Result* result{NULL};
+        Result result;
     };
 
     static TaskStatus WaitForJumping(TaskMeta* m);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Fix #3031

Problem Summary: SignalTrace mode has memory access problem

### What is changed and the side effects?

Changed: use `Result` instead of `Result *`

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
