### PR TITLE
fix(bthread/context): Add .previous after GNU-stack note for aarch64

### DIFF
--- a/src/bthread/context.cpp
+++ b/src/bthread/context.cpp
@@ -576,6 +576,7 @@ __asm (
 ".size bthread_jump_fcontext,.-bthread_jump_fcontext\n"
 "@ Mark that we don't need executable stack.\n"
 ".section .note.GNU-stack,\"\",%progbits\n"
+".previous\n"
 );
 
 #endif
@@ -607,6 +608,7 @@ __asm (
 ".size bthread_make_fcontext,.-bthread_make_fcontext\n"
 "@ Mark that we don't need executable stack.\n"
 ".section .note.GNU-stack,\"\",%progbits\n"
+".previous\n"
 );
 
 #endif
@@ -678,6 +680,7 @@ __asm (
 ".size   bthread_jump_fcontext,.-bthread_jump_fcontext\n"
 "# Mark that we don't need executable stack.\n"
 ".section .note.GNU-stack,\"\",%progbits\n"
+".previous\n"
 );
 
 #endif
@@ -710,6 +713,7 @@ __asm (
 ".size   bthread_make_fcontext,.-bthread_make_fcontext\n"
 "# Mark that we don't need executable stack.\n"
 ".section .note.GNU-stack,\"\",%progbits\n"
+".previous\n"
 );
 
 #endif


### PR DESCRIPTION
Add missing .previous directive after each .note.GNU-stack section in ARM inline assembly blocks. This ensures proper section switching and prevents potential assembler errors when building with asan.

### What problem does this PR solve?

Issue Number: resolve #1186

Problem Summary:

When build brpc with asan enabled, gcc complains something similar with the following line

```
`.note.GNU-stack' referenced in section `.init_array.00099' of ../../output/lib/libbrpc.a(context.cpp.o): defined in discarded section
```