### PR TITLE
Use int64_t instead of google::protobuf::int64

### DIFF
--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -1869,7 +1869,7 @@ bool IOBufAsZeroCopyInputStream::Skip(int count) {
     return false;
 }
 
-google::protobuf::int64 IOBufAsZeroCopyInputStream::ByteCount() const {
+int64_t IOBufAsZeroCopyInputStream::ByteCount() const {
     return _byte_count;
 }
 
@@ -1990,7 +1990,7 @@ void IOBufAsZeroCopyOutputStream::BackUp(int count) {
     LOG_IF(FATAL, count != 0) << "BackUp an empty IOBuf";
 }
 
-google::protobuf::int64 IOBufAsZeroCopyOutputStream::ByteCount() const {
+int64_t IOBufAsZeroCopyOutputStream::ByteCount() const {
     return _byte_count;
 }
 

--- a/src/json2pb/zero_copy_stream_writer.h
+++ b/src/json2pb/zero_copy_stream_writer.h
@@ -29,7 +29,7 @@
 //    // Interfaces of ZeroCopyOutputStream
 //    bool Next(void** data, int* size);
 //    void BackUp(int count);
-//    google::protobuf::int64 ByteCount() const;
+//    int64_t ByteCount() const;
 //
 //private:
 //    IOBuf* _buf;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/apache/brpc/pull/3045#issuecomment-3244872255

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
