### PR TITLE
Wrap absl::string_view as std::string to support protobuf v30+

### DIFF
--- a/src/brpc/amf.cpp
+++ b/src/brpc/amf.cpp
@@ -1000,7 +1000,7 @@ void WriteAMFObject(const google::protobuf::Message& message,
                 continue;
             }
         }
-        const std::string& name = field->name();
+        const auto& name = field->name();
         if (name.size() >= 65536u) {
             LOG(ERROR) << "name is too long!";
             return stream->set_bad();

--- a/src/brpc/builtin/protobufs_service.cpp
+++ b/src/brpc/builtin/protobufs_service.cpp
@@ -17,13 +17,16 @@
 
 
 #include <google/protobuf/descriptor.h>     // ServiceDescriptor
+
+#include "protobufs_service.h"
+
 #include "brpc/controller.h"           // Controller
 #include "brpc/server.h"               // Server
 #include "brpc/closure_guard.h"        // ClosureGuard
 #include "brpc/details/method_status.h"// MethodStatus
-#include "brpc/builtin/protobufs_service.h"
 #include "brpc/builtin/common.h"
 
+#include "butil/strings/string_util.h"
 
 namespace brpc {
 
@@ -42,7 +45,7 @@ int ProtobufsService::Init() {
         }
         const google::protobuf::ServiceDescriptor* d =
             iter->second.service->GetDescriptor();
-        _map[d->full_name()] = d->DebugString();
+        _map[butil::EnsureString(d->full_name())] = d->DebugString();
         const int method_count = d->method_count();
         for (int j = 0; j < method_count; ++j) {
             const google::protobuf::MethodDescriptor* md = d->method(j);
@@ -53,13 +56,13 @@ int ProtobufsService::Init() {
     while (!stack.empty()) {
         const google::protobuf::Descriptor* d = stack.back();
         stack.pop_back();
-        _map[d->full_name()] = d->DebugString();
+        _map[butil::EnsureString(d->full_name())] = d->DebugString();
         for (int i = 0; i < d->field_count(); ++i) {
             const google::protobuf::FieldDescriptor* f = d->field(i);
             if (f->type() == google::protobuf::FieldDescriptor::TYPE_MESSAGE ||
                 f->type() == google::protobuf::FieldDescriptor::TYPE_GROUP) {
                 const google::protobuf::Descriptor* sub_d = f->message_type();
-                if (sub_d != d && _map.find(sub_d->full_name()) == _map.end()) {
+                if (sub_d != d && _map.find(butil::EnsureString(sub_d->full_name())) == _map.end()) {
                     stack.push_back(sub_d);
                 }
             }

--- a/src/brpc/builtin/protobufs_service.cpp
+++ b/src/brpc/builtin/protobufs_service.cpp
@@ -18,7 +18,7 @@
 
 #include <google/protobuf/descriptor.h>     // ServiceDescriptor
 
-#include "protobufs_service.h"
+#include "brpc/builtin/protobufs_service.h"
 
 #include "brpc/controller.h"           // Controller
 #include "brpc/server.h"               // Server

--- a/src/brpc/channel.cpp
+++ b/src/brpc/channel.cpp
@@ -492,17 +492,17 @@ void Channel::CallMethod(const google::protobuf::MethodDescriptor* method,
 
     if (cntl->_sender == NULL && IsTraceable(Span::tls_parent())) {
         const int64_t start_send_us = butil::cpuwide_time_us();
-        const std::string* method_name = NULL;
+        std::string method_name;
         if (_get_method_name) {
-            method_name = &_get_method_name(method, cntl);
+            method_name = butil::EnsureString(_get_method_name(method, cntl));
         } else if (method) {
-            method_name = &method->full_name();
+            method_name = butil::EnsureString(method->full_name());
         } else {
             const static std::string NULL_METHOD_STR = "null-method";
-            method_name = &NULL_METHOD_STR;
+            method_name = NULL_METHOD_STR;
         }
         Span* span = Span::CreateClientSpan(
-            *method_name, start_send_real_us - start_send_us);
+            method_name, start_send_real_us - start_send_us);
         span->set_log_id(cntl->log_id());
         span->set_base_cid(correlation_id);
         span->set_protocol(_options.protocol);

--- a/src/brpc/nshead_pb_service_adaptor.cpp
+++ b/src/brpc/nshead_pb_service_adaptor.cpp
@@ -19,7 +19,7 @@
 #include <google/protobuf/descriptor.h>         // MethodDescriptor
 #include <google/protobuf/message.h>            // Message
 
-#include "nshead_pb_service_adaptor.h"
+#include "brpc/nshead_pb_service_adaptor.h"
 
 #include "brpc/controller.h"               // Controller
 #include "brpc/socket.h"                   // Socket

--- a/src/brpc/nshead_pb_service_adaptor.cpp
+++ b/src/brpc/nshead_pb_service_adaptor.cpp
@@ -19,8 +19,7 @@
 #include <google/protobuf/descriptor.h>         // MethodDescriptor
 #include <google/protobuf/message.h>            // Message
 
-#include "butil/time.h" 
-#include "butil/iobuf.h"                         // butil::IOBuf
+#include "nshead_pb_service_adaptor.h"
 
 #include "brpc/controller.h"               // Controller
 #include "brpc/socket.h"                   // Socket
@@ -28,8 +27,11 @@
 #include "brpc/span.h"
 #include "brpc/details/server_private_accessor.h"
 #include "brpc/details/controller_private_accessor.h"
-#include "brpc/nshead_pb_service_adaptor.h"
 #include "brpc/policy/most_common_message.h"
+
+#include "butil/iobuf.h"                         // butil::IOBuf
+#include "butil/strings/string_util.h"
+#include "butil/time.h"
 
 
 namespace brpc {
@@ -126,7 +128,7 @@ void NsheadPbServiceAdaptor::ProcessNsheadRequest(
         google::protobuf::Service* svc = sp->service;
         const google::protobuf::MethodDescriptor* method = sp->method;
         ControllerPrivateAccessor(controller).set_method(method);
-        done->SetMethodName(method->full_name());
+        done->SetMethodName(butil::EnsureString(method->full_name()));
         pbdone->pbreq.reset(svc->GetRequestPrototype(method).New());
         pbdone->pbres.reset(svc->GetResponsePrototype(method).New());
 

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -20,12 +20,16 @@
 #include <google/protobuf/text_format.h>
 #include <gflags/gflags.h>
 #include <string>
+
 #include "brpc/policy/http_rpc_protocol.h"
-#include "butil/unique_ptr.h"                       // std::unique_ptr
-#include "butil/string_splitter.h"                  // StringMultiSplitter
+
 #include "butil/string_printf.h"
-#include "butil/time.h"
+#include "butil/string_splitter.h"                  // StringMultiSplitter
+#include "butil/strings/string_util.h"
 #include "butil/sys_byteorder.h"
+#include "butil/time.h"
+#include "butil/unique_ptr.h"                       // std::unique_ptr
+
 #include "json2pb/pb_to_json.h"                     // ProtoMessageToJson
 #include "json2pb/json_to_pb.h"                     // JsonToProtoMessage
 #include "brpc/compress.h"
@@ -284,7 +288,7 @@ static bool JsonToProtoMessage(const butil::IOBuf& body,
     bool ok = json2pb::JsonToProtoMessage(&wrapper, message, options, &error);
     if (!ok) {
         cntl->SetFailed(error_code, "Fail to parse http json body as %s: %s",
-                        message->GetDescriptor()->full_name().c_str(),
+                        butil::EnsureString(message->GetDescriptor()->full_name()).c_str(),
                         error.c_str());
     }
     return ok;
@@ -305,7 +309,7 @@ static bool ProtoMessageToJson(const google::protobuf::Message& message,
     bool ok = json2pb::ProtoMessageToJson(message, wrapper, options, &error);
     if (!ok) {
         cntl->SetFailed(error_code, "Fail to convert %s to json: %s",
-                        message.GetDescriptor()->full_name().c_str(),
+                        butil::EnsureString(message.GetDescriptor()->full_name()).c_str(),
                         error.c_str());
     }
     return ok;
@@ -321,7 +325,7 @@ static bool ProtoJsonToProtoMessage(const butil::IOBuf& body,
     bool ok = json2pb::ProtoJsonToProtoMessage(&wrapper, message, options, &error);
     if (!ok) {
         cntl->SetFailed(error_code, "Fail to parse http proto-json body as %s: %s",
-                        message->GetDescriptor()->full_name().c_str(),
+                        butil::EnsureString(message->GetDescriptor()->full_name()).c_str(),
                         error.c_str());
     }
     return ok;
@@ -337,7 +341,7 @@ static bool ProtoMessageToProtoJson(const google::protobuf::Message& message,
     bool ok = json2pb::ProtoMessageToProtoJson(message, wrapper, options, &error);
     if (!ok) {
         cntl->SetFailed(error_code, "Fail to convert %s to proto-json: %s",
-                        message.GetDescriptor()->full_name().c_str(), error.c_str());
+                        butil::EnsureString(message.GetDescriptor()->full_name()).c_str(), error.c_str());
     }
     return ok;
 }
@@ -527,13 +531,13 @@ void ProcessHttpResponse(InputMessageBase* msg) {
         if (content_type == HTTP_CONTENT_PROTO) {
             if (!ParsePbFromIOBuf(cntl->response(), res_body)) {
                 cntl->SetFailed(ERESPONSE, "Fail to parse content as %s",
-                                cntl->response()->GetDescriptor()->full_name().c_str());
+                                butil::EnsureString(cntl->response()->GetDescriptor()->full_name()).c_str());
                 break;
             }
         } else if (content_type == HTTP_CONTENT_PROTO_TEXT) {
             if (!ParsePbTextFromIOBuf(cntl->response(), res_body)) {
                 cntl->SetFailed(ERESPONSE, "Fail to parse proto-text content as %s",
-                                cntl->response()->GetDescriptor()->full_name().c_str());
+                                butil::EnsureString(cntl->response()->GetDescriptor()->full_name()).c_str());
                 break;
             }
         } else if (content_type == HTTP_CONTENT_JSON) {
@@ -612,13 +616,13 @@ void SerializeHttpRequest(butil::IOBuf* /*not used*/,
             if (!pbreq->SerializeToZeroCopyStream(&wrapper)) {
                 cntl->request_attachment().clear();
                 return cntl->SetFailed(EREQUEST, "Fail to serialize %s",
-                                       pbreq->GetTypeName().c_str());
+                                       butil::EnsureString(pbreq->GetTypeName()).c_str());
             }
         } else if (content_type == HTTP_CONTENT_PROTO_TEXT) {
             if (!google::protobuf::TextFormat::Print(*pbreq, &wrapper)) {
                 cntl->request_attachment().clear();
                 return cntl->SetFailed(EREQUEST, "Fail to print %s as proto-text",
-                                       pbreq->GetTypeName().c_str());
+                                       butil::EnsureString(pbreq->GetTypeName()).c_str());
             }
         } else if (content_type == HTTP_CONTENT_PROTO_JSON) {
             if (!ProtoMessageToProtoJson(*pbreq, &wrapper, cntl, EREQUEST)) {
@@ -880,11 +884,13 @@ HttpResponseSender::~HttpResponseSender() {
         butil::IOBufAsZeroCopyOutputStream wrapper(&cntl->response_attachment());
         if (content_type == HTTP_CONTENT_PROTO) {
             if (!res->SerializeToZeroCopyStream(&wrapper)) {
-                cntl->SetFailed(ERESPONSE, "Fail to serialize %s", res->GetTypeName().c_str());
+                cntl->SetFailed(ERESPONSE, "Fail to serialize %s",
+                                butil::EnsureString(res->GetTypeName()).c_str());
             }
         } else if (content_type == HTTP_CONTENT_PROTO_TEXT) {
             if (!google::protobuf::TextFormat::Print(*res, &wrapper)) {
-                cntl->SetFailed(ERESPONSE, "Fail to print %s as proto-text", res->GetTypeName().c_str());
+                cntl->SetFailed(ERESPONSE, "Fail to print %s as proto-text",
+                                butil::EnsureString(res->GetTypeName()).c_str());
             }
         } else if (content_type == HTTP_CONTENT_PROTO_JSON) {
             ProtoMessageToProtoJson(*res, &wrapper, cntl, ERESPONSE);
@@ -1535,7 +1541,7 @@ void ProcessHttpRequest(InputMessageBase *msg) {
         cntl->request_attachment().swap(req_body);
         google::protobuf::Closure* done = new HttpResponseSenderAsDone(&resp_sender);
         if (span) {
-            span->ResetServerSpanName(md->full_name());
+            span->ResetServerSpanName(butil::EnsureString(md->full_name()));
             span->set_start_callback_us(butil::cpuwide_time_us());
             span->AsParent();
         }
@@ -1565,18 +1571,19 @@ void ProcessHttpRequest(InputMessageBase *msg) {
     // Switch to service-specific error.
     non_service_error.release();
     MethodStatus* method_status = mp->status;
+    const std::string method_full_name = butil::EnsureString(mp->method->full_name());
     resp_sender.set_method_status(method_status);
     if (method_status) {
         int rejected_cc = 0;
         if (!method_status->OnRequested(&rejected_cc)) {
             cntl->SetFailed(ELIMIT, "Rejected by %s's ConcurrencyLimiter, concurrency=%d",
-                            mp->method->full_name().c_str(), rejected_cc);
+                            method_full_name.c_str(), rejected_cc);
             return;
         }
     }
     
     if (span) {
-        span->ResetServerSpanName(mp->method->full_name());
+        span->ResetServerSpanName(method_full_name);
     }
     // NOTE: accesses to builtin services are not counted as part of
     // concurrency, therefore are not limited by ServerOptions.max_concurrency.
@@ -1616,6 +1623,8 @@ void ProcessHttpRequest(InputMessageBase *msg) {
     google::protobuf::Message* req = messages->Request();
     google::protobuf::Message* res = messages->Response();
 
+    const std::string request_full_name = butil::EnsureString(req->GetDescriptor()->full_name());
+
     if (__builtin_expect(!req || !res, 0)) {
         PLOG(FATAL) << "Fail to new req or res";
         cntl->SetFailed("Fail to new req or res");
@@ -1632,7 +1641,7 @@ void ProcessHttpRequest(InputMessageBase *msg) {
             if (!req->IsInitialized()) {
                 cntl->SetFailed(EREQUEST, "%s needs to be created from a"
                                 " non-empty json, it has required fields.",
-                                req->GetDescriptor()->full_name().c_str());
+                                request_full_name.c_str());
                 return;
             } // else all fields of the request are optional.
         } else {
@@ -1677,13 +1686,13 @@ void ProcessHttpRequest(InputMessageBase *msg) {
             if (content_type == HTTP_CONTENT_PROTO) {
                 if (!ParsePbFromIOBuf(req, req_body)) {
                     cntl->SetFailed(EREQUEST, "Fail to parse http body as %s",
-                                    req->GetDescriptor()->full_name().c_str());
+                                    request_full_name.c_str());
                     return;
                 }
             } else if (content_type == HTTP_CONTENT_PROTO_TEXT) {
                 if (!ParsePbTextFromIOBuf(req, req_body)) {
                     cntl->SetFailed(EREQUEST, "Fail to parse http proto-text body as %s",
-                                    req->GetDescriptor()->full_name().c_str());
+                                    request_full_name.c_str());
                     return;
                 }
             } else if (content_type == HTTP_CONTENT_PROTO_JSON) {

--- a/src/brpc/policy/mongo_protocol.cpp
+++ b/src/brpc/policy/mongo_protocol.cpp
@@ -18,8 +18,11 @@
 #include <google/protobuf/descriptor.h>         // MethodDescriptor
 #include <google/protobuf/message.h>            // Message
 #include <gflags/gflags.h>
-#include "butil/time.h" 
+
 #include "butil/iobuf.h"                         // butil::IOBuf
+#include "butil/strings/string_util.h"
+#include "butil/time.h"
+
 #include "brpc/controller.h"               // Controller
 #include "brpc/socket.h"                   // Socket
 #include "brpc/server.h"                   // Server
@@ -249,7 +252,7 @@ void ProcessMongoRequest(InputMessageBase* msg_base) {
             if (!method_status->OnRequested(&rejected_cc)) {
                 mongo_done->cntl.SetFailed(
                     ELIMIT, "Rejected by %s's ConcurrencyLimiter, concurrency=%d",
-                    mp->method->full_name().c_str(), rejected_cc);
+                    butil::EnsureString(mp->method->full_name()).c_str(), rejected_cc);
                 break;
             }
         }

--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -20,7 +20,10 @@
 #include <google/protobuf/message.h>             // Message
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <google/protobuf/io/coded_stream.h>
+
 #include "butil/time.h"
+#include "butil/strings/string_util.h"
+
 #include "brpc/controller.h"                // Controller
 #include "brpc/socket.h"                    // Socket
 #include "brpc/server.h"                    // Server
@@ -424,7 +427,7 @@ void ProcessSofaRequest(InputMessageBase* msg_base) {
             int rejected_cc = 0;
             if (!method_status->OnRequested(&rejected_cc)) {
                 cntl->SetFailed(ELIMIT, "Rejected by %s's ConcurrencyLimiter, concurrency=%d",
-                                sp->method->full_name().c_str(), rejected_cc);
+                                butil::EnsureString(sp->method->full_name()).c_str(), rejected_cc);
                 break;
             }
         }
@@ -437,7 +440,7 @@ void ProcessSofaRequest(InputMessageBase* msg_base) {
         }
 
         if (span) {
-            span->ResetServerSpanName(method->full_name());
+            span->ResetServerSpanName(butil::EnsureString(method->full_name()));
         }
         req.reset(svc->GetRequestPrototype(method).New());
         if (!ParseFromCompressedData(msg->payload, req.get(), req_cmp_type)) {

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -391,7 +391,7 @@ public:
             return !is_builtin_service && !restful_map;
         }
 
-        const std::string& service_name() const;
+        const std::string service_name() const;
     };
     typedef butil::FlatMap<std::string, ServiceProperty> ServiceMap;
 

--- a/src/butil/strings/string_util.h
+++ b/src/butil/strings/string_util.h
@@ -21,10 +21,6 @@
 #include "butil/strings/string16.h"
 #include "butil/strings/string_piece.h"  // For implicit conversions.
 
-#ifdef BRPC_HAS_ABSL
-#include <absl/strings/string_view.h>
-#endif
-
 namespace butil {
 
 // C standard-library functions like "strncasecmp" and "snprintf" that aren't
@@ -263,13 +259,6 @@ BUTIL_EXPORT bool ContainsOnlyChars(const StringPiece16& input,
 BUTIL_EXPORT bool IsStringUTF8(const StringPiece& str);
 BUTIL_EXPORT bool IsStringASCII(const StringPiece& str);
 BUTIL_EXPORT bool IsStringASCII(const string16& str);
-
-#if defined(BRPC_HAS_ABSL)
-// Wrap absl::string_view with std::string
-inline std::string EnsureString(const absl::string_view& v) {
-    return std::string(v.data(), v.size());
-}
-#endif
 
 inline std::string EnsureString(const std::string& s) {
     return s;

--- a/src/json2pb/pb_to_json.h
+++ b/src/json2pb/pb_to_json.h
@@ -93,7 +93,11 @@ bool ProtoMessageToJson(const google::protobuf::Message& message,
                         std::string* error = NULL);
 
 // See <google/protobuf/util/json_util.h> for details.
+#if GOOGLE_PROTOBUF_VERSION >= 6030000
+using Pb2ProtoJsonOptions = google::protobuf::util::JsonPrintOptions;
+#else
 using Pb2ProtoJsonOptions = google::protobuf::util::JsonOptions;
+#endif
 
 #if GOOGLE_PROTOBUF_VERSION >= 5026002
 #define AlwaysPrintPrimitiveFields(options) options.always_print_fields_with_no_presence

--- a/src/json2pb/protobuf_map.cpp
+++ b/src/json2pb/protobuf_map.cpp
@@ -38,12 +38,12 @@ bool IsProtobufMap(const FieldDescriptor* field) {
     if (NULL == key_desc
         || key_desc->is_repeated()
         || key_desc->cpp_type() != FieldDescriptor::CPPTYPE_STRING
-        || strcmp(KEY_NAME, key_desc->name().c_str()) != 0) {
+        || key_desc->name() != KEY_NAME) {
         return false;
     }
     const FieldDescriptor* value_desc = entry_desc->field(VALUE_INDEX);
     if (NULL == value_desc
-        || strcmp(VALUE_NAME, value_desc->name().c_str()) != 0) {
+        || value_desc->name() != VALUE_NAME) {
         return false;
     }
     return true;

--- a/src/json2pb/protobuf_type_resolver.h
+++ b/src/json2pb/protobuf_type_resolver.h
@@ -23,8 +23,9 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/util/type_resolver.h>
 #include <google/protobuf/util/type_resolver_util.h>
-#include "butil/string_printf.h"
 #include "butil/memory/singleton_on_pthread_once.h"
+#include "butil/string_printf.h"
+#include "butil/strings/string_util.h"
 
 namespace json2pb {
 
@@ -32,7 +33,7 @@ namespace json2pb {
 
 inline std::string GetTypeUrl(const google::protobuf::Message& message) {
     return butil::string_printf(PROTOBUF_TYPE_URL_PREFIX"/%s",
-                                message.GetDescriptor()->full_name().c_str());
+                                butil::EnsureString(message.GetDescriptor()->full_name()).c_str());
 }
 
 // unique_ptr deleter for TypeResolver only deletes the object


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #3181 

Problem Summary: support protobuf v30+

The breaking changes of Protobuf can be found at [November 7, 2024](https://protobuf.dev/news/2024-11-07)

### What is changed and the side effects?

Changed: wrapper all name/full_name with string copies, to not introduce details of absl.

Switching to StringPiece/string_view will require a re-design of the related parts.

Side effects:
- Performance effects: see above

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
