### PR TITLE
Add flag for parking lot no signal when no waiter, the default is false

### DIFF
--- a/src/bthread/parking_lot.h
+++ b/src/bthread/parking_lot.h
@@ -22,10 +22,13 @@
 #ifndef BTHREAD_PARKING_LOT_H
 #define BTHREAD_PARKING_LOT_H
 
+#include <gflags/gflags.h>
 #include "butil/atomicops.h"
 #include "bthread/sys_futex.h"
 
 namespace bthread {
+
+DECLARE_bool(parking_lot_no_signal_when_no_waiter);
 
 // Park idle workers.
 class BAIDU_CACHELINE_ALIGNMENT ParkingLot {
@@ -40,13 +43,15 @@ public:
         int val;
     };
 
-    ParkingLot() : _pending_signal(0), _waiter_num(0) {}
+    ParkingLot()
+        : _pending_signal(0), _waiter_num(0)
+        , _no_signal_when_no_waiter(FLAGS_parking_lot_no_signal_when_no_waiter) {}
 
     // Wake up at most `num_task' workers.
     // Returns #workers woken up.
     int signal(int num_task) {
         _pending_signal.fetch_add((num_task << 1), butil::memory_order_release);
-        if (_waiter_num.load(butil::memory_order_relaxed) == 0) {
+        if (_no_signal_when_no_waiter && _waiter_num.load(butil::memory_order_relaxed) == 0) {
             return 0;
         }
         return futex_wake_private(&_pending_signal, num_task);
@@ -64,9 +69,13 @@ public:
             // Fast path, no need to futex_wait.
             return;
         }
-        _waiter_num.fetch_add(1, butil::memory_order_relaxed);
+        if (_no_signal_when_no_waiter) {
+            _waiter_num.fetch_add(1, butil::memory_order_relaxed);
+        }
         futex_wait_private(&_pending_signal, expected_state.val, NULL);
-        _waiter_num.fetch_sub(1, butil::memory_order_relaxed);
+        if (_no_signal_when_no_waiter) {
+            _waiter_num.fetch_sub(1, butil::memory_order_relaxed);
+        }
     }
 
     // Wakeup suspended wait() and make them unwaitable ever. 
@@ -79,6 +88,10 @@ private:
     // higher 31 bits for signalling, LSB for stopping.
     butil::atomic<int> _pending_signal;
     butil::atomic<int> _waiter_num;
+    // Whether to signal when there is no waiter.
+    // In busy worker scenarios, signal overhead
+    // can be reduced.
+    bool _no_signal_when_no_waiter;
 };
 
 }  // namespace bthread

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -45,6 +45,10 @@ DEFINE_bool(task_group_set_worker_name, true,
 
 namespace bthread {
 
+DEFINE_bool(parking_lot_no_signal_when_no_waiter, false,
+            "ParkingLot doesn't signal when there is no waiter. "
+            "In busy worker scenarios, signal overhead can be reduced.");
+
 DECLARE_int32(bthread_concurrency);
 DECLARE_int32(bthread_min_concurrency);
 DECLARE_int32(bthread_parking_lot_of_each_tag);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 

Problem Summary:

#2907 has negative optimization in some scenarios.

### What is changed and the side effects?

Changed:

Add flag for parking lot no signal when no waiter, the default is false.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
