### PR TITLE
Add support for checking all living bthreads

### DIFF
--- a/src/brpc/builtin/bthreads_service.cpp
+++ b/src/brpc/builtin/bthreads_service.cpp
@@ -23,7 +23,10 @@
 #include "brpc/builtin/bthreads_service.h"
 
 namespace bthread {
-extern void print_task(std::ostream& os, bthread_t tid);
+extern void print_task(std::ostream& os, bthread_t tid, bool enable_trace);
+#ifdef BRPC_BTHREAD_TRACER
+extern void print_living_task(std::ostream& os, bool enable_trace);
+#endif // BRPC_BTHREAD_TRACER
 }
 
 
@@ -38,30 +41,42 @@ void BthreadsService::default_method(::google::protobuf::RpcController* cntl_bas
     cntl->http_response().set_content_type("text/plain");
     butil::IOBufBuilder os;
     const std::string& constraint = cntl->http_request().unresolved_path();
-    
     if (constraint.empty()) {
 #ifdef BRPC_BTHREAD_TRACER
-        os << "Use /bthreads/<bthread_id> or /bthreads/<bthread_id>?st=1 for stack trace";
+        // when BRPC_BTHREAD_TRACER enabled, we can trace a specified bthread and
+        // check all living bthread
+        os << "Use /bthreads/<bthread_id> or /bthreads/<bthread_id>?st=1 for stack trace\n";
+        os << "To check all living bthread, use /bthreads/<all> or /bthreads/<all>?st=1 for stack trace\n";
 #else
-        os << "Use /bthreads/<bthread_id>";
+        os << "Use /bthreads/<bthread_id>\n";
 #endif // BRPC_BTHREAD_TRACER
     } else {
-        char* endptr = NULL;
-        bthread_t tid = strtoull(constraint.c_str(), &endptr, 10);
-        if (*endptr == '\0' || *endptr == '/' || *endptr == '?') {
-            ::bthread::print_task(os, tid);
-
+        bool enable_trace = false;
 #ifdef BRPC_BTHREAD_TRACER
             const std::string* st = cntl->http_request().uri().GetQuery("st");
             if (NULL != st && *st == "1") {
-                os << "\nbthread call stack:\n";
-                ::bthread::stack_trace(os, tid);
+                enable_trace = true;
             }
 #endif // BRPC_BTHREAD_TRACER
+        char* endptr = NULL;
+        bthread_t tid = strtoull(constraint.c_str(), &endptr, 10);
+        if (*endptr == '\0' || *endptr == '/' || *endptr == '?') {
+            ::bthread::print_task(os, tid, enable_trace);
+        }
+#ifdef BRPC_BTHREAD_TRACER
+        else if (constraint != "all" && constraint != "all?st=1") {
+            cntl->SetFailed(ENOMETHOD, "path=%s is not a bthread id or all, or all?st=1\n",
+                            constraint.c_str());
         } else {
-            cntl->SetFailed(ENOMETHOD, "path=%s is not a bthread id",
+            ::bthread::print_living_task(os, enable_trace);
+        }
+#else
+        else {
+            cntl->SetFailed(ENOMETHOD, "path=%s is not a bthread id\n",
                             constraint.c_str());
         }
+#endif // BRPC_BTHREAD_TRACER
+
     }
     os.move_to(cntl->response_attachment());
 }

--- a/src/brpc/builtin/index_service.cpp
+++ b/src/brpc/builtin/index_service.cpp
@@ -158,7 +158,11 @@ void IndexService::default_method(::google::protobuf::RpcController* controller,
        << Path("/health", html_addr) << " : Test healthy" << NL
        << Path("/vlog", html_addr) << " : List all VLOG callsites" << NL
        << Path("/sockets", html_addr) << " : Check status of a Socket" << NL
+#ifdef BRPC_BTHREAD_TRACER
+       << Path("/bthreads", html_addr) << " : Check status of a bthread or all living bthreads" << NL
+#else
        << Path("/bthreads", html_addr) << " : Check status of a bthread" << NL
+#endif // BRPC_BTHREAD_TRACER
        << Path("/ids", html_addr) << " : Check status of a bthread_id" << NL
        << Path("/protobufs", html_addr) << " : List all protobuf services and messages" << NL
        << Path("/list", html_addr) << " : json signature of methods" << NL

--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -32,6 +32,7 @@
 #include "bthread/bthread.h"
 
 namespace bthread {
+extern void print_task(std::ostream& os, bthread_t tid, bool enable_trace);
 
 static bool validate_bthread_concurrency(const char*, int32_t val) {
     // bthread_setconcurrency sets the flag on success path which should
@@ -191,6 +192,23 @@ std::string stack_trace(bthread_t tid) {
         return "TaskControl has not been created";
     }
     return c->stack_trace(tid);
+}
+
+// Print all living (started and not finished) bthread
+void print_living_task(std::ostream& os, bool enable_trace) {
+    TaskControl* c = get_task_control();
+    if (NULL == c) {
+        os << "TaskControl has not been created";
+        return;
+    }
+    std::set<bthread_t> tids = c->get_living_bthreads();
+    if (tids.empty()) {
+        os << "No living bthreads\n";
+        return;
+    }
+    for (auto tid : tids) {
+        print_task(os, tid, enable_trace);
+    }
 }
 #endif // BRPC_BTHREAD_TRACER
 

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -28,6 +28,7 @@
 #include <signal.h>
 #include <stddef.h>                             // size_t
 #include <vector>
+#include <set>
 #include <array>
 #include <memory>
 #include "butil/atomicops.h"                     // butil::atomic
@@ -39,6 +40,71 @@
 
 DECLARE_int32(task_group_ntags);
 namespace bthread {
+
+#ifdef BRPC_BTHREAD_TRACER
+class ShardedBthreadSet {
+public:
+    explicit ShardedBthreadSet(size_t shard_count = 16)
+        : _shard_count(shard_count), _shards(shard_count) {}
+
+    void add(bthread_t id) {
+        get_shard(id).add(id);
+    }
+
+    void remove(bthread_t id) {
+        get_shard(id).remove(id);
+    }
+
+    std::set<bthread_t> get_all() {
+        std::set<bthread_t> result;
+        for (auto& shard : _shards) {
+            shard.copy_to(result);
+        }
+        return result;
+    }
+
+private:
+    class Shard {
+    public:
+        Shard() {
+            pthread_spin_init(&_spinlock, PTHREAD_PROCESS_PRIVATE);
+        }
+
+        ~Shard() {
+            pthread_spin_destroy(&_spinlock);
+        }
+
+        Shard(const Shard&) = delete;
+        Shard& operator=(const Shard&) = delete;
+
+        void add(bthread_t id) {
+            BAIDU_SCOPED_LOCK(_spinlock);
+            _bthread_ids.insert(id);
+        }
+
+        void remove(bthread_t id) {
+            BAIDU_SCOPED_LOCK(_spinlock);
+            _bthread_ids.erase(id);
+        }
+
+        void copy_to(std::set<bthread_t>& target) {
+            BAIDU_SCOPED_LOCK(_spinlock);
+            target.insert(_bthread_ids.begin(), _bthread_ids.end());
+        }
+
+    private:
+        pthread_spinlock_t _spinlock;
+        std::set<bthread_t> _bthread_ids;
+    };
+
+    Shard& get_shard(bthread_t id) {
+        return _shards[id % _shard_count];
+    }
+
+    const size_t _shard_count;
+    std::vector<Shard> _shards;
+};
+#endif // BRPC_BTHREAD_TRACER
 
 class TaskGroup;
 
@@ -95,6 +161,9 @@ public:
     // A stacktrace of bthread can be helpful in debugging.
     void stack_trace(std::ostream& os, bthread_t tid);
     std::string stack_trace(bthread_t tid);
+    std::set<bthread_t> get_living_bthreads() {
+        return _living_bthreads.get_all();
+    }
 #endif // BRPC_BTHREAD_TRACER
 
     void push_priority_queue(bthread_tag_t tag, bthread_t tid) {
@@ -129,6 +198,16 @@ private:
     bvar::LatencyRecorder* create_exposed_pending_time();
     bvar::Adder<int64_t>& tag_nworkers(bthread_tag_t tag);
     bvar::Adder<int64_t>& tag_nbthreads(bthread_tag_t tag);
+
+#ifdef BRPC_BTHREAD_TRACER
+    void record_bthread_start(bthread_t tid) {
+        _living_bthreads.add(tid);
+    }
+
+    void record_bthread_finish(bthread_t tid) {
+        _living_bthreads.remove(tid);
+    }
+#endif // BRPC_BTHREAD_TRACER
 
     std::vector<butil::atomic<size_t>> _tagged_ngroup;
     std::vector<TaggedGroups> _tagged_groups;
@@ -165,6 +244,7 @@ private:
 
 #ifdef BRPC_BTHREAD_TRACER
     TaskTracer _task_tracer;
+    ShardedBthreadSet _living_bthreads;
 #endif // BRPC_BTHREAD_TRACER
 
 };

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -36,6 +36,7 @@
 #include "bthread/task_control.h"
 #include "bthread/task_group.h"
 #include "bthread/timer_thread.h"
+#include "bthread/bthread.h"
 
 #ifdef __x86_64__
 #include <x86intrin.h>
@@ -442,6 +443,7 @@ void TaskGroup::task_runner(intptr_t skip_remained) {
             g->_control->_task_tracer.WaitForTracing(m);
         }
         g->_control->_task_tracer.set_status(TASK_STATUS_UNKNOWN, m);
+        g->_control->record_bthread_finish(m->tid);
 #endif // BRPC_BTHREAD_TRACER
 
         g->_control->_nbthreads << -1;
@@ -507,6 +509,7 @@ int TaskGroup::start_foreground(TaskGroup** pg,
     g->_control->tag_nbthreads(g->tag()) << 1;
 #ifdef BRPC_BTHREAD_TRACER
     g->_control->_task_tracer.set_status(TASK_STATUS_CREATED, m);
+    g->_control->record_bthread_start(*th);
 #endif // BRPC_BTHREAD_TRACER
     if (g->is_current_pthread_task()) {
         // never create foreground task in pthread.
@@ -570,6 +573,7 @@ int TaskGroup::start_background(bthread_t* __restrict th,
     _control->tag_nbthreads(tag()) << 1;
 #ifdef BRPC_BTHREAD_TRACER
     _control->_task_tracer.set_status(TASK_STATUS_CREATED, m);
+    _control->record_bthread_start(*th);
 #endif // BRPC_BTHREAD_TRACER
     if (REMOTE) {
         ready_to_run_remote(m, (using_attr.flags & BTHREAD_NOSIGNAL));
@@ -1088,10 +1092,10 @@ void TaskGroup::yield(TaskGroup** pg) {
     sched(pg);
 }
 
-void print_task(std::ostream& os, bthread_t tid) {
+void print_task(std::ostream& os, bthread_t tid, bool enable_trace) {
     TaskMeta* const m = TaskGroup::address_meta(tid);
     if (m == NULL) {
-        os << "bthread=" << tid << " : never existed";
+        os << "bthread=" << tid << " : never existed\n";
         return;
     }
     const uint32_t given_ver = get_version(tid);
@@ -1127,7 +1131,7 @@ void print_task(std::ostream& os, bthread_t tid) {
         }
     }
     if (!matched) {
-        os << "bthread=" << tid << " : not exist now";
+        os << "bthread=" << tid << " : not exist now\n";
     } else {
         os << "bthread=" << tid << " :\nstop=" << stop
            << "\ninterrupted=" << interrupted
@@ -1136,6 +1140,7 @@ void print_task(std::ostream& os, bthread_t tid) {
            << "\narg=" << (void*)arg
            << "\nattr={stack_type=" << attr.stack_type
            << " flags=" << attr.flags
+           << " specified tag=" << attr.tag
            << " keytable_pool=" << attr.keytable_pool
            << "}\nhas_tls=" << has_tls
            << "\nuptime_ns=" << butil::cpuwide_time_ns() - cpuwide_start_ns
@@ -1145,8 +1150,15 @@ void print_task(std::ostream& os, bthread_t tid) {
            << "\nstatus=" << status
            << "\ntraced=" << traced
            << "\nworker_tid=" << worker_tid;
-#else
-           ;
+        if (enable_trace) {
+            os << "\nbthread call stack:\n";
+            stack_trace(os, tid);
+            os << "\n";
+        } else {
+            os << "\n\n";
+        }
+ #else
+           << "\n\n";
            (void)status;(void)traced;(void)worker_tid;
 #endif // BRPC_BTHREAD_TRACER
     }

--- a/test/brpc_builtin_service_unittest.cpp
+++ b/test/brpc_builtin_service_unittest.cpp
@@ -850,6 +850,34 @@ void* bthread_trace(void*) {
     }
     return NULL;
 }
+
+// check all living bthreads without need to specify bthread id
+bool check_all_bthreads(bthread_t expected_th, bool enable_trace) {
+    brpc::BthreadsService service;
+    brpc::BthreadsRequest req;
+    brpc::BthreadsResponse res;
+    ClosureChecker done;
+    brpc::Controller cntl;
+    std::string all_string("all");
+    if (enable_trace) {
+        all_string.append("?st=1");
+    }
+    cntl.http_request()._unresolved_path = all_string;
+    cntl.http_request().uri().SetHttpURL("/bthreads/" + all_string);
+    service.default_method(&cntl, &req, &res, &done);
+    EXPECT_FALSE(cntl.Failed());
+    const std::string& content = cntl.response_attachment().to_string();
+    std::string expected_str = butil::string_printf("bthread=%llu",
+        (unsigned long long)expected_th);
+    bool ok = content.find("stop=0") != std::string::npos &&
+        content.find(expected_str) != std::string::npos;
+    if (ok && enable_trace) {
+        ok = content.find("bthread_trace") != std::string::npos;
+    } else if (ok && !enable_trace) {
+        ok = content.find("bthread_trace") == std::string::npos;
+    }
+    return ok;
+}
 #endif // BRPC_BTHREAD_TRACER
 
 TEST_F(BuiltinServiceTest, bthreads) {
@@ -869,8 +897,40 @@ TEST_F(BuiltinServiceTest, bthreads) {
         cntl.http_request()._unresolved_path = "not_valid";
         service.default_method(&cntl, &req, &res, &done);
         EXPECT_TRUE(cntl.Failed());
-        CheckErrorText(cntl, "is not a bthread id");
+#ifdef BRPC_BTHREAD_TRACER
+        // For now, the ability to check all living bthread is
+        // enabled only when BRPC_BTHREAD_TRACER is defined
+        CheckErrorText(cntl, "is not a bthread id or all");
+#else
+        CheckErrorText(cntl, "is not a bthread id\n");
+#endif // BRPC_BTHREAD_TRACER
     }    
+    {
+        ClosureChecker done;
+        brpc::Controller cntl;
+        cntl.http_request()._unresolved_path = "all";
+        service.default_method(&cntl, &req, &res, &done);
+#ifdef BRPC_BTHREAD_TRACER
+        EXPECT_FALSE(cntl.Failed());
+        CheckContent(cntl, "stop=0");
+#else
+        EXPECT_TRUE(cntl.Failed());
+        CheckErrorText(cntl, "is not a bthread id\n");
+#endif // BRPC_BTHREAD_TRACER
+    }
+    {
+        ClosureChecker done;
+        brpc::Controller cntl;
+        cntl.http_request()._unresolved_path = "all?st=1";
+        service.default_method(&cntl, &req, &res, &done);
+#ifdef BRPC_BTHREAD_TRACER
+        EXPECT_FALSE(cntl.Failed());
+        CheckContent(cntl, "stop=0");
+#else
+        EXPECT_TRUE(cntl.Failed());
+        CheckErrorText(cntl, "is not a bthread id\n");
+#endif // BRPC_BTHREAD_TRACER
+    }
     {
         bthread_t th;
         EXPECT_EQ(0, bthread_start_background(&th, NULL, dummy_bthread, NULL));
@@ -885,13 +945,14 @@ TEST_F(BuiltinServiceTest, bthreads) {
     }
 
 #ifdef BRPC_BTHREAD_TRACER
-    bool ok = false;
+    bool ok = false, check_all_ok = false;
     for (int i = 0; i < 10; ++i) {
         bthread_t th;
         EXPECT_EQ(0, bthread_start_background(&th, NULL, bthread_trace, NULL));
         while (!g_bthread_trace_start) {
             bthread_usleep(1000 * 10);
         }
+        LOG(INFO) << "start bthread = " << th;
         ClosureChecker done;
         brpc::Controller cntl;
         std::string id_string;
@@ -899,16 +960,20 @@ TEST_F(BuiltinServiceTest, bthreads) {
         cntl.http_request().uri().SetHttpURL("/bthreads/" + id_string);
         cntl.http_request()._unresolved_path = id_string;
         service.default_method(&cntl, &req, &res, &done);
-        g_bthread_trace_stop = true;
         EXPECT_FALSE(cntl.Failed());
         const std::string& content = cntl.response_attachment().to_string();
         ok = content.find("stop=0") != std::string::npos &&
              content.find("bthread_trace") != std::string::npos;
-        if (ok) {
+        check_all_ok = check_all_bthreads(th, true) && check_all_bthreads(th, false);
+        g_bthread_trace_stop = true;
+        bthread_join(th, NULL);
+        // the `bthread_trace` bthread should not be queried now
+        EXPECT_TRUE(!check_all_bthreads(th, true) && !check_all_bthreads(th, false));
+        if (ok && check_all_ok) {
             break;
         }
     }
-    ASSERT_TRUE(ok);
+    ASSERT_TRUE(ok && check_all_ok);
 #endif // BRPC_BTHREAD_TRACER
 }
 


### PR DESCRIPTION
User can check all living bthreads by `curl ip:port/bthreads/all` or `curl ip:port/bthreads/all?st=1` to show bthread stack trace. This is an enhancement of the original /bthreads service which provides a method to check a specified bthread by designated bthread id, as user has no idea what the bthread id is.

Condisering the performance cost brought by recording the bthread id on bthread startup and finish, currently this function is only enabled when BRPC_BTHREAD_TRACER is defined.

### What problem does this PR solve?
brpc kindly provides a bthreads_service to check a specified thread by curl ip:port/bthreads/<bthread_id>. The problem is that we have no idea what the <bthread_id> is as it is generated by code, which makes this service useless.

Issue Number:
#3088 

The sample output with stack trace (note that the bthread name is shown due to another commit not included in this pr yet) :
```
# curl ip:port/bthreads/all?st=1
bthread=4294972672 :
stop=0
interrupted=0
about_to_quit=0
fn=0x55b2104e6d40
arg=0
attr={stack_type=3 flags=0 specified tag=-1 name=GlobalUpdate keytable_pool=0}
has_tls=0
uptime_ns=190567011013
cputime_ns=4864568
nswitch=191
status=6
traced=0
worker_tid=64
bthread call stack:
#0 0x55b210601235 bthread::TaskGroup::sched()
#1 0x55b21060139d bthread::TaskGroup::usleep()
#2 0x55b2105f7c68 bthread_usleep
#3 0x55b2104e72f5 brpc::GlobalUpdate()
#4 0x55b210601b52 bthread::TaskGroup::task_runner()
#5 0x55b21061baf1 bthread_make_fcontext

bthread=4294972673 :
stop=0
interrupted=0
about_to_quit=0
fn=0x55b21047fe00
arg=0x55b2d3d0ba00
attr={stack_type=3 flags=0 specified tag=-1 name=RunWatchConnections keytable_pool=0}
has_tls=0
uptime_ns=190569412002
cputime_ns=2741573
nswitch=191
status=6
traced=0
worker_tid=63
bthread call stack:
#0 0x55b210601235 bthread::TaskGroup::sched()
#1 0x55b21060139d bthread::TaskGroup::usleep()
#2 0x55b2105f7c68 bthread_usleep
#3 0x55b21047fade brpc::SocketMap::WatchConnections()
#4 0x55b21047fe09 brpc::SocketMap::RunWatchConnections()
#5 0x55b210601b52 bthread::TaskGroup::task_runner()
#6 0x55b21061baf1 bthread_make_fcontext

bthread=4294972674 :
stop=0
interrupted=0
about_to_quit=0
fn=0x55b2104e09f0
arg=0x55b213820248
attr={stack_type=3 flags=64 specified tag=0 name=EventDispatcher::RunThis keytable_pool=0}
has_tls=0
uptime_ns=190569994951
cputime_ns=188933862493
nswitch=92666
status=5
traced=0
worker_tid=62
bthread call stack:
#0 0x55b2104e0729 brpc::EventDispatcher::Run()
#1 0x55b2104e09f9 brpc::EventDispatcher::RunThis()
#2 0x55b210601b52 bthread::TaskGroup::task_runner()
#3 0x55b21061baf1 bthread_make_fcontext

bthread=4294972675 :
stop=0
interrupted=0
about_to_quit=0
fn=0x55b2104e09f0
arg=0x55b2138202a0
attr={stack_type=3 flags=64 specified tag=1 name=EventDispatcher::RunThis keytable_pool=0}
has_tls=0
uptime_ns=190571575082
cputime_ns=0
nswitch=0
status=5
traced=0
worker_tid=73
bthread call stack:
#0 0x55b2104e0729 brpc::EventDispatcher::Run()
#1 0x55b2104e09f9 brpc::EventDispatcher::RunThis()
#2 0x55b210601b52 bthread::TaskGroup::task_runner()
#3 0x55b21061baf1 bthread_make_fcontext

bthread=4294972676 :
stop=0
interrupted=0
about_to_quit=0
fn=0x55b2104a8bc0
arg=0x7ffda6297480
attr={stack_type=3 flags=0 specified tag=0 name=UpdateDerivedVars keytable_pool=0}
has_tls=0
uptime_ns=186566458068
cputime_ns=31630252
nswitch=187
status=6
traced=0
worker_tid=63
bthread call stack:
#0 0x55b210601235 bthread::TaskGroup::sched()
#1 0x55b21060139d bthread::TaskGroup::usleep()
#2 0x55b2105f7c68 bthread_usleep
#3 0x55b2104a9a15 brpc::Server::UpdateDerivedVars()
#4 0x55b210601b52 bthread::TaskGroup::task_runner()
#5 0x55b21061baf1 bthread_make_fcontext

bthread=4294972677 :
stop=0
interrupted=0
about_to_quit=0
fn=0x55b2104a8bc0
arg=0x7ffda629a340
attr={stack_type=3 flags=0 specified tag=0 name=UpdateDerivedVars keytable_pool=0}
has_tls=0
uptime_ns=186567623212
cputime_ns=33209308
nswitch=187
status=6
traced=0
worker_tid=64
bthread call stack:
#0 0x55b210601235 bthread::TaskGroup::sched()
#1 0x55b21060139d bthread::TaskGroup::usleep()
#2 0x55b2105f7c68 bthread_usleep
#3 0x55b2104a9a15 brpc::Server::UpdateDerivedVars()
#4 0x55b210601b52 bthread::TaskGroup::task_runner()
#5 0x55b21061baf1 bthread_make_fcontext

bthread=592705498944 :
stop=0
interrupted=0
about_to_quit=0
fn=0x55b210489c00
arg=0x55b3366ccf00
attr={stack_type=3 flags=0 specified tag=0 name=ProcessEvent keytable_pool=0x55b30773c780}
has_tls=0
uptime_ns=13930923
cputime_ns=0
nswitch=0
status=5
traced=0
worker_tid=67
bthread call stack:
No frame
Error message:

Can not trace self=592705498944
```

Problem Summary:

### What is changed and the side effects?

Changed:
when BRPC_BTHREAD_TRACER is defined: 1. add method to record bthread id on bthread startup and finish. 2. add /bthreads/all and /bthreads/all?st=1 service for user

Side effects:
- Performance effects:
The primary effects on performance is brought by recording the bthread id on bthread startup and finish, which needs lock to protect the data structure (like std::set).
To test the performance cost I use one rdma_performance_client and rdma_performance_server in each machine, with TCP mode enabled:   
<img width="2162" height="432" alt="image" src="https://github.com/user-attachments/assets/0f7d3fd6-45bb-4ed6-9add-f7075392482e" />

This commit use multiple spin lock by sharding to minimize performance effects.

- Breaking backward compatibility: N/A

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
