### PR TITLE
Add pthread CPU affinity support

### DIFF
--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -106,23 +106,6 @@ public:
         (void)r;
     }
 
-    static inline std::vector<unsigned> get_current_cpus() {
-        cpu_set_t cs;
-        auto r = pthread_getaffinity_np(pthread_self(), sizeof(cs), &cs);
-        if (r != 0) {
-            LOG(ERROR) << "get thread affinity failed";
-            exit(1);
-        }
-        std::vector<unsigned> cpus;
-        unsigned nr = CPU_COUNT(&cs);
-        for (int cpu = 0; cpu < CPU_SETSIZE && cpus.size() < nr; cpu++) {
-            if (CPU_ISSET(cpu, &cs)) {
-                cpus.push_back(cpu);
-            }
-        }
-        return cpus;
-    }
-
 #ifdef BRPC_BTHREAD_TRACER
     // A stacktrace of bthread can be helpful in debugging.
     void stack_trace(std::ostream& os, bthread_t tid);

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -30,8 +30,6 @@
 #include <vector>
 #include <array>
 #include <memory>
-#include <set>
-#include <regex>
 #include "butil/atomicops.h"                     // butil::atomic
 #include "bvar/bvar.h"                          // bvar::PassiveStatus
 #include "bthread/task_tracer.h"
@@ -95,16 +93,7 @@ public:
 
     static int parse_cpuset(std::string value, std::vector<unsigned>& cpus);
 
-    static inline void bind_thread(pthread_t pthread, unsigned cpuId) {
-        cpu_set_t cs;
-        CPU_ZERO(&cs);
-        CPU_SET(cpuId, &cs);
-        auto r = pthread_setaffinity_np(pthread, sizeof(cs), &cs);
-        if (r != 0) {
-            LOG(WARNING) << "Failed to bind thread to cpu: " << cpuId;
-        }
-        (void)r;
-    }
+    static void bind_thread_to_cpu(pthread_t pthread, unsigned cpu_id);
 
 #ifdef BRPC_BTHREAD_TRACER
     // A stacktrace of bthread can be helpful in debugging.
@@ -154,7 +143,7 @@ private:
     bool _stop;
     butil::atomic<int> _concurrency;
     std::vector<pthread_t> _workers;
-    static std::vector<unsigned> _cpus;
+    std::vector<unsigned> _cpus;
     butil::atomic<int> _next_worker_id;
 
     bvar::Adder<int64_t> _nworkers;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:[#1140](https://github.com/apache/brpc/issues/1140)

Problem Summary:

### What is changed and the side effects?

Changed:
添加gflag 
cpu_set：用户需要绑定的cpu集合，默认为空串，表示不开启绑核
当开启绑核时，会解析cpu集合到_cpus数组中
每次调用pthread_create(&_workers[i], NULL, worker_thread, arg);后，会绑定worker_id对应的_cpus[worker_id % _cpus.size()]

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
