### PR TITLE
replace google::protobuf::int64 by int64_t

### DIFF
--- a/src/butil/iobuf.h
+++ b/src/butil/iobuf.h
@@ -23,7 +23,7 @@
 #define BUTIL_IOBUF_H
 
 #include <sys/uio.h>                             // iovec
-#include <stdint.h>                              // uint32_t
+#include <stdint.h>                              // uint32_t, int64_t
 #include <functional>
 #include <string>                                // std::string
 #include <ostream>                               // std::ostream
@@ -562,12 +562,12 @@ public:
     bool Next(const void** data, int* size) override;
     void BackUp(int count) override;
     bool Skip(int count) override;
-    google::protobuf::int64 ByteCount() const override;
+    int64_t ByteCount() const override;
 
 private:
     int _ref_index;
     int _add_offset;
-    google::protobuf::int64 _byte_count;
+    int64_t _byte_count;
     const IOBuf* _buf;
 };
 
@@ -593,7 +593,7 @@ public:
 
     bool Next(void** data, int* size) override;
     void BackUp(int count) override; // `count' can be as long as ByteCount()
-    google::protobuf::int64 ByteCount() const override;
+    int64_t ByteCount() const override;
 
 private:
     void _release_block();
@@ -601,7 +601,7 @@ private:
     IOBuf* _buf;
     uint32_t _block_size;
     IOBuf::Block *_cur_block;
-    google::protobuf::int64 _byte_count;
+    int64_t _byte_count;
 };
 
 // Wrap IOBuf into input of snappy compression.


### PR DESCRIPTION
google::protobuf::int64 has been removed.

### What problem does this PR solve?

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
