### PR TITLE
`Fix: Preserve HTTP headers in ParallelChannel sub-calls`

### DIFF
--- a/src/brpc/parallel_channel.cpp
+++ b/src/brpc/parallel_channel.cpp
@@ -139,6 +139,14 @@ public:
             new (d->sub_done(i)) SubDone;
             d->sub_done(i)->cntl.ApplyClientSettings(settings);
             d->sub_done(i)->cntl.allow_done_to_run_in_place();
+
+            // Propagate all HTTP headers from parent controller to sub-controllers.
+            // This preserves application-set headers (e.g., Authorization) on each sub-call.
+            auto& parent_hdr = cntl->http_request();
+            auto& sub_hdr = d->sub_done(i)->cntl.http_request();
+            for (auto it = parent_hdr.HeaderBegin(); it != parent_hdr.HeaderEnd(); ++it) {
+                sub_hdr.AppendHeader(it->first, it->second);
+            }
         }
         // Setup the map for finding sub_done of i-th sub_channel
         if (ndone != nchan) {


### PR DESCRIPTION
## Problem
When using ParallelChannel, HTTP headers set on the parent controller (e.g., Authorization headers) are lost during sub-calls because they are not propagated to the sub-controllers.

## Solution
- Propagate all HTTP headers from parent controller to each sub-controller
- Preserve application-set headers (like Authorization) on each sub-call
- Maintain backward compatibility

