### PR TITLE
Use compare_exchange_weak in steal loop for potential performance imp…

### DIFF
--- a/src/bthread/work_stealing_queue.h
+++ b/src/bthread/work_stealing_queue.h
@@ -128,7 +128,7 @@ public:
                 return false;
             }
             *val = _buffer[t & (_capacity - 1)];
-        } while (!_top.compare_exchange_strong(t, t + 1,
+        } while (!_top.compare_exchange_weak(t, t + 1,
                                                butil::memory_order_seq_cst,
                                                butil::memory_order_relaxed));
         return true;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 

Problem Summary:
在 WorkStealingQueue 的 steal 函数中，使用 compare_exchange_strong 在循环中重试。
由于已经在 do-while 循环中，改用 compare_exchange_weak 可以获得更好的性能，
同时保持语义正确

### What is changed and the side effects?

Changed:
- 将 `_top.compare_exchange_strong` 改为 `_top.compare_exchange_weak`
- 保持其他逻辑不变

Side effects:
- Performance effects:
- Breaking backward compatibility:

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
