### PR TITLE
Fix symbol conflict with glog by marking InstallSymbolizeOpenObjectFileCallback as BAIDU_WEAK

### DIFF
--- a/src/butil/third_party/symbolize/symbolize.cc
+++ b/src/butil/third_party/symbolize/symbolize.cc
@@ -85,7 +85,7 @@ void BAIDU_WEAK InstallSymbolizeCallback(SymbolizeCallback callback) {
 
 static SymbolizeOpenObjectFileCallback g_symbolize_open_object_file_callback =
     NULL;
-void InstallSymbolizeOpenObjectFileCallback(
+void BAIDU_WEAK InstallSymbolizeOpenObjectFileCallback(
     SymbolizeOpenObjectFileCallback callback) {
   g_symbolize_open_object_file_callback = callback;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve  #3063 


### What is changed and the side effects?

Changed:
- Marked InstallSymbolizeOpenObjectFileCallback() as BAIDU_WEAK in src/butil/third_party/symbolize/symbolize.cc to avoid symbol collision with glog.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
