### PR TITLE
when rdma event dispatcher unschedule is true, start ProcessEvent background

### DIFF
--- a/src/brpc/rdma/rdma_helper.h
+++ b/src/brpc/rdma/rdma_helper.h
@@ -91,7 +91,16 @@ bool SupportedByRdma(std::string protocol);
 
 }  // namespace rdma
 }  // namespace brpc
+#else
+namespace brpc {
+namespace rdma {
 
+// Initialize RDMA environment
+// Exit if failed
+void GlobalRdmaInitializeOrDie();
+
+}  // namespace rdma
+}  // namespace brpc
 #endif  // if BRPC_WITH_RDMA
 
 #endif  // BRPC_RDMA_HELPER_H

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -2276,7 +2276,7 @@ int Socket::OnInputEvent(void* user_data, uint32_t events,
         if (FLAGS_usercode_in_coroutine) {
             ProcessEvent(p);
 #if BRPC_WITH_RDMA
-        } else if (rdma::FLAGS_rdma_edisp_unsched == false) {
+        } else if (rdma::FLAGS_rdma_edisp_unsched) {
             auto rc = bthread_start_background(&tid, &attr, ProcessEvent, p);
             if (rc != 0) {
                 LOG(FATAL) << "Fail to start ProcessEvent";


### PR DESCRIPTION
when rdma event dispatcher unschedule is true, start ProcessEvent background

### What problem does this PR solve?

Issue Number:

Problem Summary:

In certain scenarios, such as when using SPDK, it is required that the bthread executing SPDK must run on a single thread—that is, in single-threaded polling mode. This means the bthread of the event dispatcher must continuously occupy one worker thread and must not preempt other bthreads. This ensures no scheduling occurs, preventing SPDK from being scheduled onto other worker threads.


### What is changed and the side effects?

No

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
