### PR TITLE
fix socket _versioned_ref can not recover && remove _hc_started flag

### DIFF
--- a/src/brpc/details/health_check.cpp
+++ b/src/brpc/details/health_check.cpp
@@ -183,7 +183,6 @@ bool HealthCheckTask::OnTriggeringTask(timespec* next_abstime) {
         _first_time = false;
         if (ptr->WaitAndReset(2/*note*/) != 0) {
             LOG(INFO) << "Cancel checking " << *ptr;
-            ptr->AfterHCCompleted();
             return false;
         }
     }
@@ -210,11 +209,9 @@ bool HealthCheckTask::OnTriggeringTask(timespec* next_abstime) {
         if (!ptr->health_check_path().empty()) {
             HealthCheckManager::StartCheck(_id, ptr->_health_check_interval_s);
         }
-        ptr->AfterHCCompleted();
         return false;
     } else if (hc == ESTOP) {
         LOG(INFO) << "Cancel checking " << *ptr;
-        ptr->AfterHCCompleted();
         return false;
     } else {
         RPC_VLOG << "Fail to check " << *ptr

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -430,9 +430,6 @@ public:
     // reference which is held on created.
     void ReleaseHCRelatedReference();
 
-    // After health checking is complete, set _hc_started to false.
-    void AfterHCCompleted() { _hc_started.store(false, butil::memory_order_relaxed); }
-
     // `user' parameter passed to Create().
     SocketUser* user() const { return _user; }
 
@@ -885,10 +882,6 @@ private:
     // to the health checking is held by someone. It can be
     // synchronized via _versioned_ref atomic variable.
     bool _is_hc_related_ref_held;
-
-    // Default: false.
-    // true, if health checking is started.
-    butil::atomic<bool> _hc_started;
 
     // +-1 bit-+---31 bit---+
     // |  flag |   counter  |


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:
Fix #3058 
Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
