### PR TITLE
rdma runtime extend block restriction

### DIFF
--- a/src/brpc/input_messenger.cpp
+++ b/src/brpc/input_messenger.cpp
@@ -331,7 +331,12 @@ int InputMessenger::ProcessNewMessage(
                     "destroyed when authentication failed";
             }
         }
-        if (!m->is_read_progressive()) {
+#if BRPC_WITH_RDMA
+        if (!m->is_read_progressive() && !rdma::FLAGS_rdma_use_polling)
+#else
+        if (!m->is_read_progressive())
+#endif
+        {
             // Transfer ownership to last_msg
             last_msg.reset(msg.release());
         } else {

--- a/src/brpc/rdma/rdma_endpoint.h
+++ b/src/brpc/rdma/rdma_endpoint.h
@@ -36,6 +36,7 @@ namespace brpc {
 class Socket;
 namespace rdma {
 
+DECLARE_bool(rdma_use_polling);
 DECLARE_int32(rdma_poller_num);
 DECLARE_bool(rdma_edisp_unsched);
 DECLARE_bool(rdma_disable_bthread);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

When both rdma_memory_pool_max_regions and rdma_memory_pool_buckets are greater than 1, dynamic memory expansion may cause concurrent modification issues in the memory linked list due to lock contention problems. To address this, we increase the region_num count for each block_type. Dynamic memory expansion is only permitted when both of the following conditions are met:

rdma_memory_pool_buckets equals 1
g_info->region_num[block_type] is less than 1

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
