### PR TITLE
Fix UAF in batch_create_stream_feedback_race unittest

### DIFF
--- a/test/brpc_streaming_rpc_unittest.cpp
+++ b/test/brpc_streaming_rpc_unittest.cpp
@@ -91,6 +91,7 @@ struct BatchStreamFeedbackRaceState {
     std::atomic<bool> client_got_second_msg{false};
     std::atomic<bool> server_write_done{false};
     std::atomic<bool> rpc_done{false};
+    std::atomic<int> client_closed_count{0};
 
     bthread_t server_send_tid{0};
     std::atomic<bool> server_send_started{false};
@@ -123,7 +124,9 @@ public:
 
     void on_idle_timeout(brpc::StreamId /*id*/) override {}
 
-    void on_closed(brpc::StreamId /*id*/) override {}
+    void on_closed(brpc::StreamId /*id*/) override {
+        _state->client_closed_count.fetch_add(1, std::memory_order_release);
+    }
 
     void on_failed(brpc::StreamId /*id*/, int /*error_code*/, const std::string& /*error_text*/) override {}
 
@@ -224,12 +227,17 @@ static void SetAtomicTrue(std::atomic<bool>* f) {
     f->store(true, std::memory_order_release);
 }
 
-static bool WaitForTrue(const std::atomic<bool>& f, int timeout_ms) {
+template <typename Pred>
+static bool WaitForTrue(Pred pred, int timeout_ms) {
     const int64_t deadline_us = butil::gettimeofday_us() + (int64_t)timeout_ms * 1000L;
-    while (!f.load(std::memory_order_acquire) && butil::gettimeofday_us() < deadline_us) {
+    while (!pred() && butil::gettimeofday_us() < deadline_us) {
         usleep(1000);
     }
-    return f.load(std::memory_order_acquire);
+    return pred();
+}
+
+static bool WaitForTrue(const std::atomic<bool>& f, int timeout_ms) {
+    return WaitForTrue([&f]() { return f.load(std::memory_order_acquire); }, timeout_ms);
 }
 
 TEST_F(StreamingRpcTest, sanity) {
@@ -307,6 +315,22 @@ TEST_F(StreamingRpcTest, batch_create_stream_feedback_race) {
         }
         server.Stop(0);
         server.Join();
+
+        // Release the SocketUniquePtr held above so the fake socket can be
+        // recycled. Otherwise BeforeRecycle / on_closed for the extra stream
+        // is deferred until `client_extra_ptr` destructs at scope exit, which
+        // happens *after* `client_handler` and `state` are destroyed -> UAF
+        // inside Stream::Consume on Linux.
+        client_extra_ptr.reset();
+
+        // on_closed() runs asynchronously on each client stream's consumer
+        // bthread. Wait for both before letting handler/state go out of
+        // scope, otherwise Stream::Consume will dereference freed memory.
+        int expected_closed = request_streams.size();
+        WaitForTrue([&state, expected_closed]() {
+            return state.client_closed_count.load(std::memory_order_acquire)
+                   >= expected_closed;
+        }, 2000);
     };
 
     test::EchoService_Stub stub(&channel);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

 `StreamingRpcTest.batch_create_stream_feedback_race` crashes
  with SIGSEGV inside `Stream::Consume`([ci1](https://github.com/chenBright/brpc/actions/runs/26095041030/job/76730443077?pr=51) [ci2](https://github.com/apache/brpc/actions/runs/25729038610/job/75549212531?pr=3294)):

```
#0  0x00007ff22a810461 in brpc::Stream::Consume (meta=0x2757c540, iter=...) at src/brpc/stream.cpp:604
#1  0x00007ff22a69453c in bthread::ExecutionQueueBase::_execute (this=this@entry=0x2757e300, head=<optimized out>, high_priority=<optimized out>, niterated=niterated@entry=0x0) at src/bthread/execution_queue.cpp:308
#2  0x00007ff22a6948e0 in bthread::ExecutionQueueBase::_execute_tasks (arg=<optimized out>) at src/bthread/execution_queue.cpp:169
#3  0x00007ff22a6bf510 in bthread::TaskGroup::task_runner (skip_remained=<optimized out>) at src/bthread/task_group.cpp:388
#4  0x00007ff22a693b21 in bthread_make_fcontext () from ./libbrpc.dbg.so
#5  0x0000000000000000 in ?? ()
```

  Stream close is asynchronous: `StreamClose` only marks the fake socket
  failed; the handler's `on_closed` is invoked later on the consumer
  bthread, when `Consume` is invoked with `iter.is_queue_stopped()`.

  The test allocates `BatchStreamClientHandler` and
  `BatchStreamFeedbackRaceState` on its stack and passes the handler
  pointer to two streams via `StreamOptions::handler`. It also keeps a
  `SocketUniquePtr` (`client_extra_ptr`) alive across the whole test body
  to enlarge the `SetConnected` race window. That reference pins the
  extra stream's fake socket, so `BeforeRecycle` ->
  `execution_queue_stop` -> the final `Consume(is_queue_stopped)` for the
  extra stream cannot run until `client_extra_ptr` itself destructs at
  scope exit — which happens *after* the handler/state stack objects have
  already been destroyed. When `Consume` finally runs,
  `_options.handler` is dangling.

  Other tests in this file avoid the issue by setting a flag in
  `on_closed` and waiting on it before returning, but
  `BatchStreamClientHandler::on_closed` was empty.

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
