### PR TITLE
[bvar] fix sampler interval after switch to cpuwide_time_ns

### DIFF
--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -155,7 +155,7 @@ void SamplerCollector::run() {
     butil::LinkNode<Sampler> root;
     int consecutive_nosleep = 0;
     while (!_stop) {
-        int64_t abstime = butil::cpuwide_time_ns();
+        int64_t abstime = butil::cpuwide_time_us();
         Sampler* s = this->reset();
         if (s) {
             s->InsertBeforeAsList(&root);
@@ -176,13 +176,13 @@ void SamplerCollector::run() {
             p = saved_next;
         }
         bool slept = false;
-        int64_t now = butil::cpuwide_time_ns();
+        int64_t now = butil::cpuwide_time_us();
         _cumulated_time_us += now - abstime;
         abstime += 1000000L;
         while (abstime > now) {
             ::usleep(abstime - now);
             slept = true;
-            now = butil::cpuwide_time_ns();
+            now = butil::cpuwide_time_us();
         }
         if (slept) {
             consecutive_nosleep = 0;


### PR DESCRIPTION
### What problem does this PR solve?

Fixes the unit-mismatch regression introduced by #3268 (commit 12fb539a, "Use monotonic time instead of wall time").

Before this PR, on master / 1.17.0-rc1, the bvar sampler thread effectively runs at ~1 kHz instead of 1 Hz and spams

    sampler.cpp:192 bvar is busy at sampling for 2 seconds!

PR #3268 switched the three time-source calls in `SamplerCollector::run()` from `gettimeofday_us()` (microseconds) to `cpuwide_time_ns()` (nanoseconds), but left the 1-second offset constant (`abstime += 1000000L`) and the `usleep(abstime - now)` call untouched. As a result:

- `abstime += 1000000L` now adds 1 ms instead of 1 s, so the sampler spins at ~1 kHz instead of 1 Hz;
- `usleep(abstime - now)` is passed a nanosecond delta that `usleep()` interprets as microseconds, which further distorts the sleep duration.

See #3277 for the full analysis and a reproducer.

### What is changed and how does it work?

`src/bvar/detail/sampler.cpp::SamplerCollector::run()`:

- `abstime += 1000000L` (1 ms in nanoseconds) → `abstime += 1000000000L` (1 s in nanoseconds), restoring the intended 1-second sample period.
- `::usleep(abstime - now)` — `usleep()` takes microseconds, but the difference is now in nanoseconds; divide by 1000.

### Checklist

- [x] Fix compiles and links (verified against an application tree linking brpc master).
- [x] Manually verified on a live cluster: "bvar is busy at sampling" warning count dropped from ~17k/minute per process to 0; sampler thread CPU dropped accordingly.
- [ ] No dedicated unit test added — the existing `SamplerCollector::run()` loop is not currently covered by a direct unit test. Happy to add one if reviewers can suggest a good shape (the challenge is driving the loop deterministically without sleeping wall-clock time).

Fixes #3277.
