### PR TITLE
Restore reader_count in case of failure in rwlock_rdlock_impl

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -238,7 +238,7 @@ cc_test(
             # glog CHECK die with a fatal error
             "bthread_key_unittest.cpp",
             "bthread_butex_multi_tag_unittest.cpp",
-            "bthread_rwlock_unittest.cpp",
+            #"bthread_rwlock_unittest.cpp",
             "bthread_semaphore_unittest.cpp",
         ],
     ),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Fix #3051

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
