### PR TITLE
fix: add acquire fence in bthread_join for ARM memory visibility

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -635,6 +635,12 @@ int TaskGroup::join(bthread_t tid, void** return_value) {
             return errno;
         }
     }
+#if defined(__aarch64__) || defined(__arm__)
+    // On ARM's weak memory model, ensure all memory writes made by the
+    // joined bthread are visible to the joining thread after join returns.
+    // This matches the semantic guarantee provided by pthread_join().
+    butil::atomic_thread_fence(butil::memory_order_acquire);
+#endif
     if (return_value) {
         *return_value = NULL;
     }

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -635,12 +635,10 @@ int TaskGroup::join(bthread_t tid, void** return_value) {
             return errno;
         }
     }
-#if defined(__aarch64__) || defined(__arm__)
-    // On ARM's weak memory model, ensure all memory writes made by the
-    // joined bthread are visible to the joining thread after join returns.
-    // This matches the semantic guarantee provided by pthread_join().
+    // Ensure all memory writes made by the joined bthread are visible to
+    // the joining thread after join returns. This matches the semantic
+    // guarantee provided by pthread_join() across supported architectures.
     butil::atomic_thread_fence(butil::memory_order_acquire);
-#endif
     if (return_value) {
         *return_value = NULL;
     }


### PR DESCRIPTION
Ensure memory visibility on ARM architecture after thread join.

### What problem does this PR solve?

Issue Number: fix #3274  

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
