### PR TITLE
Refactor: Use static_cast for safer downcasting in brpc::Span

### DIFF
--- a/src/brpc/span.cpp
+++ b/src/brpc/span.cpp
@@ -130,7 +130,7 @@ Span* Span::CreateClientSpan(const std::string& full_method_name,
     span->_tls_next = NULL;
     span->_full_method_name = full_method_name;
     span->_info.clear();
-    Span* parent = (Span*)bthread::tls_bls.rpcz_parent_span;
+    Span* parent = static_cast<Span*>(bthread::tls_bls.rpcz_parent_span);
     if (parent) {
         span->_trace_id = parent->trace_id();
         span->_parent_span_id = parent->span_id();
@@ -148,7 +148,7 @@ Span* Span::CreateClientSpan(const std::string& full_method_name,
 
 Span* Span::CreateBthreadSpan(const std::string& full_method_name, 
                               int64_t base_real_us) {
-    Span* parent = (Span*)bthread::tls_bls.rpcz_parent_span;
+    Span* parent = static_cast<Span*>(bthread::tls_bls.rpcz_parent_span);
     if (parent == NULL) {
         return NULL;
     }
@@ -349,7 +349,7 @@ bool CanAnnotateSpan() {
 }
 
 void AnnotateSpan(const char* fmt, ...) {
-    Span* span = (Span*)bthread::tls_bls.rpcz_parent_span;
+    Span* span = static_cast<Span*>(bthread::tls_bls.rpcz_parent_span);
     va_list ap;
     va_start(ap, fmt);
     span->Annotate(fmt, ap);
@@ -406,7 +406,9 @@ static bvar::DisplaySamplingRatio s_display_sampling_ratio(
 
 struct SpanEarlier {
     bool operator()(bvar::Collected* c1, bvar::Collected* c2) const {
-        return ((Span*)c1)->GetStartRealTimeUs() < ((Span*)c2)->GetStartRealTimeUs();
+        const Span* span1 = static_cast<const Span*>(c1);
+        const Span* span2 = static_cast<const Span*>(c2);
+        return span1->GetStartRealTimeUs() < span2->GetStartRealTimeUs();
     }
 };
 class SpanPreprocessor : public bvar::CollectorPreprocessor {

--- a/src/brpc/span.h
+++ b/src/brpc/span.h
@@ -117,7 +117,7 @@ public:
 
     Span* local_parent() const { return _local_parent; }
     static Span* tls_parent() {
-        return (Span*)bthread::tls_bls.rpcz_parent_span;
+        return static_cast<Span*>(bthread::tls_bls.rpcz_parent_span);
     }
 
     uint64_t trace_id() const { return _trace_id; }
@@ -151,7 +151,7 @@ private:
     bvar::CollectorPreprocessor* preprocessor();
 
     void EndAsParent() {
-        if (this == (Span*)bthread::tls_bls.rpcz_parent_span) {
+        if (this == static_cast<Span*>(bthread::tls_bls.rpcz_parent_span)) {
             bthread::tls_bls.rpcz_parent_span = NULL;
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: no

Problem Summary:
Hello maintainers,

This PR makes two contributions:

##### 1. Code Quality Improvement:

It replaces the C-style cast in Span class with static_cast.

##### 2. Discussion on Robustness (Important):

During my usage of bRPC, I extended the functions of Collected and encountered a scenario where the container being sorted by SpanEarlier contained bvar::Collected* pointers that were not Span instances. This led to a crash due to the unsafe downcast.

The current implementation implicitly assumes that only Span objects will ever be passed to this comparator. While this is efficient, it's not robust against incorrect usage.

### What is changed and the side effects?

Changed:
Using static_cast instead of a C-style cast is a modern C++ best practice. It improves code quality by:

Type Safety: It provides compile-time checks for the validity of the cast within the type hierarchy.
Clarity: It makes the programmer's intent (a static downcast) explicit.
Maintainability: It's easier to search for and audit C++-style casts.
This change has no impact on runtime performance or behavior, as it preserves the original assumption that the bvar::Collected* pointers are guaranteed to be Span instances.

Side effects:
- Performance effects: no

- Breaking backward compatibility: no

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
