### PR TITLE
Hide libunwind's _Unwind_* symbols under Bazel to fix bthread_tracer crash

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,8 @@
 ./example/build_with_bazel
+
+# `registry/` is brpc's self-maintained Bzlmod registry. Its overlay
+# BUILD.bazel files reference sources from the libunwind tarball that is
+# only materialized at module resolution time, not in the source tree.
+# Without this entry, `bazel build //...` would try to evaluate them as
+# regular packages and fail with "missing input file ...".
+./registry

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -218,4 +218,7 @@ header:
     # Fuzzing seed
     - 'test/fuzzing/fuzz_*_seed_corpus/*'
 
+    # bazel-central-registry
+    - 'registry/**'
+
   comment: on-failure

--- a/LICENSE
+++ b/LICENSE
@@ -959,3 +959,41 @@ copyright The Chromium Authors and licensed under the 3-clause BSD license:
   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+registry/modules/libunwind/**: licensed under the following terms:
+
+  Forked from the Bazel Central Registry (BCR):
+    https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/libunwind
+
+  The upstream files are distributed under the Apache License, Version 2.0,
+  the same license as brpc itself (the full text of which is reproduced at
+  the top of this LICENSE file). brpc has modified the forked files; per the
+  Apache License 2.0 §4(b), the modifications are summarized below:
+
+    - registry/modules/libunwind/<version>/MODULE.bazel
+    - registry/modules/libunwind/<version>/overlay/MODULE.bazel
+        Append the suffix `.brpc-no-unwind` to the `version` field, marking
+        these as brpc's variant of the libunwind module.
+
+    - registry/modules/libunwind/<version>/overlay/BUILD.bazel
+        Add the `hide_unwind_symbols` config_setting (gated by
+        `--define=libunwind_hide_unwind_symbols=true`); when the switch is
+        on, drop `src/unwind/*.c` (the GCC `_Unwind_*` ABI compatibility
+        layer) from `unwind_srcs` so the resulting libunwind does not export
+        `_Unwind_*` symbols. See docs/cn/bthread_tracer.md for the
+        rationale.
+
+    - registry/modules/libunwind/<version>/source.json
+        Update overlay file SHA-256 hashes to match the modified
+        BUILD.bazel / MODULE.bazel.
+
+    - registry/modules/libunwind/metadata.json
+        Replace the `versions` array with brpc's renamed versions.
+
+  The above only governs the build/source files brpc redistributes inside
+  registry/modules/libunwind/. The libunwind source code itself, downloaded
+  by Bazel from the URL pinned in source.json, remains governed by the
+  libunwind project's own license; see https://github.com/libunwind/libunwind
+  for details.

--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -136,6 +136,7 @@ config_setting(
     define_values = {
         "with_bthread_tracer": "true",
     },
+    visibility = ["//visibility:public"],
 )
 
 config_setting(

--- a/docs/cn/bthread_tracer.md
+++ b/docs/cn/bthread_tracer.md
@@ -58,7 +58,7 @@ jump_stack是bthread挂起或者运行的必经之路，也是STB的拦截点。
 
 # 使用方法
 
-1. 下载安装libunwind和abseil-cpp。
+1. 下载安装libunwind和abseil-cpp。**注意：libunwind 必须从源码编译，不要使用系统包管理器安装的 `libunwind-dev` / `libunwind-devel`**，否则会触发本文末尾「[已知问题：libunwind 与 libgcc_s 的 `_Unwind_*` 符号冲突](#已知问题libunwind-与-libgcc_s-的-_unwind_-符号冲突)」中描述的崩溃。bazel 构建可以跳过此步，直接使用 brpc 仓库自维护的 libunwind 版本。
 2. 给config_brpc.sh增加`--with-bthread-tracer`选项或者给cmake增加`-DWITH_BTHREAD_TRACER=ON`选项或者给bazel（Bzlmod模式）增加`--define with_bthread_tracer=true`选项。
 3. 访问服务的内置服务：`http://ip:port/bthreads/<bthread_id>?st=1`或者代码里调用`bthread::stack_trace()`函数。
 4. 如果希望追踪pthread的调用栈，在对应pthread上调用`bthread::init_for_pthread_stack_trace()`函数获取一个伪bthread_t，然后使用步骤3即可获取pthread调用栈。
@@ -72,6 +72,145 @@ jump_stack是bthread挂起或者运行的必经之路，也是STB的拦截点。
 #4 0x0000000000413289 (anonymous namespace)::spin_and_log()
 #5 0x00007fdbbfa58dc0 bthread::TaskGroup::task_runner()
 ```
+
+# 已知问题
+
+## libunwind 与 libgcc_s 的 `_Unwind_*` 符号冲突
+
+### 现象
+
+启用 bthread tracer 后，可能在 `bthread_exit` / `pthread_exit` 或者 C++ 异常处理路径上偶发段错误，类似如下调用栈：
+
+```text
+#0  0x0000000000000000 in ?? ()
+#1  0x00007fa2b5d6458a in _ULx86_64_dwarf_find_proc_info ()
+   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
+#2  0x00007fa2b5d6668d in fetch_proc_info ()
+   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
+#3  0x00007fa2b5d681a1 in _ULx86_64_dwarf_make_proc_info ()
+   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
+#4  0x00007fa2b5d70cfd in _ULx86_64_get_proc_info ()
+   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
+#5  0x00007fa2b5d6c775 in __libunwind_Unwind_GetLanguageSpecificData ()
+   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
+#6  0x00007fa2b503c6df in __gxx_personality_v0 () from /lib/x86_64-linux-gnu/libstdc++.so.6
+#7  0x00007fa2b5452ce5 in ?? () from /lib/x86_64-linux-gnu/libgcc_s.so.1
+#8  0x00007fa2b54533c0 in _Unwind_ForcedUnwind () from /lib/x86_64-linux-gnu/libgcc_s.so.1
+#9  0x00007fa2b4ca57a4 in __GI___pthread_unwind (buf=<optimized out>) at ./nptl/unwind.c:130
+#10 0x00007fa2b4c9dd22 in __do_cancel () at ../sysdeps/nptl/pthreadP.h:271
+#11 __GI___pthread_exit (value=0x0) at ./nptl/pthread_exit.c:36
+#12 0x0000000000000000 in ?? ()
+```
+
+### 根因
+
+libunwind 的 `src/unwind/*.c` 实现了 GCC 的 `_Unwind_*` ABI 兼容层（`_Unwind_GetLanguageSpecificData`、`_Unwind_ForcedUnwind`、`_Unwind_Resume` 等），与 `libgcc_s.so.1` 提供同名的全局符号。当 libunwind 以**动态库**形式被链接，并且在最终二进制的 `DT_NEEDED` 列表中位置比 `libgcc_s.so.1` 靠前时，运行时动态链接器 `ld.so` 会把 `pthread_exit` / 异常处理触发的 `_Unwind_*` 调用解析到 libunwind 中的 DWARF 实现。该实现需要的内部上下文在 `pthread_exit` 路径上未被 bRPC 初始化好，从而触发空指针访问。
+
+这是一个 ELF **运行时符号解析顺序**问题，与编译器（GCC / Clang）无关 —— Clang 默认运行时同样使用 `libstdc++ + libgcc_s`，会复现完全一致的崩溃。
+
+### 解决方案
+
+> **重要：不要使用系统包管理器安装的 libunwind**（例如 `apt install libunwind-dev`、`yum install libunwind-devel`）。多数发行版打包的 `libunwind.so` 仍把 `_Unwind_*` 暴露在动态符号表中，会触发本节描述的崩溃。
+>
+> 必须使用**从源码编译的 libunwind**。上游 `./configure` + `make` 默认会通过 `-Wl,--version-script` 把 `_Unwind_*` 标为 local，不导出到动态符号表，从而避免冲突。
+
+下表汇总了三种构建方式的推荐方案：
+
+| 构建方式 | 推荐方案 |
+|---|---|
+| `config_brpc.sh` + `make` | 从源码编译并安装 libunwind，把头文件与库目录显式传给 `config_brpc.sh` |
+| `cmake` | 从源码编译并安装 libunwind，把头文件与库目录显式传给 `cmake` |
+| `bazel`（Bzlmod） | 直接使用 brpc 仓库自维护的 libunwind 版本 |
+
+### `make`（`config_brpc.sh`）
+
+源码编译并安装 libunwind 到一个独立目录（避免污染系统目录），然后让 `config_brpc.sh` 显式从该目录查找 libunwind。
+
+```bash
+# 1) 源码编译 libunwind（推荐 v1.8.1 或以上版本）
+git clone https://github.com/libunwind/libunwind.git
+cd libunwind && git checkout tags/v1.8.1
+mkdir -p /opt/libunwind
+autoreconf -i
+./configure --prefix=/opt/libunwind
+make -j$(nproc) && make install
+cd ..
+
+# 2) 让 config_brpc.sh 使用 /libunwind 下的头文件与库（不要让它自动找到系统的 libunwind-dev）
+cd brpc
+sh config_brpc.sh \
+    --with-bthread-tracer \
+    --headers="/opt/libunwind/include /usr/include" \
+    --libs="/opt/libunwind/lib /usr/lib /usr/lib64"
+make -j$(nproc)
+```
+
+构建完成后可用以下命令确认 libunwind.so 没有导出 `_Unwind_*`：
+
+```bash
+nm -D /libunwind/lib/libunwind.so | grep ' T _Unwind_' \
+    && echo "WARN: _Unwind_* exported" \
+    || echo "OK: _Unwind_* hidden"
+```
+
+### `cmake`
+
+[`CMakeLists.txt`](../../CMakeLists.txt:90-100) 通过 `find_library(... NAMES unwind unwind-x86_64)` 查找 libunwind。同样需要先源码编译 libunwind 到独立前缀，再用 `CMAKE_PREFIX_PATH` 让 cmake 优先在该前缀下查找：
+
+```bash
+# 1) 源码编译 libunwind（同 make 章节）
+
+# 2) 让 cmake 在 /libunwind 下优先查找头文件和库
+cd brpc
+mkdir build && cd build
+cmake -DWITH_BTHREAD_TRACER=ON \
+      -DCMAKE_PREFIX_PATH=/opt/libunwind \
+      ..
+make -j$(nproc)
+```
+
+> 提示：如果系统已经装了 `libunwind-dev`，`find_library` 仍可能优先匹配到 `/usr/lib`。可在 cmake 命令上额外指定
+> `-DLIBUNWIND_LIB=/libunwind/lib/libunwind.so -DLIBUNWIND_X86_64_LIB=/libunwind/lib/libunwind-x86_64.so -DLIBUNWIND_INCLUDE_PATH=/libunwind/include`
+> 强制走自编译版本，避免系统包混入。
+
+### `bazel`（Bzlmod）
+
+bRPC 仓库已经在 [`registry/modules/libunwind/`](../../registry/modules/libunwind/) 维护了一份 libunwind 的 Bzlmod overlay，并通过 [`.bazelrc`](../../.bazelrc) 中的 `--registry=https://github.com/apache/brpc/registry` 使用 bRPC 维护的 overlay。版本号采用 `<base>.brpc-no-unwind` 后缀（例如 `1.8.3.brpc-no-unwind`），用以区别于 BCR 上的同基版本。该 overlay 增加了一个开关：
+
+```
+--define libunwind_hide_unwind_symbols=true
+```
+
+开启后，libunwind 的 `src/unwind/*.c`（即 GCC `_Unwind_*` 兼容层）整体不参与编译，等效于上游 autoconf 默认效果。bRPC 只使用 libunwind 的 `unw_*` 原生 API（`unw_getcontext`、`unw_init_local`、`unw_step` 等），不依赖 `_Unwind_*` 兼容层，因此该开关安全无副作用。
+
+`.bazelrc` 已默认在 `build:test` / `test` 配置下打开此开关：
+
+```
+build:test --define libunwind_hide_unwind_symbols=true
+test       --define libunwind_hide_unwind_symbols=true
+```
+
+用户按文档使用方法第 2 步加上 `--define=with_bthread_tracer=true` 即可：
+
+```bash
+# 测试场景，.bazelrc 中 test 配置已自动带上 hide 开关
+bazel test //test:bthread_unittest
+
+# 非测试构建（生产部署），需要显式同时带上两个 define
+bazel build --define=with_bthread_tracer=true \
+            --define=libunwind_hide_unwind_symbols=true \
+            //...
+```
+
+> **特别注意**：如果在生产构建中只启用 `--define=with_bthread_tracer=true` 而漏掉 `--define=libunwind_hide_unwind_symbols=true`，binary 在 `pthread_exit` / 异常路径上会概率性崩溃。
+
+构建后可用以下命令验证 libunwind 共享库没有导出 `_Unwind_*`：
+
+```bash
+nm -D bazel-bin/external/_solib_*/libexternal*libunwind*.so 2>/dev/null \
+    | grep ' T _Unwind_' || echo "OK: no _Unwind_* exported by libunwind.so"
+```
+
 
 # 相关flag
 

--- a/registry/modules/libunwind/1.8.1.brpc-no-unwind/MODULE.bazel
+++ b/registry/modules/libunwind/1.8.1.brpc-no-unwind/MODULE.bazel
@@ -1,0 +1,21 @@
+# Forked from the Bazel Central Registry:
+#   https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/libunwind/1.8.1/MODULE.bazel
+# Distributed under the Apache License, Version 2.0. See the `registry/modules/
+# libunwind/**` entry near the bottom of brpc's LICENSE file.
+#
+# brpc modification (Apache License 2.0 §4(b)):
+#   - `version` suffixed with `.brpc-no-unwind` to distinguish this brpc
+#     variant from the upstream BCR version.
+
+module(
+    name = "libunwind",
+    version = "1.8.1.brpc-no-unwind",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "xz", version = "5.4.5.bcr.5")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")

