### PR TITLE
Fix time source mismatch in client RPC path after #3268 migration

### DIFF
--- a/src/brpc/policy/locality_aware_load_balancer.cpp
+++ b/src/brpc/policy/locality_aware_load_balancer.cpp
@@ -18,7 +18,7 @@
 
 #include <limits>                                            // numeric_limits
 #include <gflags/gflags.h>
-#include "butil/time.h"                                      // cpuwide_time_us
+#include "butil/time.h"                                       // gettimeofday_us
 #include "butil/fast_rand.h"
 #include "brpc/log.h"
 #include "brpc/socket.h"
@@ -376,7 +376,7 @@ void LocalityAwareLoadBalancer::Feedback(const CallInfo& info) {
 
 int64_t LocalityAwareLoadBalancer::Weight::Update(
     const CallInfo& ci, size_t index) {
-    const int64_t end_time_us = butil::cpuwide_time_us();
+    const int64_t end_time_us = butil::gettimeofday_us();
     const int64_t latency = end_time_us - ci.begin_time_us;
     BAIDU_SCOPED_LOCK(_mutex);
     if (Disabled()) {
@@ -524,7 +524,7 @@ void LocalityAwareLoadBalancer::Describe(
     if (_db_servers.Read(&s) != 0) {
         os << "fail to read _db_servers";
     } else {
-        const int64_t now = butil::cpuwide_time_us();
+        const int64_t now = butil::gettimeofday_us();
         const size_t n = s->weight_tree.size();
         os << '[';
         for (size_t i = 0; i < n; ++i) {

--- a/test/brpc_load_balancer_unittest.cpp
+++ b/test/brpc_load_balancer_unittest.cpp
@@ -1303,6 +1303,83 @@ TEST_F(LoadBalancerTest, revived_from_all_failed_intergrated) {
 }
 #endif // BUTIL_USE_ASAN
 
+// Regression for #3268's incomplete migration of LocalityAwareLoadBalancer.
+//
+// #3268 switched `LocalityAwareLoadBalancer::Weight::Update::end_time_us` and
+// `LocalityAwareLoadBalancer::Describe::now` to `butil::cpuwide_time_us()`
+// while every caller that supplies `CallInfo::begin_time_us` (the RPC entry
+// in `Channel::CallMethod` and the retry sites in
+// `Controller::OnVersionedRPCReturned`) still uses `butil::gettimeofday_us()`.
+// The resulting time-source mismatch makes
+//
+//     latency = end_time_us - ci.begin_time_us
+//             = cpuwide_now - wallclock_begin
+//             ~= -1.7e15 us  (huge negative)
+//
+// trigger the
+//
+//     if (latency <= 0) { /* time skews, ignore the sample */ return 0; }
+//
+// short-circuit on every call. `_time_q` never accumulates samples,
+// `_avg_latency` stays at 0, and locality-aware weight feedback is silently
+// disabled. Visible downstream symptom: cold-start `list://` channels with
+// `lb=la` and 2 backends occasionally fail RPCs with `EHOSTDOWN`
+// ("Fail to select server") on retry even when one backend is healthy.
+//
+// This commit reverts the LA side of #3268, so `Weight::Update` and
+// `Describe` once again use `butil::gettimeofday_us()` to match every
+// existing caller of `CallInfo::begin_time_us`.
+//
+// The test below runs entirely against `LocalityAwareLoadBalancer` (no
+// Server / Channel is involved), so it is hermetic. It supplies a
+// gettimeofday-based `begin_time_us` (matching what `Channel::CallMethod`
+// passes today) and asserts that the LB records a positive `_avg_latency`,
+// rather than tripping the time-skew short-circuit.
+TEST_F(LoadBalancerTest, la_records_latency_with_consistent_time_source) {
+    LALB lalb;
+    char addr[] = "192.168.1.1:8080";
+    butil::EndPoint dummy;
+    ASSERT_EQ(0, str2endpoint(addr, &dummy));
+    brpc::ServerId id(8888);
+    brpc::SocketOptions options;
+    options.remote_side = dummy;
+    ASSERT_EQ(0, brpc::Socket::Create(options, &id.id));
+    ASSERT_TRUE(lalb.AddServer(id));
+
+    auto avg_latency = [&]() -> int64_t {
+        std::ostringstream os;
+        brpc::DescribeOptions opts;
+        opts.verbose = true;
+        lalb.Describe(os, opts);
+        const std::string s = os.str();
+        const size_t p = s.find("avg_latency=");
+        if (p == std::string::npos) return -1;
+        return strtoll(s.c_str() + p + strlen("avg_latency="), NULL, 10);
+    };
+
+    // Drive a few "RPCs": pick a server, sleep ~2ms, feed back. begin_time_us
+    // comes from gettimeofday_us(), matching what Channel::CallMethod and the
+    // retry sites in Controller::OnVersionedRPCReturned pass on every RPC.
+    for (int i = 0; i < 8; ++i) {
+        const int64_t begin_us = butil::gettimeofday_us();
+        brpc::SocketUniquePtr ptr;
+        brpc::LoadBalancer::SelectIn in = { begin_us, true, false, 0u, NULL };
+        brpc::LoadBalancer::SelectOut out(&ptr);
+        ASSERT_EQ(0, lalb.SelectServer(in, &out));
+        bthread_usleep(2000);
+        brpc::LoadBalancer::CallInfo ci = { begin_us, id.id, 0, NULL };
+        lalb.Feedback(ci);
+    }
+
+    // _avg_latency must reflect actual elapsed time. If this is 0, either
+    // Weight::Update::end_time_us was changed away from gettimeofday_us
+    // again (re-introducing the time-source mismatch) or some caller of
+    // CallInfo::begin_time_us drifted to a different clock domain.
+    EXPECT_GT(avg_latency(), 0);
+
+    ASSERT_EQ(0, brpc::Socket::SetFailed(id.id));
+}
+
 TEST_F(LoadBalancerTest, la_selection_too_long) {
     brpc::GlobalInitializeOrDie();
     brpc::LoadBalancerWithNaming lb;


### PR DESCRIPTION
> 已按 @chenBright 在 [#issuecomment-4319830604](https://github.com/apache/brpc/pull/3283#issuecomment-4319830604) 的建议改成"回退 LocalityAwareLoadBalancer 这一侧的改动"，比迁移整条调用链更局部、更保守。

### 这个 PR 解决什么问题

#3268（"Use monotonic time instead of wall time"）把
`LocalityAwareLoadBalancer::Weight::Update` 的 `end_time_us` 与
`LocalityAwareLoadBalancer::Describe` 的 `now` 切到了
`butil::cpuwide_time_us()`，但所有产生 `CallInfo::begin_time_us` 的调用
方还在用 `butil::gettimeofday_us()`：

- `Channel::CallMethod`（`channel.cpp:451`）→ `Controller::IssueRPC` →
  `Controller::Call::begin_time_us` → `SelectIn::begin_time_us` →
  `CallInfo::begin_time_us`
- `Controller::OnVersionedRPCReturned` 中的 backup-request 与普通重试入口
  （`controller.cpp:672, 715`）都是 `IssueRPC(butil::gettimeofday_us())`

时钟域错配导致：

```cpp
const int64_t end_time_us = butil::cpuwide_time_us();         // 单调时钟，约 5e6
const int64_t latency = end_time_us - ci.begin_time_us;       // - 墙上时钟（约 1.7e15）
                                                              // ≈ -1.7e15 us
if (latency <= 0) {
    // time skews, ignore the sample.
    return 0;
}
```

每个 sample 都被 time-skew 短路丢掉。`_time_q` 永远拿不到新条目，
`_avg_latency` 一直是 0，locality-aware 反馈机制实际被静默关掉。

**下游可观测的现象**：冷启动场景下，`list://` channel + `lb=la` + 2 个
backend、`max_retry=1`，第一个 backend 不通时，retry 偶发返回
`EHOSTDOWN`（`Fail to select server from list://...`），即使第二个
backend 是健康的。

### Bisect / 复现

我在内部 fork 上对 brpc 1.16.1 与 1.17.0-rc2 之间的 51 个 commit 做了
bisect（master 代码不变，只换 brpc 版本），每一步在 2-backend
`list://` + `lb=la` + `max_retry=1` 下跑探测 RPC 重复 500 次：

| 步骤 | commit | 失败 |
|-----|--------|------|
| good | `c41e838a` Release 1.16.1                  |  0/500 |
| ...  | （4 个 GOOD 步骤）                          | ...    |
| #47  | `771de31e` Fix UAF in LatencyRecorder      |  0/500 |
| **#48** | **`12fb539a` Use monotonic time (#3268)** | **25/500** |
| #49  | `b223e60b` Fix RDMA resource               | 30/500 |
| bad  | `604dad0c` 1.17.0-rc2                      | 28/500 |

在 `12fb539a` 上做单行隔离实验：只把

```diff
 int64_t LocalityAwareLoadBalancer::Weight::Update(const CallInfo& ci, ...) {
-    const int64_t end_time_us = butil::cpuwide_time_us();
+    const int64_t end_time_us = butil::gettimeofday_us();
```

撤回（保留 #3268 其余所有改动），测试就回到 0/500 PASS。这把回归精确钉
到了那一行 `end_time_us` 切换。

### 改动内容

按 @chenBright 的建议，把 `LocalityAwareLoadBalancer` 一侧从 #3268 引入
的 cpuwide 改动回退，让它继续使用 `gettimeofday_us()`，与现有调用方对
齐：

| 文件 | 行号 | 改动 |
|------|------|------|
| `src/brpc/policy/locality_aware_load_balancer.cpp` | 21  | include 注释回退到 `gettimeofday_us` |
| `src/brpc/policy/locality_aware_load_balancer.cpp` | 379 | `Weight::Update::end_time_us` 回退 |
| `src/brpc/policy/locality_aware_load_balancer.cpp` | 527 | `Describe::now` 回退 |

`Channel::CallMethod` 与 `Controller::OnVersionedRPCReturned` 中那些
`butil::gettimeofday_us()` 调用都不用动；`Controller::_begin_time_us`、
`Controller::latency_us()` 等公开 API 的墙上时钟语义保持不变。

### 测试

新增 `test/brpc_load_balancer_unittest.cpp::la_records_latency_with_consistent_time_source`，
不依赖 Server / Channel 的 LB 单元测试。它驱动若干次
`SelectServer` + `Feedback` 循环，`begin_time_us` 用
`butil::gettimeofday_us()`（与 `Channel::CallMethod` 当前行为一致），并
断言 `_avg_latency` 反映了真实的过期时间，而不是被 time-skew 短路卡在
0。

如果将来有人再把 `Weight::Update::end_time_us` 切走，或者某个
`CallInfo::begin_time_us` 的调用方漂到了别的时钟域，这个测试都会失败。

不起 Server / 不依赖网络，CI 上是确定性结果（本地 ~16ms）。
`la_sanity` 与 `la_selection_too_long` 也都仍然通过。

### Check List

- [x] 没有公开 API 变更。
- [x] 新增测试 `la_records_latency_with_consistent_time_source`。
- [x] 向后兼容：`Controller::_begin_time_us` / `latency_us()` 保持墙上
      时钟语义不变。
