### PR TITLE
Bugfix: _combiner is not initialized in IntRecorder constructor

### DIFF
--- a/cmake/CMakeLists.download_gtest.in
+++ b/cmake/CMakeLists.download_gtest.in
@@ -20,7 +20,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.8.0
+  GIT_TAG           release-1.12.0
   SOURCE_DIR        "${PROJECT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${PROJECT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/src/bvar/detail/combiner.h
+++ b/src/bvar/detail/combiner.h
@@ -172,7 +172,7 @@ friend class GlobalValue<self_type>;
             }
         }
         
-        void reset(const ElementTp& val, self_shared_type c) {
+        void reset(const ElementTp& val, const self_shared_type& c) {
             combiner = c;
             element.store(val);
         }

--- a/src/bvar/recorder.h
+++ b/src/bvar/recorder.h
@@ -118,12 +118,12 @@ public:
 
     IntRecorder() : _combiner(std::make_shared<combiner_type>()), _sampler(NULL) {}
 
-    explicit IntRecorder(const butil::StringPiece& name) : _sampler(NULL) {
+    explicit IntRecorder(const butil::StringPiece& name) : IntRecorder() {
         expose(name);
     }
 
     IntRecorder(const butil::StringPiece& prefix, const butil::StringPiece& name)
-        : _sampler(NULL) {
+        : IntRecorder() {
         expose_as(prefix, name);
     }
 

--- a/test/bvar_recorder_unittest.cpp
+++ b/test/bvar_recorder_unittest.cpp
@@ -70,13 +70,18 @@ TEST(RecorderTest, sanity) {
         for (size_t i = 0; i < 100; ++i) {
             recorder << 2;
         }
-        ASSERT_EQ(2l, (int64_t)recorder.average());
+        ASSERT_EQ(2l, recorder.average());
         ASSERT_EQ("2", bvar::Variable::describe_exposed("var1"));
         std::vector<std::string> vars;
         bvar::Variable::list_exposed(&vars);
         ASSERT_EQ(1UL, vars.size());
         ASSERT_EQ("var1", vars[0]);
         ASSERT_EQ(1UL, bvar::Variable::count_exposed());
+    }
+    {
+        bvar::IntRecorder recorder("var2");
+        recorder << 2;
+        ASSERT_EQ(2l, recorder.average());
     }
     ASSERT_EQ(0UL, bvar::Variable::count_exposed());
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Fix #3065

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
