### PR TITLE
Expose the received_us of RPC to users

### DIFF
--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -298,6 +298,7 @@ void Controller::ResetPods() {
     _response_streams.clear();
     _remote_stream_settings = NULL;
     _auth_flags = 0;
+    _rpc_received_us = 0;
 }
 
 Controller::Call::Call(Controller::Call* rhs)

--- a/src/brpc/controller.h
+++ b/src/brpc/controller.h
@@ -638,6 +638,17 @@ public:
         return _response_content_type;
     }
 
+    // If brpc acts as a server, this interface exposes the time when the RPC was received from the
+    // socket. This function can be used in scenarios where the user code needs to understand the RPC
+    // reception time, such as for precise control of timeouts. Users will require timing to start
+    // from the receipt of the RPC. When the user processing function starts to handle the RPC, if
+    // it is found that the RPC has timed out, it will be directly discarded
+    void set_rpc_received_us(int64_t received_us) { _rpc_received_us = received_us; }
+
+    // Get the received time of RPC (in microseconds), if the returned value is 0, it means that
+    // the received time of RPC is not recorded in the controller.
+    int64_t get_rpc_received_us() const { return _rpc_received_us; }
+
 private:
     struct CompletionInfo {
         CallId id;           // call_id of the corresponding request
@@ -909,6 +920,9 @@ private:
     uint32_t _auth_flags;
 
     AfterRpcRespFnType _after_rpc_resp_fn;
+
+    // The point in time when the rpc is read from the socket
+    int64_t _rpc_received_us;
 };
 
 // Advises the RPC system that the caller desires that the RPC call be

--- a/src/brpc/policy/baidu_rpc_protocol.cpp
+++ b/src/brpc/policy/baidu_rpc_protocol.cpp
@@ -615,6 +615,7 @@ void ProcessRpcRequest(InputMessageBase* msg_base) {
     cntl->set_request_content_type(meta.content_type());
     cntl->set_request_compress_type((CompressType)meta.compress_type());
     cntl->set_request_checksum_type((ChecksumType)meta.checksum_type());
+    cntl->set_rpc_received_us(msg->received_us());
     accessor.set_checksum_value(meta.checksum_value());
     accessor.set_server(server)
         .set_security_mode(security_mode)
@@ -943,6 +944,7 @@ void ProcessRpcResponse(InputMessageBase* msg_base) {
         }
     }
 
+    cntl->set_rpc_received_us(msg->received_us());
     Span* span = accessor.span();
     if (span) {
         span->set_base_real_us(msg->base_real_us());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #3072

Problem Summary:

当前，brpc 的用户函数里（CallMethod ）无法获取 RPC 在  socket 被读取的时间点，所以存在几个问题：
1. 无法在用户代码里统计出 RPC 正确的处理总耗时：因为在用户代码里只能从 RPC 开始被处理时开始统计时间， 而实际耗时还应该包含 RPC 在 bthread 队列里的等待时间
2. 无法直接抛弃超时的RPC： 如果 RPC 在 bthread 调度队列等待的时间过长（也就是从 socket 读取到被 bthread 开始处理这个 RPC 的排队时间，我们线上偶发）， 且超过了超时时间， 这个请求应该直接被抛弃， 但是用户无法获取 RPC 到达时间， 导致无法实现这功能

所以，应该把 RPC 从 socket 读取到的时间点暴露给用户代码。

> 说明：
> 1.  brpc 中 RPC 的 received_us 并不是 RPC 达到机器网卡的时间， 也不代表用户的发送时间， 但是相对于从 CallMethod 调用后用户自己统计 RPC 耗时， received_us 相对更精确
> 2. 当前代码仅修改了 baidu_rpc， 其他的协议没支持， get_rpc_received_us 返回 0， 表示这个协议不支持



### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
