### PR TITLE
bvar: fix bad_weak_ptr crash in AgentCombiner::get_or_create_tls_agent

### DIFF
--- a/src/bvar/detail/combiner.h
+++ b/src/bvar/detail/combiner.h
@@ -341,7 +341,16 @@ friend class GlobalValue<self_type>;
         if (!agent->combiner.expired()) {
             return agent;
         }
-        agent->reset(_element_identity, this->shared_from_this());
+        self_shared_type self;
+        try {
+            self = this->shared_from_this();
+        } catch (const std::bad_weak_ptr&) {
+            // The combiner is no longer managed by any shared_ptr, which can
+            // happen when a bvar is being destroyed concurrently with a write.
+            // Silently skip this recording instead of crashing.
+            return NULL;
+        }
+        agent->reset(_element_identity, self);
         // TODO: Is uniqueness-checking necessary here?
         {
             butil::AutoLock guard(_lock);

--- a/src/bvar/detail/percentile.cpp
+++ b/src/bvar/detail/percentile.cpp
@@ -108,7 +108,6 @@ Percentile::value_type Percentile::get_value() const {
 Percentile &Percentile::operator<<(int64_t latency) {
     agent_type* agent = _combiner->get_or_create_tls_agent();
     if (BAIDU_UNLIKELY(!agent)) {
-        LOG(FATAL) << "Fail to create agent";
         return *this;
     }
     if (latency < 0) {

--- a/src/bvar/recorder.h
+++ b/src/bvar/recorder.h
@@ -269,7 +269,6 @@ inline IntRecorder& IntRecorder::operator<<(int64_t sample) {
     }
     agent_type* agent = _combiner->get_or_create_tls_agent();
     if (BAIDU_UNLIKELY(!agent)) {
-        LOG(FATAL) << "Fail to create agent";
         return *this;
     }
     uint64_t n;

--- a/src/bvar/reducer.h
+++ b/src/bvar/reducer.h
@@ -303,7 +303,6 @@ inline Reducer<T, Op, InvOp>& Reducer<T, Op, InvOp>::operator<<(
     // It's wait-free for most time
     agent_type* agent = _combiner->get_or_create_tls_agent();
     if (__builtin_expect(!agent, 0)) {
-        LOG(FATAL) << "Fail to create agent";
         return *this;
     }
     agent->element.modify(_combiner->op(), value);


### PR DESCRIPTION
## Problem

When a bvar object (`Reducer`, `IntRecorder`, `Percentile`) is destroyed
while another thread is concurrently writing to it via `operator<<`, the
following crash occurs:

```
terminate called after throwing an instance of 'std::bad_weak_ptr'
  what():  bad_weak_ptr
Aborted (core dumped)
```

This has been observed in high-concurrency RDMA performance testing
(see #3288).

## Root Cause

`AgentCombiner` inherits from `std::enable_shared_from_this`.
In `get_or_create_tls_agent()`, when an agent's `combiner` weak_ptr has
expired (the previous combiner was destroyed and the slot was reused), the
method calls `this->shared_from_this()` to re-bind the agent to the
current combiner.

`shared_from_this()` throws `std::bad_weak_ptr` if the object is not
currently managed by any `shared_ptr`. This can happen in a race where:

1. The `AgentCombiner` is the last object keeping a bvar alive
2. Another thread releases the last `shared_ptr` to it (e.g., the owning
   `Reducer` goes out of scope or is destroyed during program shutdown)
3. A third thread is simultaneously inside `get_or_create_tls_agent()`,
   past the `agent->combiner.expired()` check, and calls `shared_from_this()`
   on the now-unmanaged object → `bad_weak_ptr` → `terminate()`

## Fix

Wrap `shared_from_this()` in a `try/catch(std::bad_weak_ptr)`. When caught,
return `NULL` and silently skip the recording. This is safe: the metric is
being torn down, so dropping a write in flight is acceptable and far
preferable to crashing.

Also remove the `LOG(FATAL)` in the three `operator<<` callers that fire
when `get_or_create_tls_agent()` returns `NULL`:
- For **allocation failure**, `get_or_create_tls_agent()` already calls
  `LOG(FATAL)` internally (which aborts); the outer `LOG(FATAL)` was
  unreachable in that case.
- For the new **combiner-expired** path, calling `LOG(FATAL)` would
  incorrectly abort the process for a benign race during teardown.

## Affected files

| File | Change |
|------|--------|
| `src/bvar/detail/combiner.h` | catch `bad_weak_ptr` in `get_or_create_tls_agent()` |
| `src/bvar/reducer.h` | remove outer `LOG(FATAL)` from `operator<<` |
| `src/bvar/recorder.h` | remove outer `LOG(FATAL)` from `operator<<` |
| `src/bvar/detail/percentile.cpp` | remove outer `LOG(FATAL)` from `operator<<` |

Fixes #3288