### PR TITLE
add flag for brpc timer buckets count

### DIFF
--- a/src/bthread/timer_thread.cpp
+++ b/src/bthread/timer_thread.cpp
@@ -19,6 +19,7 @@
 
 
 #include <queue>                           // heap functions
+#include <gflags/gflags.h>
 #include "butil/scoped_lock.h"
 #include "butil/logging.h"
 #include "butil/third_party/murmurhash3/murmurhash3.h"   // fmix64
@@ -30,6 +31,8 @@
 #include "bthread/log.h"
 
 namespace bthread {
+
+DEFINE_uint32(brpc_timer_num_buckets, 13, "brpc timer num buckets");
 
 // Defined in task_control.cpp
 void run_worker_startfn();
@@ -469,6 +472,7 @@ static void init_global_timer_thread() {
     }
     TimerThreadOptions options;
     options.bvar_prefix = "bthread_timer";
+    options.num_buckets = FLAGS_brpc_timer_num_buckets;
     const int rc = g_timer_thread->start(&options);
     if (rc != 0) {
         LOG(FATAL) << "Fail to start timer_thread, " << berror(rc);


### PR DESCRIPTION
### What problem does this PR solve?

add a gflag for brpc timer bucket count

Issue Number:

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
