### PR TITLE
Fix protobuf version (< 3.4.0) compatibility for ByteSizeLong() and SpaceUsedLong()

### DIFF
--- a/src/brpc/memcache.cpp
+++ b/src/brpc/memcache.cpp
@@ -17,6 +17,7 @@
 
 #include "brpc/memcache.h"
 
+#include <google/protobuf/io/coded_stream.h>
 #include "brpc/policy/memcache_binary_header.h"
 #include "brpc/proto_base.pb.h"
 #include "butil/logging.h"

--- a/src/brpc/nonreflectable_message.h
+++ b/src/brpc/nonreflectable_message.h
@@ -163,9 +163,19 @@ public:
 #endif
 
     // Size of bytes after serialization.
+#if GOOGLE_PROTOBUF_VERSION < 3004000
+    virtual size_t ByteSizeLong() const {
+        return 0;
+    }
+
+    int ByteSize() const override {
+        return static_cast<int>(ByteSizeLong());
+    }
+#else
     size_t ByteSizeLong() const override {
         return 0;
     }
+#endif
 
 #if GOOGLE_PROTOBUF_VERSION >= 3007000 && GOOGLE_PROTOBUF_VERSION < 3010000
     void SerializeWithCachedSizes(::google::protobuf::io::CodedOutputStream*) const override {}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

The project fails to compile with protobuf versions < 3.4.0. The `ByteSizeLong()` and `SpaceUsedLong()` methods were introduced in protobuf 3.4.0, but the code unconditionally uses them with the `override` keyword, causing compilation errors:
- `'size_t brpc::NonreflectableMessage<T>::SpaceUsedLong() const' marked 'override', but does not override`
- `'size_t brpc::NonreflectableMessage<T>::ByteSizeLong() const' marked 'override', but does not override`

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