--- a/registry/modules/libunwind/1.8.1.brpc-no-unwind/overlay/BUILD.bazel
+++ b/registry/modules/libunwind/1.8.1.brpc-no-unwind/overlay/BUILD.bazel
@@ -1,0 +1,781 @@
+# This file is forked from the Bazel Central Registry:
+#   https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/libunwind/1.8.1/overlay/BUILD.bazel
+#
+# The original file is distributed under the Apache License, Version 2.0
+# (https://www.apache.org/licenses/LICENSE-2.0). See the `registry/modules/
+# libunwind/**` entry near the bottom of brpc's LICENSE file for the full
+# notice and the list of brpc's modifications.
+#
+# Modifications by brpc maintainers (Apache License 2.0 §4(b)):
+#   - Add the `hide_unwind_symbols` config_setting (gated by
+#     `--define=libunwind_hide_unwind_symbols=true`).
+#   - When the switch is on, drop `src/unwind/*.c` (the GCC `_Unwind_*` ABI
+#     compatibility layer) from `unwind_srcs` so the resulting libunwind
+#     does not export `_Unwind_*` symbols. See docs/cn/bthread_tracer.md
+#     for the rationale.
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Targets in this file are based off configure.ac, Makefile.am, and
+# src/Makefile.am with the default configurations.
+#
+# Only supports aarch64, arm, and x86_64 on Linux for now.
+
+### Config settings ############################################################
+
+# Bazel does not support nested selects, so we need config settings with the
+# various combinations of OS and CPU.
+
+# Switch to drop the GCC `_Unwind_*` ABI compatibility layer (src/unwind/*.c)
+# from the build. These sources implement `_Unwind_GetLanguageSpecificData`,
+# `_Unwind_ForcedUnwind`, `_Unwind_Resume`, etc. - the very symbols that
+# libgcc_s also provides. When Bazel builds libunwind as a dylib (its default
+# behavior in fastbuild), these symbols get exported and at runtime the dynamic
+# loader resolves the libstdc++ / pthread_exit unwinding paths to libunwind's
+# DWARF-based implementations instead of libgcc_s's, causing crashes such as:
+#   _Unwind_ForcedUnwind -> __gxx_personality_v0 ->
+#     __libunwind_Unwind_GetLanguageSpecificData -> SEGV in
+#     _ULx86_64_dwarf_find_proc_info.
+#
+# brpc only consumes libunwind's native `unw_*` API (provided by src/mi/), so
+# omitting src/unwind/*.c is safe and is the same effect autoconf gets via
+# `--version-script` in the upstream Makefile (the make-built libunwind.so does
+# not export `_Unwind_*` either - see CI's init-ut-make-config action).
+#
+# Enable with: --define=libunwind_hide_unwind_symbols=true
+config_setting(
+    name = "hide_unwind_symbols",
+    values = {"define": "libunwind_hide_unwind_symbols=true"},
+)
+
+selects.config_setting_group(
+    name = "linux_arm64",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_arm",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_x86_64",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+### Common defines #############################################################
+
+libunwind_defines = [
+    # Defaults based on configure.ac assuming we're on a modern Linux OS.
+    "_GNU_SOURCE",
+    "CONFIG_BLOCK_SIGNALS",
+    "CONFIG_WEAK_BACKTRACE",
+    "CONSERVATIVE_CHECKS",
+    "HAVE__BUILTIN___CLEAR_CACHE",
+    "HAVE__BUILTIN_UNREACHABLE",
+    "HAVE_ELF_H",
+    "HAVE_LINK_H",
+    "HAVE_LZMA",
+    "HAVE_ZLIB",
+]
+
+### Common source files ########################################################
+
+dwarf_srcs = glob(["src/dwarf/*.c"])
+
+dwarf_textual_hdrs = glob(["src/dwarf/G*.c"])
+
+mi_srcs = glob(
+    ["src/mi/*.c"],
+    exclude = [
+        # Only included if Linux.
+        "src/mi/_ReadSLEB.c",
+        "src/mi/_ReadULEB.c",
+        # The Makefile does not include this, it's also broken as it can include
+        # Gdyn-remote.c in certain situations, which uses WSIZE, which will not
+        # be defined in the situations Gdyn-remote.c is included.
+        "src/mi/Ldyn-remote.c",
+        # TODO: for some reason these complain about duplicate definitions if
+        # included.
+        "src/mi/Gaddress_validator.c",
+        "src/mi/Gget_accessors.c",
+    ],
+)
+
+mi_textual_hdrs = glob(["src/mi/G*.c"])
+
+# When `--define=libunwind_hide_unwind_symbols=true`, drop src/unwind/ entirely
+# so libunwind does not provide its own `_Unwind_*` implementations. See the
+# comment on `:hide_unwind_symbols` config_setting above.
+unwind_srcs = select({
+    ":hide_unwind_symbols": [],
+    "//conditions:default": glob([
+        "src/unwind/*.c",
+        "src/unwind/*.h",
+    ]),
+})
+
+### Features source files ######################################################
+
+coredump_srcs = glob(
+    [
+        "src/coredump/*.c",
+        "src/coredump/*.h",
+    ],
+    exclude = [
+        "src/coredump/_UCD_access_reg_freebsd.c",
+        "src/coredump/_UCD_access_reg_linux.c",
+        "src/coredump/_UCD_access_reg_qnx.c",
+        "src/coredump/_UCD_get_mapinfo_generic.c",
+        "src/coredump/_UCD_get_mapinfo_linux.c",
+        "src/coredump/_UCD_get_mapinfo_qnx.c",
+        "src/coredump/_UCD_get_threadinfo_prstatus.c",
+    ],
+) + select({
+    "@platforms//os:linux": [
+        "src/coredump/_UCD_access_reg_linux.c",
+        "src/coredump/_UCD_get_mapinfo_linux.c",
+        "src/coredump/_UCD_get_threadinfo_prstatus.c",
+    ],
+    "//conditions:default": [],
+})
+
+ptrace_srcs = glob([
+    "src/ptrace/*.c",
+    "src/ptrace/*.h",
+])
+
+setjmp_srcs = glob([
+    "src/setjmp/*.c",
+    "src/setjmp/*.h",
+]) + select({
+    "@platforms//cpu:aarch64": [
+        "src/aarch64/longjmp.S",
+        "src/aarch64/siglongjmp.S",
+    ],
+    "@platforms//cpu:arm": [
+        "src/arm/siglongjmp.S",
+    ],
+    "@platforms//cpu:x86_64": [
+        "src/x86_64/longjmp.S",
+        "src/x86_64/siglongjmp.S",
+    ],
+})
+
+### Arch specific source files #################################################
+
+arm64_srcs = select({
+    "@platforms//cpu:aarch64": glob(
+        [
+            "src/aarch64/*.c",
+            "src/aarch64/*.h",
+        ],
+        exclude = [
+            "src/aarch64/Los-freebsd.c",
+            "src/aarch64/Los-linux.c",
+            "src/aarch64/Los-qnx.c",
+            "src/aarch64/Gos-freebsd.c",
+            "src/aarch64/Gos-linux.c",
+            "src/aarch64/Gos-qnx.c",
+        ],
+    ) + [
+        # The Makefile doesn't include this and only includes it if the OS
+        # is FreeBSD. This is inconsistent with the other archs, not sure
+        # whether this is intended.
+        # "src/aarch64/setcontext.S",
+        "src/aarch64/getcontext.S",
+        "src/elf64.h",
+    ],
+    "//conditions:default": [],
+})
+
+arm64_textual_hdrs = select({
+    "@platforms//cpu:aarch64": glob(
+        [
+            "src/aarch64/G*.c",
+        ],
+        exclude = [
+            "src/aarch64/Gos-freebsd.c",
+            "src/aarch64/Gos-linux.c",
+            "src/aarch64/Gos-qnx.c",
+        ],
+    ) + [
+        "src/elf64.c",
+    ],
+    "//conditions:default": [],
+})
+
+arm_srcs = select({
+    "@platforms//cpu:arm": glob(
+        [
+            "src/arm/*.c",
+            "src/arm/*.h",
+        ],
+        exclude = [
+            "src/arm/Los-freebsd.c",
+            "src/arm/Los-linux.c",
+            "src/arm/Los-other.c",
+            "src/arm/Gos-freebsd.c",
+            "src/arm/Gos-linux.c",
+            "src/arm/Gos-other.c",
+        ],
+    ) + [
+        "src/arm/getcontext.S",
+        "src/elf32.h",
+    ],
+    "//conditions:default": [],
+})
+
+arm_textual_hdrs = select({
+    "@platforms//cpu:arm": glob(
+        [
+            "src/arm/G*.c",
+        ],
+        exclude = [
+            "src/arm/Gos-freebsd.c",
+            "src/arm/Gos-linux.c",
+            "src/arm/Gos-other.c",
+        ],
+    ) + [
+        "src/elf32.c",
+    ],
+    "//conditions:default": [],
+})
+
+x86_64_srcs = select({
+    "@platforms//cpu:x86_64": glob(
+        [
+            "src/x86_64/*.c",
+            "src/x86_64/*.h",
+        ],
+        exclude = [
+            "src/x86_64/Los-freebsd.c",
+            "src/x86_64/Los-linux.c",
+            "src/x86_64/Los-qnx.c",
+            "src/x86_64/Los-solaris.c",
+            "src/x86_64/Gos-freebsd.c",
+            "src/x86_64/Gos-linux.c",
+            "src/x86_64/Gos-qnx.c",
+            "src/x86_64/Gos-solaris.c",
+        ],
+    ) + [
+        "src/elf64.h",
+        "src/x86_64/getcontext.S",
+        "src/x86_64/setcontext.S",
+    ],
+    "//conditions:default": [],
+})
+
+x86_64_textual_hdrs = select({
+    "@platforms//cpu:x86_64": glob(
+        [
+            "src/x86_64/G*.c",
+        ],
+        exclude = [
+            "src/x86_64/Gos-freebsd.c",
+            "src/x86_64/Gos-linux.c",
+            "src/x86_64/Gos-qnx.c",
+            "src/x86_64/Gos-solaris.c",
+        ],
+    ) + [
+        "src/elf64.c",
+    ],
+    "//conditions:default": [],
+})
+
+### OS specific source files ###################################################
+
+linux_srcs = select({
+    "@platforms//os:linux": [
+        "src/dl-iterate-phdr.c",
+        "src/mi/_ReadSLEB.c",
+        "src/mi/_ReadULEB.c",
+        "src/os-linux.c",
+        "src/os-linux.h",
+    ],
+    "//conditions:default": [],
+}) + select({
+    ":linux_arm64": [
+        "src/aarch64/Los-linux.c",
+        "src/aarch64/Gos-linux.c",
+    ],
+    "//conditions:default": [],
+}) + select({
+    ":linux_arm": [
+        "src/arm/Los-linux.c",
+        "src/arm/Gos-linux.c",
+    ],
+    "//conditions:default": [],
+}) + select({
+    ":linux_x86_64": [
+        "src/x86_64/Los-linux.c",
+        "src/x86_64/Gos-linux.c",
+    ],
+    "//conditions:default": [],
+})
+
+linux_textual_hdrs = select({
+    ":linux_arm64": ["src/aarch64/Gos-linux.c"],
+    "//conditions:default": [],
+}) + select({
+    ":linux_arm": ["src/arm/Gos-linux.c"],
+    "//conditions:default": [],
+}) + select({
+    ":linux_x86_64": ["src/x86_64/Gos-linux.c"],
+    "//conditions:default": [],
+})
+
+### libunwind ##################################################################
+
+libunwind_srcs = [
+    "src/elfxx.h",
+    "src/elfxx.c",
+] + dwarf_srcs + mi_srcs + unwind_srcs + arm64_srcs + arm_srcs + x86_64_srcs + linux_srcs
+
+libunwind_textual_hdrs = [
+    "src/elfxx.c",
+] + dwarf_textual_hdrs + mi_textual_hdrs + arm64_textual_hdrs + arm_textual_hdrs + x86_64_textual_hdrs + linux_textual_hdrs
+
+expand_template(
+    name = "libunwind_common_h",
+    out = "include/libunwind-common.h",
+    substitutions = {
+        "@PKG_MAJOR@": "1",
+        "@PKG_MINOR@": "8",
+        "@PKG_EXTRA@": "1",
+    },
+    template = "include/libunwind-common.h.in",
+)
+
+cc_library(
+    name = "unwind",
+    srcs = libunwind_srcs,
+    hdrs = glob(["include/tdep/*.h"]) + [
+        "include/compiler.h",
+        "include/dwarf.h",
+        "include/dwarf-eh.h",
+        "include/dwarf_i.h",
+        "include/libunwind.h",
+        "include/libunwind-dynamic.h",
+        "include/libunwind_i.h",
+        "include/mempool.h",
+        "include/remote.h",
+        "include/unwind.h",
+        ":libunwind_common_h",
+    ] + select({
+        "@platforms//cpu:arm64": glob(["include/tdep-aarch64/*.h"]) + ["include/libunwind-aarch64.h"],
+        "@platforms//cpu:arm": glob(["include/tdep-arm/*.h"]) + ["include/libunwind-arm.h"],
+        "@platforms//cpu:x86_64": ["include/libunwind-x86_64.h"] + glob(["include/tdep-x86_64/*.h"]),
+    }),
+    includes = [
+        "include",
+        "src",
+    ] + select({
+        "@platforms//cpu:arm64": [
+            "include/tdep-aarch64",
+        ],
+        "@platforms//cpu:arm": [
+            "include/tdep-arm",
+        ],
+        "@platforms//cpu:x86_64": [
+            "include/tdep-x86_64",
+        ],
+    }),
+    local_defines = libunwind_defines + ["HAVE_DL_ITERATE_PHDR"],
+    textual_hdrs = libunwind_textual_hdrs,
+    deps = [
+        "@xz//:lzma",
+        "@zlib",
+    ],
+)
+
+cc_library(
+    name = "unwind_coredump",
+    srcs = coredump_srcs + ["src/mi/init.c"],
+    hdrs = ["include/libunwind-coredump.h"],
+    includes = ["include"],
+    local_defines = libunwind_defines + [
+        "HAVE_STRUCT_ELF_PRSTATUS",
+        "HAVE_SYS_PROCFS_H",
+    ] + select({
+        "@platforms//cpu:arm64": [
+            "CONFIG_DEBUG_FRAME",
+            "SIZEOF_OFF_T=8",
+        ],
+        "@platforms//cpu:arm": [
+            "CONFIG_DEBUG_FRAME",
+            "SIZEOF_OFF_T=4",
+        ],
+        "@platforms//cpu:x86_64": [
+            "SIZEOF_OFF_T=8",
+        ],
+    }),
+    deps = [
+        ":unwind",
+        "@xz//:lzma",
+        "@zlib",
+    ],
+)
+
+cc_library(
+    name = "unwind_ptrace",
+    srcs = ptrace_srcs + ["src/mi/init.c"],
+    hdrs = ["include/libunwind-ptrace.h"],
+    includes = ["include"],
+    local_defines = libunwind_defines + ["HAVE_TTRACE"],
+    deps = [
+        ":unwind",
+        "@xz//:lzma",
+        "@zlib",
+    ],
+)
+
+cc_library(
+    name = "unwind_setjmp",
+    srcs = setjmp_srcs + ["src/mi/init.c"],
+    local_defines = libunwind_defines,
+    deps = [
+        ":unwind",
+        "@xz//:lzma",
+        "@zlib",
+    ],
+)
+
+alias(
+    name = "libunwind",
+    actual = ":unwind",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libunwind_coredump",
+    actual = ":unwind_coredump",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libunwind_ptrace",
+    actual = ":unwind_ptrace",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libunwind_setjmp",
+    actual = ":unwind_setjmp",
+    visibility = ["//visibility:public"],
+)
+
+### Tests #####################################################################
+
+# TODO: the following tests currently do not work:
+#   crasher.c
+#   forker.c
+#   test-coredump-unwind.c
+#   test-init-remote.c
+#   test-proc-info.c
+#   test-ptrace-misc.c
+#   test-ptrace.c
+#   test-setjmp.c
+
+# Some tests require these test helper files.
+cc_library(
+    name = "unwind_test_helpers",
+    testonly = True,
+    srcs = [
+        "tests/flush-cache.S",
+        "tests/ident.c",
+    ],
+    hdrs = glob(["tests/*G*.c"]) + [
+        "tests/Gtest-init.cxx",
+        "tests/flush-cache.h",
+        "tests/ident.h",
+    ],
+    defines = ["_GNU_SOURCE"],
+)
+
+cc_test(
+    name = "frame_record_test",
+    srcs = ["tests/aarch64-test-frame-record.c"],
+    target_compatible_with = ["@platforms//cpu:arm64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "plt_test",
+    srcs = ["tests/aarch64-test-plt.c"],
+    target_compatible_with = ["@platforms//cpu:arm64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "arm64_sve_signal_test",
+    srcs = ["tests/Larm64-test-sve-signal.c"],
+    target_compatible_with = ["@platforms//cpu:arm64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "perf_simple_test",
+    srcs = ["tests/Lperf-simple.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "perf_trace_test",
+    srcs = ["tests/Lperf-trace.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "rs_race_test",
+    srcs = ["tests/Lrs-race.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "bt_test",
+    srcs = ["tests/Ltest-bt.c"],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "concurrent_test",
+    srcs = ["tests/Ltest-concurrent.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "cxx_exceptions_test",
+    srcs = ["tests/Ltest-cxx-exceptions.cxx"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+# TODO: fails on Debian 11 and Ubuntu 20.04.
+# cc_test(
+#     name = "dyn1_test",
+#     srcs = ["tests/Ltest-dyn1.c"],
+#     deps = [
+#         ":unwind",
+#         ":unwind_test_helpers",
+#     ],
+#     linkopts = ["-ldl"],
+# )
+
+cc_test(
+    name = "exc_test",
+    srcs = ["tests/Ltest-exc.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "init_local_signal_test",
+    srcs = [
+        "tests/Ltest-init-local-signal.c",
+        "tests/Ltest-init-local-signal-lib.c",
+    ],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "init_test",
+    srcs = ["tests/Ltest-init.cxx"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "mem_validate_test",
+    srcs = ["tests/Ltest-mem-validate.c"],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "nocalloc_test",
+    srcs = ["tests/Ltest-nocalloc.c"],
+    linkopts = ["-ldl"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "nomalloc_test",
+    srcs = ["tests/Ltest-nomalloc.c"],
+    linkopts = ["-ldl"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "resume_sig_rt_test",
+    srcs = ["tests/Ltest-resume-sig-rt.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "resume_sig_test",
+    srcs = ["tests/Ltest-resume-sig.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "trace_test",
+    srcs = ["tests/Ltest-trace.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "varargs_test",
+    srcs = ["tests/Ltest-varargs.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "dwarf_expressions_test",
+    srcs = [
+        "tests/Lx64-test-dwarf-expressions.c",
+        "tests/x64-test-dwarf-expressions.S",
+    ],
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "async_sig_test",
+    srcs = ["tests/test-async-sig.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "flush_cache_test",
+    srcs = ["tests/test-flush-cache.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "mem_test",
+    srcs = ["tests/test-mem.c"],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "reg_state_test",
+    srcs = ["tests/test-reg-state.c"],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "static_link_loc_test",
+    srcs = [
+        "tests/test-static-link-gen.c",
+        "tests/test-static-link-loc.c",
+    ],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "strerror_test",
+    srcs = ["tests/test-strerror.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "unwind_badjmp_signal_frame_test",
+    srcs = ["tests/x64-unwind-badjmp-signal-frame.c"],
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)

--- a/registry/modules/libunwind/1.8.1.brpc-no-unwind/overlay/MODULE.bazel
+++ b/registry/modules/libunwind/1.8.1.brpc-no-unwind/overlay/MODULE.bazel
@@ -1,0 +1,21 @@
+# Forked from the Bazel Central Registry:
+#   https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/libunwind/1.8.1/overlay/MODULE.bazel
+# Distributed under the Apache License, Version 2.0. See the `registry/modules/
+# libunwind/**` entry near the bottom of brpc's LICENSE file.
+#
+# brpc modification (Apache License 2.0 §4(b)):
+#   - `version` suffixed with `.brpc-no-unwind` to distinguish this brpc
+#     variant from the upstream BCR version.
+
+module(
+    name = "libunwind",
+    version = "1.8.1.brpc-no-unwind",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "xz", version = "5.4.5.bcr.5")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")

--- a/registry/modules/libunwind/1.8.1.brpc-no-unwind/presubmit.yml
+++ b/registry/modules/libunwind/1.8.1.brpc-no-unwind/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@libunwind//:libunwind"
+      - "@libunwind//:libunwind_coredump"
+      - "@libunwind//:libunwind_ptrace"
+      - "@libunwind//:libunwind_setjmp"
+    test_targets:
+      - "@libunwind//..."

--- a/registry/modules/libunwind/1.8.1.brpc-no-unwind/source.json
+++ b/registry/modules/libunwind/1.8.1.brpc-no-unwind/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/libunwind/libunwind/releases/download/v1.8.1/libunwind-1.8.1.tar.gz",
+    "integrity": "sha256-3fDjLdX6/lKDGY035L+d7Pe6F3C25+AGwz5t955qYVc=",
+    "strip_prefix": "libunwind-1.8.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-X2B6q+gpb5U0BGoD8LJPoBPCpyIvT5QFSwsjFxZ9R+0=",
+        "MODULE.bazel": "sha256-Yu1CCsCC+A2NXfQ3bgzpbtQcYhM+bPPb2YAPKPojdIY="
+    }
+}

--- a/registry/modules/libunwind/1.8.3.brpc-no-unwind/MODULE.bazel
+++ b/registry/modules/libunwind/1.8.3.brpc-no-unwind/MODULE.bazel
@@ -1,0 +1,21 @@
+# Forked from the Bazel Central Registry:
+#   https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/libunwind/1.8.3/MODULE.bazel
+# Distributed under the Apache License, Version 2.0. See the `registry/modules/
+# libunwind/**` entry near the bottom of brpc's LICENSE file.
+#
+# brpc modification (Apache License 2.0 §4(b)):
+#   - `version` suffixed with `.brpc-no-unwind` to distinguish this brpc
+#     variant from the upstream BCR version.
+
+module(
+    name = "libunwind",
+    version = "1.8.3.brpc-no-unwind",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "xz", version = "5.4.5.bcr.8")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.8")

--- a/registry/modules/libunwind/1.8.3.brpc-no-unwind/overlay/BUILD.bazel
+++ b/registry/modules/libunwind/1.8.3.brpc-no-unwind/overlay/BUILD.bazel
@@ -1,0 +1,781 @@
+# This file is forked from the Bazel Central Registry:
+#   https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/libunwind/1.8.3/overlay/BUILD.bazel
+#
+# The original file is distributed under the Apache License, Version 2.0
+# (https://www.apache.org/licenses/LICENSE-2.0). See the `registry/modules/
+# libunwind/**` entry near the bottom of brpc's LICENSE file for the full
+# notice and the list of brpc's modifications.
+#
+# Modifications by brpc maintainers (Apache License 2.0 §4(b)):
+#   - Add the `hide_unwind_symbols` config_setting (gated by
+#     `--define=libunwind_hide_unwind_symbols=true`).
+#   - When the switch is on, drop `src/unwind/*.c` (the GCC `_Unwind_*` ABI
+#     compatibility layer) from `unwind_srcs` so the resulting libunwind
+#     does not export `_Unwind_*` symbols. See docs/cn/bthread_tracer.md
+#     for the rationale.
+
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+# Targets in this file are based off configure.ac, Makefile.am, and
+# src/Makefile.am with the default configurations.
+#
+# Only supports aarch64, arm, and x86_64 on Linux for now.
+
+### Config settings ############################################################
+
+# Bazel does not support nested selects, so we need config settings with the
+# various combinations of OS and CPU.
+
+# Switch to drop the GCC `_Unwind_*` ABI compatibility layer (src/unwind/*.c)
+# from the build. These sources implement `_Unwind_GetLanguageSpecificData`,
+# `_Unwind_ForcedUnwind`, `_Unwind_Resume`, etc. - the very symbols that
+# libgcc_s also provides. When Bazel builds libunwind as a dylib (its default
+# behavior in fastbuild), these symbols get exported and at runtime the dynamic
+# loader resolves the libstdc++ / pthread_exit unwinding paths to libunwind's
+# DWARF-based implementations instead of libgcc_s's, causing crashes such as:
+#   _Unwind_ForcedUnwind -> __gxx_personality_v0 ->
+#     __libunwind_Unwind_GetLanguageSpecificData -> SEGV in
+#     _ULx86_64_dwarf_find_proc_info.
+#
+# brpc only consumes libunwind's native `unw_*` API (provided by src/mi/), so
+# omitting src/unwind/*.c is safe and is the same effect autoconf gets via
+# `--version-script` in the upstream Makefile (the make-built libunwind.so does
+# not export `_Unwind_*` either - see CI's init-ut-make-config action).
+#
+# Enable with: --define=libunwind_hide_unwind_symbols=true
+config_setting(
+    name = "hide_unwind_symbols",
+    values = {"define": "libunwind_hide_unwind_symbols=true"},
+)
+
+selects.config_setting_group(
+    name = "linux_arm64",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_arm",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_x86_64",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+### Common defines #############################################################
+
+libunwind_defines = [
+    # Defaults based on configure.ac assuming we're on a modern Linux OS.
+    "_GNU_SOURCE",
+    "CONFIG_BLOCK_SIGNALS",
+    "CONFIG_WEAK_BACKTRACE",
+    "CONSERVATIVE_CHECKS",
+    "HAVE__BUILTIN___CLEAR_CACHE",
+    "HAVE__BUILTIN_UNREACHABLE",
+    "HAVE_ELF_H",
+    "HAVE_LINK_H",
+    "HAVE_LZMA",
+    "HAVE_ZLIB",
+]
+
+### Common source files ########################################################
+
+dwarf_srcs = glob(["src/dwarf/*.c"])
+
+dwarf_textual_hdrs = glob(["src/dwarf/G*.c"])
+
+mi_srcs = glob(
+    ["src/mi/*.c"],
+    exclude = [
+        # Only included if Linux.
+        "src/mi/_ReadSLEB.c",
+        "src/mi/_ReadULEB.c",
+        # The Makefile does not include this, it's also broken as it can include
+        # Gdyn-remote.c in certain situations, which uses WSIZE, which will not
+        # be defined in the situations Gdyn-remote.c is included.
+        "src/mi/Ldyn-remote.c",
+        # TODO: for some reason these complain about duplicate definitions if
+        # included.
+        "src/mi/Gaddress_validator.c",
+        "src/mi/Gget_accessors.c",
+    ],
+)
+
+mi_textual_hdrs = glob(["src/mi/G*.c"])
+
+# When `--define=libunwind_hide_unwind_symbols=true`, drop src/unwind/ entirely
+# so libunwind does not provide its own `_Unwind_*` implementations. See the
+# comment on `:hide_unwind_symbols` config_setting above.
+unwind_srcs = select({
+    ":hide_unwind_symbols": [],
+    "//conditions:default": glob([
+        "src/unwind/*.c",
+        "src/unwind/*.h",
+    ]),
+})
+
+### Features source files ######################################################
+
+coredump_srcs = glob(
+    [
+        "src/coredump/*.c",
+        "src/coredump/*.h",
+    ],
+    exclude = [
+        "src/coredump/_UCD_access_reg_freebsd.c",
+        "src/coredump/_UCD_access_reg_linux.c",
+        "src/coredump/_UCD_access_reg_qnx.c",
+        "src/coredump/_UCD_get_mapinfo_generic.c",
+        "src/coredump/_UCD_get_mapinfo_linux.c",
+        "src/coredump/_UCD_get_mapinfo_qnx.c",
+        "src/coredump/_UCD_get_threadinfo_prstatus.c",
+    ],
+) + select({
+    "@platforms//os:linux": [
+        "src/coredump/_UCD_access_reg_linux.c",
+        "src/coredump/_UCD_get_mapinfo_linux.c",
+        "src/coredump/_UCD_get_threadinfo_prstatus.c",
+    ],
+    "//conditions:default": [],
+})
+
+ptrace_srcs = glob([
+    "src/ptrace/*.c",
+    "src/ptrace/*.h",
+])
+
+setjmp_srcs = glob([
+    "src/setjmp/*.c",
+    "src/setjmp/*.h",
+]) + select({
+    "@platforms//cpu:aarch64": [
+        "src/aarch64/longjmp.S",
+        "src/aarch64/siglongjmp.S",
+    ],
+    "@platforms//cpu:arm": [
+        "src/arm/siglongjmp.S",
+    ],
+    "@platforms//cpu:x86_64": [
+        "src/x86_64/longjmp.S",
+        "src/x86_64/siglongjmp.S",
+    ],
+})
+
+### Arch specific source files #################################################
+
+arm64_srcs = select({
+    "@platforms//cpu:aarch64": glob(
+        [
+            "src/aarch64/*.c",
+            "src/aarch64/*.h",
+        ],
+        exclude = [
+            "src/aarch64/Los-freebsd.c",
+            "src/aarch64/Los-linux.c",
+            "src/aarch64/Los-qnx.c",
+            "src/aarch64/Gos-freebsd.c",
+            "src/aarch64/Gos-linux.c",
+            "src/aarch64/Gos-qnx.c",
+        ],
+    ) + [
+        # The Makefile doesn't include this and only includes it if the OS
+        # is FreeBSD. This is inconsistent with the other archs, not sure
+        # whether this is intended.
+        # "src/aarch64/setcontext.S",
+        "src/aarch64/getcontext.S",
+        "src/elf64.h",
+    ],
+    "//conditions:default": [],
+})
+
+arm64_textual_hdrs = select({
+    "@platforms//cpu:aarch64": glob(
+        [
+            "src/aarch64/G*.c",
+        ],
+        exclude = [
+            "src/aarch64/Gos-freebsd.c",
+            "src/aarch64/Gos-linux.c",
+            "src/aarch64/Gos-qnx.c",
+        ],
+    ) + [
+        "src/elf64.c",
+    ],
+    "//conditions:default": [],
+})
+
+arm_srcs = select({
+    "@platforms//cpu:arm": glob(
+        [
+            "src/arm/*.c",
+            "src/arm/*.h",
+        ],
+        exclude = [
+            "src/arm/Los-freebsd.c",
+            "src/arm/Los-linux.c",
+            "src/arm/Los-other.c",
+            "src/arm/Gos-freebsd.c",
+            "src/arm/Gos-linux.c",
+            "src/arm/Gos-other.c",
+        ],
+    ) + [
+        "src/arm/getcontext.S",
+        "src/elf32.h",
+    ],
+    "//conditions:default": [],
+})
+
+arm_textual_hdrs = select({
+    "@platforms//cpu:arm": glob(
+        [
+            "src/arm/G*.c",
+        ],
+        exclude = [
+            "src/arm/Gos-freebsd.c",
+            "src/arm/Gos-linux.c",
+            "src/arm/Gos-other.c",
+        ],
+    ) + [
+        "src/elf32.c",
+    ],
+    "//conditions:default": [],
+})
+
+x86_64_srcs = select({
+    "@platforms//cpu:x86_64": glob(
+        [
+            "src/x86_64/*.c",
+            "src/x86_64/*.h",
+        ],
+        exclude = [
+            "src/x86_64/Los-freebsd.c",
+            "src/x86_64/Los-linux.c",
+            "src/x86_64/Los-qnx.c",
+            "src/x86_64/Los-solaris.c",
+            "src/x86_64/Gos-freebsd.c",
+            "src/x86_64/Gos-linux.c",
+            "src/x86_64/Gos-qnx.c",
+            "src/x86_64/Gos-solaris.c",
+        ],
+    ) + [
+        "src/elf64.h",
+        "src/x86_64/getcontext.S",
+        "src/x86_64/setcontext.S",
+    ],
+    "//conditions:default": [],
+})
+
+x86_64_textual_hdrs = select({
+    "@platforms//cpu:x86_64": glob(
+        [
+            "src/x86_64/G*.c",
+        ],
+        exclude = [
+            "src/x86_64/Gos-freebsd.c",
+            "src/x86_64/Gos-linux.c",
+            "src/x86_64/Gos-qnx.c",
+            "src/x86_64/Gos-solaris.c",
+        ],
+    ) + [
+        "src/elf64.c",
+    ],
+    "//conditions:default": [],
+})
+
+### OS specific source files ###################################################
+
+linux_srcs = select({
+    "@platforms//os:linux": [
+        "src/dl-iterate-phdr.c",
+        "src/mi/_ReadSLEB.c",
+        "src/mi/_ReadULEB.c",
+        "src/os-linux.c",
+        "src/os-linux.h",
+    ],
+    "//conditions:default": [],
+}) + select({
+    ":linux_arm64": [
+        "src/aarch64/Los-linux.c",
+        "src/aarch64/Gos-linux.c",
+    ],
+    "//conditions:default": [],
+}) + select({
+    ":linux_arm": [
+        "src/arm/Los-linux.c",
+        "src/arm/Gos-linux.c",
+    ],
+    "//conditions:default": [],
+}) + select({
+    ":linux_x86_64": [
+        "src/x86_64/Los-linux.c",
+        "src/x86_64/Gos-linux.c",
+    ],
+    "//conditions:default": [],
+})
+
+linux_textual_hdrs = select({
+    ":linux_arm64": ["src/aarch64/Gos-linux.c"],
+    "//conditions:default": [],
+}) + select({
+    ":linux_arm": ["src/arm/Gos-linux.c"],
+    "//conditions:default": [],
+}) + select({
+    ":linux_x86_64": ["src/x86_64/Gos-linux.c"],
+    "//conditions:default": [],
+})
+
+### libunwind ##################################################################
+
+libunwind_srcs = [
+    "src/elfxx.h",
+    "src/elfxx.c",
+] + dwarf_srcs + mi_srcs + unwind_srcs + arm64_srcs + arm_srcs + x86_64_srcs + linux_srcs
+
+libunwind_textual_hdrs = [
+    "src/elfxx.c",
+] + dwarf_textual_hdrs + mi_textual_hdrs + arm64_textual_hdrs + arm_textual_hdrs + x86_64_textual_hdrs + linux_textual_hdrs
+
+expand_template(
+    name = "libunwind_common_h",
+    out = "include/libunwind-common.h",
+    substitutions = {
+        "@PKG_MAJOR@": "1",
+        "@PKG_MINOR@": "8",
+        "@PKG_EXTRA@": "1",
+    },
+    template = "include/libunwind-common.h.in",
+)
+
+cc_library(
+    name = "unwind",
+    srcs = libunwind_srcs,
+    hdrs = glob(["include/tdep/*.h"]) + [
+        "include/compiler.h",
+        "include/dwarf.h",
+        "include/dwarf-eh.h",
+        "include/dwarf_i.h",
+        "include/libunwind.h",
+        "include/libunwind-dynamic.h",
+        "include/libunwind_i.h",
+        "include/mempool.h",
+        "include/remote.h",
+        "include/unwind.h",
+        ":libunwind_common_h",
+    ] + select({
+        "@platforms//cpu:arm64": glob(["include/tdep-aarch64/*.h"]) + ["include/libunwind-aarch64.h"],
+        "@platforms//cpu:arm": glob(["include/tdep-arm/*.h"]) + ["include/libunwind-arm.h"],
+        "@platforms//cpu:x86_64": ["include/libunwind-x86_64.h"] + glob(["include/tdep-x86_64/*.h"]),
+    }),
+    includes = [
+        "include",
+        "src",
+    ] + select({
+        "@platforms//cpu:arm64": [
+            "include/tdep-aarch64",
+        ],
+        "@platforms//cpu:arm": [
+            "include/tdep-arm",
+        ],
+        "@platforms//cpu:x86_64": [
+            "include/tdep-x86_64",
+        ],
+    }),
+    local_defines = libunwind_defines + ["HAVE_DL_ITERATE_PHDR"],
+    textual_hdrs = libunwind_textual_hdrs,
+    deps = [
+        "@xz//:lzma",
+        "@zlib",
+    ],
+)
+
+cc_library(
+    name = "unwind_coredump",
+    srcs = coredump_srcs + ["src/mi/init.c"],
+    hdrs = ["include/libunwind-coredump.h"],
+    includes = ["include"],
+    local_defines = libunwind_defines + [
+        "HAVE_STRUCT_ELF_PRSTATUS",
+        "HAVE_SYS_PROCFS_H",
+    ] + select({
+        "@platforms//cpu:arm64": [
+            "CONFIG_DEBUG_FRAME",
+            "SIZEOF_OFF_T=8",
+        ],
+        "@platforms//cpu:arm": [
+            "CONFIG_DEBUG_FRAME",
+            "SIZEOF_OFF_T=4",
+        ],
+        "@platforms//cpu:x86_64": [
+            "SIZEOF_OFF_T=8",
+        ],
+    }),
+    deps = [
+        ":unwind",
+        "@xz//:lzma",
+        "@zlib",
+    ],
+)
+
+cc_library(
+    name = "unwind_ptrace",
+    srcs = ptrace_srcs + ["src/mi/init.c"],
+    hdrs = ["include/libunwind-ptrace.h"],
+    includes = ["include"],
+    local_defines = libunwind_defines + ["HAVE_TTRACE"],
+    deps = [
+        ":unwind",
+        "@xz//:lzma",
+        "@zlib",
+    ],
+)
+
+cc_library(
+    name = "unwind_setjmp",
+    srcs = setjmp_srcs + ["src/mi/init.c"],
+    local_defines = libunwind_defines,
+    deps = [
+        ":unwind",
+        "@xz//:lzma",
+        "@zlib",
+    ],
+)
+
+alias(
+    name = "libunwind",
+    actual = ":unwind",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libunwind_coredump",
+    actual = ":unwind_coredump",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libunwind_ptrace",
+    actual = ":unwind_ptrace",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libunwind_setjmp",
+    actual = ":unwind_setjmp",
+    visibility = ["//visibility:public"],
+)
+
+### Tests #####################################################################
+
+# TODO: the following tests currently do not work:
+#   crasher.c
+#   forker.c
+#   test-coredump-unwind.c
+#   test-init-remote.c
+#   test-proc-info.c
+#   test-ptrace-misc.c
+#   test-ptrace.c
+#   test-setjmp.c
+
+# Some tests require these test helper files.
+cc_library(
+    name = "unwind_test_helpers",
+    testonly = True,
+    srcs = [
+        "tests/flush-cache.S",
+        "tests/ident.c",
+    ],
+    hdrs = glob(["tests/*G*.c"]) + [
+        "tests/Gtest-init.cxx",
+        "tests/flush-cache.h",
+        "tests/ident.h",
+    ],
+    defines = ["_GNU_SOURCE"],
+)
+
+cc_test(
+    name = "frame_record_test",
+    srcs = ["tests/aarch64-test-frame-record.c"],
+    target_compatible_with = ["@platforms//cpu:arm64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "plt_test",
+    srcs = ["tests/aarch64-test-plt.c"],
+    target_compatible_with = ["@platforms//cpu:arm64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "arm64_sve_signal_test",
+    srcs = ["tests/Larm64-test-sve-signal.c"],
+    target_compatible_with = ["@platforms//cpu:arm64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "perf_simple_test",
+    srcs = ["tests/Lperf-simple.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "perf_trace_test",
+    srcs = ["tests/Lperf-trace.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "rs_race_test",
+    srcs = ["tests/Lrs-race.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "bt_test",
+    srcs = ["tests/Ltest-bt.c"],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "concurrent_test",
+    srcs = ["tests/Ltest-concurrent.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "cxx_exceptions_test",
+    srcs = ["tests/Ltest-cxx-exceptions.cxx"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+# TODO: fails on Debian 11 and Ubuntu 20.04.
+# cc_test(
+#     name = "dyn1_test",
+#     srcs = ["tests/Ltest-dyn1.c"],
+#     deps = [
+#         ":unwind",
+#         ":unwind_test_helpers",
+#     ],
+#     linkopts = ["-ldl"],
+# )
+
+cc_test(
+    name = "exc_test",
+    srcs = ["tests/Ltest-exc.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "init_local_signal_test",
+    srcs = [
+        "tests/Ltest-init-local-signal.c",
+        "tests/Ltest-init-local-signal-lib.c",
+    ],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "init_test",
+    srcs = ["tests/Ltest-init.cxx"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "mem_validate_test",
+    srcs = ["tests/Ltest-mem-validate.c"],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "nocalloc_test",
+    srcs = ["tests/Ltest-nocalloc.c"],
+    linkopts = ["-ldl"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "nomalloc_test",
+    srcs = ["tests/Ltest-nomalloc.c"],
+    linkopts = ["-ldl"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "resume_sig_rt_test",
+    srcs = ["tests/Ltest-resume-sig-rt.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "resume_sig_test",
+    srcs = ["tests/Ltest-resume-sig.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "trace_test",
+    srcs = ["tests/Ltest-trace.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "varargs_test",
+    srcs = ["tests/Ltest-varargs.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "dwarf_expressions_test",
+    srcs = [
+        "tests/Lx64-test-dwarf-expressions.c",
+        "tests/x64-test-dwarf-expressions.S",
+    ],
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "async_sig_test",
+    srcs = ["tests/test-async-sig.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "flush_cache_test",
+    srcs = ["tests/test-flush-cache.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "mem_test",
+    srcs = ["tests/test-mem.c"],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "reg_state_test",
+    srcs = ["tests/test-reg-state.c"],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "static_link_loc_test",
+    srcs = [
+        "tests/test-static-link-gen.c",
+        "tests/test-static-link-loc.c",
+    ],
+    local_defines = ["UNW_LOCAL_ONLY"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "strerror_test",
+    srcs = ["tests/test-strerror.c"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)
+
+cc_test(
+    name = "unwind_badjmp_signal_frame_test",
+    srcs = ["tests/x64-unwind-badjmp-signal-frame.c"],
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    deps = [
+        ":unwind",
+        ":unwind_test_helpers",
+    ],
+)

--- a/registry/modules/libunwind/1.8.3.brpc-no-unwind/overlay/MODULE.bazel
+++ b/registry/modules/libunwind/1.8.3.brpc-no-unwind/overlay/MODULE.bazel
@@ -1,0 +1,21 @@
+# Forked from the Bazel Central Registry:
+#   https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/libunwind/1.8.3/overlay/MODULE.bazel
+# Distributed under the Apache License, Version 2.0. See the `registry/modules/
+# libunwind/**` entry near the bottom of brpc's LICENSE file.
+#
+# brpc modification (Apache License 2.0 §4(b)):
+#   - `version` suffixed with `.brpc-no-unwind` to distinguish this brpc
+#     variant from the upstream BCR version.
+
+module(
+    name = "libunwind",
+    version = "1.8.3.brpc-no-unwind",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "xz", version = "5.4.5.bcr.8")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.8")

--- a/registry/modules/libunwind/1.8.3.brpc-no-unwind/presubmit.yml
+++ b/registry/modules/libunwind/1.8.3.brpc-no-unwind/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@libunwind//:libunwind"
+      - "@libunwind//:libunwind_coredump"
+      - "@libunwind//:libunwind_ptrace"
+      - "@libunwind//:libunwind_setjmp"
+    test_targets:
+      - "@libunwind//..."

--- a/registry/modules/libunwind/1.8.3.brpc-no-unwind/source.json
+++ b/registry/modules/libunwind/1.8.3.brpc-no-unwind/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/libunwind/libunwind/releases/download/v1.8.3/libunwind-1.8.3.tar.gz",
+    "strip_prefix": "libunwind-1.8.3",
+    "overlay": {
+        "BUILD.bazel": "sha256-ozAABv0I3+tacve4z2m+lAh/lhJWh7t7L3unh8FSfp8=",
+        "MODULE.bazel": "sha256-EtBEsSDMJgdmCs7ByJxVP2SSVc+E7kUVLgpI3TEh/9M="
+    },
+    "integrity": "sha256-vjDZEOZ/WNgudTIx8TV/MmoaCIrPEmsh/3fmCqsZuQs="
+}

--- a/registry/modules/libunwind/metadata.json
+++ b/registry/modules/libunwind/metadata.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "https://www.nongnu.org/libunwind/",
+    "maintainers": [
+        {
+            "email": "vtsao@openai.com",
+            "github": "vtsao-openai",
+            "github_user_id": 176426301,
+            "name": "Vincent Tsao"
+        }
+    ],
+    "repository": [
+        "github:libunwind/libunwind"
+    ],
+    "versions": [
+        "1.8.1.brpc-no-unwind",
+        "1.8.3.brpc-no-unwind"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

When `--define=with_bthread_tracer=true` is enabled under Bazel
(`bazel test //test:bthread_unittest`), tests such as
`BthreadTest.bthread_exit` segfault inside `pthread_exit` /
`__gxx_personality_v0`, with a stack like:

```
#0  0x0000000000000000 in ?? ()
#1  0x00007fa2b5d6458a in _ULx86_64_dwarf_find_proc_info ()
   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
#2  0x00007fa2b5d6668d in fetch_proc_info ()
   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
#3  0x00007fa2b5d681a1 in _ULx86_64_dwarf_make_proc_info ()
   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
#4  0x00007fa2b5d70cfd in _ULx86_64_get_proc_info ()
   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
#5  0x00007fa2b5d6c775 in __libunwind_Unwind_GetLanguageSpecificData ()
   from /root/.cache/bazel/_bazel_root/743b333b2429a1dbd390ef66b59c771d/execroot/_main/bazel-out/k8-fastbuild/bin/test/../_solib_k8/libexternal_Slibunwind~_Slibunwind.so
#6  0x00007fa2b503c6df in __gxx_personality_v0 () from /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007fa2b5452ce5 in ?? () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#8  0x00007fa2b54533c0 in _Unwind_ForcedUnwind () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#9  0x00007fa2b4ca57a4 in __GI___pthread_unwind (buf=<optimized out>) at ./nptl/unwind.c:130
#10 0x00007fa2b4c9dd22 in __do_cancel () at ../sysdeps/nptl/pthreadP.h:271
#11 __GI___pthread_exit (value=0x0) at ./nptl/pthread_exit.c:36
#12 0x0000000000000000 in ?? ()
```

Root cause: libunwind's `src/unwind/*.c` exports the `_Unwind_*` GCC ABI
symbols, which collide with the same symbols in `libgcc_s.so.1`. Bazel's
default fastbuild mode wraps each `cc_library` into an intermediate `.so`,
so `libexternal_S~libunwind.so` ends up earlier in the binary's
`DT_NEEDED` than `libgcc_s.so.1`, and the runtime dynamic linker resolves
the `_Unwind_*` calls coming from `pthread_exit` / libstdc++ to
libunwind's DWARF-based implementation instead of libgcc_s. 

This is a runtime symbol-resolution-order issue independent of the
compiler -- Clang's default toolchain on Linux uses the same
`libstdc++ + libgcc_s` runtime and reproduces the exact same crash.

The make / cmake CI does not hit this because it links the
autoconf-built libunwind which hides `_Unwind_*`  by default. 
Distro packages (`libunwind-dev`, `libunwind-devel`) typically 
also re-export the symbols, so they have the same risk.

### What is changed and the side effects?

Changed:

* New self-maintained Bazel module registry under
  `registry/modules/libunwind/`, hosting two variants of libunwind:
  `1.8.1.brpc-no-unwind` and `1.8.3.brpc-no-unwind`. Both are forks of
  the corresponding modules in [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/libunwind), Apache-2.0 licensed. 
  License attribution and a per-file change list are added at the bottom 
  of the top-level `LICENSE` file.
* The variant overlays add a `hide_unwind_symbols` `config_setting`
  gated by `--define=libunwind_hide_unwind_symbols=true`. When the switch
  is on, the `src/unwind/*.c` glob is dropped from the build via
  `select()`, so libunwind no longer provides `_Unwind_*` symbols and
  `libgcc_s.so.1` wins the runtime lookup.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
