### PR TITLE
fix(http): apply auth check to builtin requests on public port

### DIFF
--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -1387,10 +1387,12 @@ bool VerifyHttpRequest(const InputMessageBase* msg) {
         http_request->header().uri().path(), server, NULL);
     if (mp != NULL && mp->is_builtin_service &&
         mp->service->GetDescriptor() != BadMethodService::descriptor()) {
-        // BuiltinService doesn't need authentication
-        // TODO: Fix backdoor that sends BuiltinService at first
-        // and then sends other requests without authentication
-        return true;
+        // Builtin services on internal_port doesn't need authentication
+        // Builtin services on the public listener must pass authentication
+        if (server->options().internal_port >= 0 &&
+            socket->local_side().port == server->options().internal_port) {
+            return true;
+        }
     }
 
     const std::string *authorization 

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -60,6 +60,7 @@ DECLARE_bool(rpc_dump);
 DECLARE_string(rpc_dump_dir);
 DECLARE_int32(rpc_dump_max_requests_in_one_file);
 DECLARE_bool(allow_chunked_length);
+DECLARE_int32(max_connection_pool_size);
 extern bvar::CollectorSpeedLimit g_rpc_dump_sl;
 }
 
@@ -163,6 +164,23 @@ protected:
         EXPECT_EQ(expect, brpc::policy::VerifyHttpRequest(msg));
     }
 
+    void VerifyMessageFromLocalPort(brpc::InputMessageBase* msg,
+                                    bool expect,
+                                    int local_port) {
+        brpc::SocketId id;
+        brpc::SocketOptions options;
+        options.fd = dup(_pipe_fds[1]);
+        EXPECT_GE(options.fd, 0);
+        options.local_side = butil::EndPoint(butil::my_ip(), local_port);
+        EXPECT_EQ(0, brpc::Socket::Create(options, &id));
+
+        brpc::SocketUniquePtr socket;
+        EXPECT_EQ(0, brpc::Socket::Address(id, &socket));
+        socket->ReAddress(&msg->_socket);
+        msg->_arg = &_server;
+        EXPECT_EQ(expect, brpc::policy::VerifyHttpRequest(msg));
+    }
+
     void ProcessMessage(void (*process)(brpc::InputMessageBase*),
                         brpc::InputMessageBase* msg, bool set_eof) {
         if (msg->_socket == NULL) {
@@ -223,6 +241,30 @@ protected:
         msg->header().uri().set_path(path);
         msg->header().set_method(brpc::HTTP_METHOD_GET);
         return msg;
+    }
+
+    void InitHttpPooledChannel(brpc::Channel* channel,
+                               const butil::EndPoint& ep,
+                               const std::string& connection_group) {
+        brpc::ChannelOptions options;
+        options.protocol = brpc::PROTOCOL_HTTP;
+        options.connection_type = brpc::CONNECTION_TYPE_POOLED;
+        options.connection_group = connection_group;
+        options.max_retry = 0;
+        ASSERT_EQ(0, channel->Init(ep, &options));
+    }
+
+    void CallVersion(brpc::Channel* channel, brpc::Controller* cntl) {
+        cntl->http_request().uri() = "/status";
+        cntl->http_request().set_method(brpc::HTTP_METHOD_GET);
+        channel->CallMethod(NULL, cntl, NULL, NULL, NULL);
+    }
+
+    void CallHttpEcho(brpc::Channel* channel, brpc::Controller* cntl) {
+        cntl->http_request().uri() = "/EchoService/Echo";
+        cntl->http_request().set_method(brpc::HTTP_METHOD_POST);
+        cntl->request_attachment().append(R"({"message":"hello"})");
+        channel->CallMethod(NULL, cntl, NULL, NULL, NULL);
     }
 
 
@@ -300,6 +342,14 @@ protected:
     MyAuthenticator _auth;
 };
 
+int AllocateFreePortOrDie() {
+    butil::fd_guard fd(tcp_listen(butil::EndPoint(butil::my_ip(), 0)));
+    EXPECT_GE(fd, 0);
+    butil::EndPoint point;
+    EXPECT_EQ(0, butil::get_local_side(fd, &point));
+    return point.port;
+}
+
 TEST_F(HttpTest, indenting_ostream) {
     std::ostringstream os1;
     brpc::IndentingOStream is1(os1, 2);
@@ -355,6 +405,12 @@ TEST_F(HttpTest, verify_request) {
     }
     {
         brpc::policy::HttpContext* msg = MakeGetRequestMessage("/status");
+        VerifyMessage(msg, false);
+        msg->Destroy();
+    }
+    {
+        brpc::policy::HttpContext* msg = MakeGetRequestMessage("/status");
+        msg->header().SetHeader("Authorization", MOCK_CREDENTIAL);
         VerifyMessage(msg, true);
         msg->Destroy();
     }
@@ -377,6 +433,101 @@ TEST_F(HttpTest, verify_request) {
         VerifyMessage(msg, false);
         msg->Destroy();
     }
+}
+
+TEST_F(HttpTest, verify_builtin_request_on_internal_port) {
+    _server._options.internal_port = 9527;
+    {
+        brpc::policy::HttpContext* msg = MakeGetRequestMessage("/status");
+        VerifyMessage(msg, false);
+        msg->Destroy();
+    }
+    {
+        brpc::policy::HttpContext* msg = MakeGetRequestMessage("/status");
+        VerifyMessageFromLocalPort(msg, true, _server._options.internal_port);
+        msg->Destroy();
+    }
+}
+
+TEST(HttpProtocolAuthTest, builtin_auth_policy_on_public_and_internal_port) {
+    const int saved_max_connection_pool_size = brpc::FLAGS_max_connection_pool_size;
+    brpc::FLAGS_max_connection_pool_size = 1;
+
+    butil::EndPoint ep;
+    ASSERT_EQ(0, str2endpoint("127.0.0.1:0", &ep));
+
+    brpc::Server server;
+    MyEchoService svc;
+    MyAuthenticator auth;
+    brpc::ServerOptions options;
+    options.auth = &auth;
+    options.internal_port = AllocateFreePortOrDie();
+    ASSERT_EQ(0, server.AddService(&svc, brpc::SERVER_DOESNT_OWN_SERVICE));
+    ASSERT_EQ(0, server.Start(ep, &options));
+    ep = server.listen_address();
+    const butil::EndPoint internal_ep(ep.ip, options.internal_port);
+
+    {
+        brpc::Channel chan;
+        brpc::ChannelOptions copt;
+        copt.protocol = brpc::PROTOCOL_HTTP;
+        copt.max_retry = 0;
+        ASSERT_EQ(0, chan.Init(ep, &copt));
+
+        brpc::Controller cntl;
+        cntl.http_request().uri() = "/status";
+        cntl.http_request().set_method(brpc::HTTP_METHOD_GET);
+        chan.CallMethod(NULL, &cntl, NULL, NULL, NULL);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, cntl.http_response().status_code());
+    }
+
+    {
+        brpc::Channel chan;
+        brpc::ChannelOptions copt;
+        copt.protocol = brpc::PROTOCOL_HTTP;
+        copt.max_retry = 0;
+        ASSERT_EQ(0, chan.Init(internal_ep, &copt));
+
+        brpc::Controller cntl;
+        cntl.http_request().uri() = "/status";
+        cntl.http_request().set_method(brpc::HTTP_METHOD_GET);
+        chan.CallMethod(NULL, &cntl, NULL, NULL, NULL);
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        ASSERT_EQ(brpc::HTTP_STATUS_OK, cntl.http_response().status_code());
+    }
+
+    {
+        const std::string connection_group = "builtin-auth-policy";
+        brpc::Channel builtin_channel;
+        brpc::Channel protected_channel;
+        brpc::ChannelOptions copt;
+        copt.protocol = brpc::PROTOCOL_HTTP;
+        copt.connection_type = brpc::CONNECTION_TYPE_POOLED;
+        copt.connection_group = connection_group;
+        copt.max_retry = 0;
+        ASSERT_EQ(0, builtin_channel.Init(ep, &copt));
+        ASSERT_EQ(0, protected_channel.Init(ep, &copt));
+
+        brpc::Controller builtin_cntl;
+        builtin_cntl.http_request().uri() = "/status";
+        builtin_cntl.http_request().set_method(brpc::HTTP_METHOD_GET);
+        builtin_channel.CallMethod(NULL, &builtin_cntl, NULL, NULL, NULL);
+        ASSERT_TRUE(builtin_cntl.Failed());
+        ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, builtin_cntl.http_response().status_code());
+
+        brpc::Controller protected_cntl;
+        protected_cntl.http_request().uri() = "/EchoService/Echo";
+        protected_cntl.http_request().set_method(brpc::HTTP_METHOD_POST);
+        protected_cntl.request_attachment().append(R"({"message":"hello"})");
+        protected_channel.CallMethod(NULL, &protected_cntl, NULL, NULL, NULL);
+        ASSERT_TRUE(protected_cntl.Failed());
+        ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, protected_cntl.http_response().status_code());
+    }
+
+    ASSERT_EQ(0, server.Stop(0));
+    ASSERT_EQ(0, server.Join());
+    brpc::FLAGS_max_connection_pool_size = saved_max_connection_pool_size;
 }
 
 TEST_F(HttpTest, process_request_failed_socket) {

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -261,10 +261,13 @@ protected:
     }
 
     void CallHttpEcho(brpc::Channel* channel, brpc::Controller* cntl) {
+        test::EchoRequest req;
+        test::EchoResponse res;
+        req.set_message(EXP_REQUEST);
         cntl->http_request().uri() = "/EchoService/Echo";
         cntl->http_request().set_method(brpc::HTTP_METHOD_POST);
-        cntl->request_attachment().append(R"({"message":"hello"})");
-        channel->CallMethod(NULL, cntl, NULL, NULL, NULL);
+        cntl->http_request().set_content_type("application/json");
+        channel->CallMethod(NULL, cntl, &req, &res, NULL);
     }
 
 
@@ -449,7 +452,7 @@ TEST_F(HttpTest, verify_builtin_request_on_internal_port) {
     }
 }
 
-TEST(HttpProtocolAuthTest, builtin_auth_policy_on_public_and_internal_port) {
+TEST_F(HttpTest, builtin_auth_policy_on_public_and_internal_port) {
     const int saved_max_connection_pool_size = brpc::FLAGS_max_connection_pool_size;
     brpc::FLAGS_max_connection_pool_size = 1;
 
@@ -479,6 +482,7 @@ TEST(HttpProtocolAuthTest, builtin_auth_policy_on_public_and_internal_port) {
         cntl.http_request().set_method(brpc::HTTP_METHOD_GET);
         chan.CallMethod(NULL, &cntl, NULL, NULL, NULL);
         ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(brpc::EHTTP, cntl.ErrorCode()) << cntl.ErrorText();
         ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, cntl.http_response().status_code());
     }
 
@@ -510,19 +514,22 @@ TEST(HttpProtocolAuthTest, builtin_auth_policy_on_public_and_internal_port) {
         ASSERT_EQ(0, protected_channel.Init(ep, &copt));
 
         brpc::Controller builtin_cntl;
-        builtin_cntl.http_request().uri() = "/status";
-        builtin_cntl.http_request().set_method(brpc::HTTP_METHOD_GET);
-        builtin_channel.CallMethod(NULL, &builtin_cntl, NULL, NULL, NULL);
+        CallVersion(&builtin_channel, &builtin_cntl);
         ASSERT_TRUE(builtin_cntl.Failed());
+        ASSERT_EQ(brpc::EHTTP, builtin_cntl.ErrorCode()) << builtin_cntl.ErrorText();
         ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, builtin_cntl.http_response().status_code());
 
         brpc::Controller protected_cntl;
-        protected_cntl.http_request().uri() = "/EchoService/Echo";
-        protected_cntl.http_request().set_method(brpc::HTTP_METHOD_POST);
-        protected_cntl.request_attachment().append(R"({"message":"hello"})");
-        protected_channel.CallMethod(NULL, &protected_cntl, NULL, NULL, NULL);
+        CallHttpEcho(&protected_channel, &protected_cntl);
         ASSERT_TRUE(protected_cntl.Failed());
-        ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, protected_cntl.http_response().status_code());
+        if (protected_cntl.ErrorCode() == brpc::EHTTP) {
+            ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN,
+                      protected_cntl.http_response().status_code())
+                << protected_cntl.ErrorText();
+        } else {
+            ASSERT_EQ(brpc::EEOF, protected_cntl.ErrorCode())
+                << protected_cntl.ErrorText();
+        }
     }
 
     ASSERT_EQ(0, server.Stop(0));

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -522,14 +522,6 @@ TEST_F(HttpTest, builtin_auth_policy_on_public_and_internal_port) {
         brpc::Controller protected_cntl;
         CallHttpEcho(&protected_channel, &protected_cntl);
         ASSERT_TRUE(protected_cntl.Failed());
-        if (protected_cntl.ErrorCode() == brpc::EHTTP) {
-            ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN,
-                      protected_cntl.http_response().status_code())
-                << protected_cntl.ErrorText();
-        } else {
-            ASSERT_EQ(brpc::EEOF, protected_cntl.ErrorCode())
-                << protected_cntl.ErrorText();
-        }
     }
 
     ASSERT_EQ(0, server.Stop(0));

--- a/test/brpc_server_unittest.cpp
+++ b/test/brpc_server_unittest.cpp
@@ -67,7 +67,6 @@ int main(int argc, char* argv[]) {
 namespace brpc {
 DECLARE_bool(enable_threads_service);
 DECLARE_bool(enable_dir_service);
-DECLARE_int32(max_connection_pool_size);
 
 namespace policy {
 DECLARE_bool(use_http_error_code);
@@ -2038,38 +2037,6 @@ void TestHttpAuth(const butil::EndPoint& ep,
     ASSERT_EQ(cntl.http_response().status_code(), status_code);
 }
 
-void InitHttpPooledChannel(brpc::Channel* channel,
-                           const butil::EndPoint& ep,
-                           const std::string& connection_group) {
-    brpc::ChannelOptions copt;
-    copt.protocol = brpc::PROTOCOL_HTTP;
-    copt.connection_type = brpc::CONNECTION_TYPE_POOLED;
-    copt.connection_group = connection_group;
-    copt.max_retry = 0;
-    ASSERT_EQ(0, channel->Init(ep, &copt));
-}
-
-void CallVersion(brpc::Channel* channel, brpc::Controller* cntl) {
-    cntl->http_request().uri() = "/version";
-    cntl->http_request().set_method(brpc::HTTP_METHOD_GET);
-    channel->CallMethod(NULL, cntl, NULL, NULL, NULL);
-}
-
-void CallHttpEcho(brpc::Channel* channel, brpc::Controller* cntl) {
-    cntl->http_request().uri() = "/EchoService/Echo";
-    cntl->http_request().set_method(brpc::HTTP_METHOD_POST);
-    cntl->request_attachment().append(R"({"message":"hello"})");
-    channel->CallMethod(NULL, cntl, NULL, NULL, NULL);
-}
-
-int AllocateFreePortOrDie() {
-    butil::fd_guard fd(tcp_listen(butil::EndPoint(butil::my_ip(), 0)));
-    EXPECT_GE(fd, 0);
-    butil::EndPoint point;
-    EXPECT_EQ(0, butil::get_local_side(fd, &point));
-    return point.port;
-}
-
 TEST_F(ServerTest, auth) {
     butil::EndPoint ep;
     ASSERT_EQ(0, str2endpoint("127.0.0.1:8613", &ep));
@@ -2094,87 +2061,11 @@ TEST_F(ServerTest, auth) {
     ASSERT_NE(cntl.response_attachment().to_string().find(g_unauthorized_error_text),
               std::string::npos);
 
-    brpc::Channel builtin_chan;
-    InitHttpPooledChannel(&builtin_chan, ep, "builtin_auth_public");
-    cntl.Reset();
-    CallVersion(&builtin_chan, &cntl);
-    ASSERT_TRUE(cntl.Failed());
-    ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, cntl.http_response().status_code());
-    ASSERT_NE(cntl.response_attachment().to_string().find(g_unauthorized_error_text),
-              std::string::npos);
-
     g_verify_success = true;
     cntl.Reset();
     cntl.http_request().SetHeader("Authorization", "123");
     TestHttpAuth(ep, cntl, brpc::HTTP_STATUS_OK, false);
 
-    brpc::Channel builtin_auth_chan;
-    InitHttpPooledChannel(&builtin_auth_chan, ep, "builtin_auth_public_ok");
-    cntl.Reset();
-    cntl.http_request().SetHeader("Authorization", "123");
-    CallVersion(&builtin_auth_chan, &cntl);
-    ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
-    ASSERT_EQ(brpc::HTTP_STATUS_OK, cntl.http_response().status_code());
-
-    ASSERT_EQ(0, server.Stop(0));
-    ASSERT_EQ(0, server.Join());
-}
-
-TEST_F(ServerTest, builtin_http_request_skips_auth_on_internal_port) {
-    butil::EndPoint ep;
-    ASSERT_EQ(0, str2endpoint("127.0.0.1:0", &ep));
-
-    brpc::Server server;
-    EchoServiceImpl service;
-    ASSERT_EQ(0, server.AddService(&service, brpc::SERVER_DOESNT_OWN_SERVICE));
-
-    MyAuthenticator auth;
-    brpc::ServerOptions opt;
-    opt.auth = &auth;
-    opt.internal_port = AllocateFreePortOrDie();
-    ASSERT_EQ(0, server.Start(ep, &opt));
-    ep = server.listen_address();
-    const butil::EndPoint internal_ep(ep.ip, opt.internal_port);
-
-    const bool saved_verify_success = g_verify_success;
-    g_verify_success = false;
-
-    {
-        brpc::Channel direct_channel;
-        InitHttpPooledChannel(&direct_channel, ep, "direct_unauth");
-
-        brpc::Controller direct_cntl;
-        CallHttpEcho(&direct_channel, &direct_cntl);
-        ASSERT_TRUE(direct_cntl.Failed());
-        ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, direct_cntl.http_response().status_code());
-        ASSERT_NE(direct_cntl.response_attachment().to_string().find(g_unauthorized_error_text),
-                  std::string::npos);
-    }
-
-    {
-        brpc::Channel builtin_channel;
-        InitHttpPooledChannel(&builtin_channel, ep, "builtin_public");
-
-        brpc::Controller version_cntl;
-        CallVersion(&builtin_channel, &version_cntl);
-        ASSERT_TRUE(version_cntl.Failed());
-        ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, version_cntl.http_response().status_code());
-        ASSERT_NE(version_cntl.response_attachment().to_string().find(g_unauthorized_error_text),
-                  std::string::npos);
-    }
-
-    {
-        brpc::Channel internal_builtin_channel;
-        InitHttpPooledChannel(&internal_builtin_channel, internal_ep, "builtin_internal");
-
-        brpc::Controller internal_version_cntl;
-        CallVersion(&internal_builtin_channel, &internal_version_cntl);
-        ASSERT_FALSE(internal_version_cntl.Failed()) << internal_version_cntl.ErrorText();
-        ASSERT_EQ(brpc::HTTP_STATUS_OK,
-                  internal_version_cntl.http_response().status_code());
-    }
-
-    g_verify_success = saved_verify_success;
     ASSERT_EQ(0, server.Stop(0));
     ASSERT_EQ(0, server.Join());
 }

--- a/test/brpc_server_unittest.cpp
+++ b/test/brpc_server_unittest.cpp
@@ -67,6 +67,7 @@ int main(int argc, char* argv[]) {
 namespace brpc {
 DECLARE_bool(enable_threads_service);
 DECLARE_bool(enable_dir_service);
+DECLARE_int32(max_connection_pool_size);
 
 namespace policy {
 DECLARE_bool(use_http_error_code);
@@ -2037,6 +2038,38 @@ void TestHttpAuth(const butil::EndPoint& ep,
     ASSERT_EQ(cntl.http_response().status_code(), status_code);
 }
 
+void InitHttpPooledChannel(brpc::Channel* channel,
+                           const butil::EndPoint& ep,
+                           const std::string& connection_group) {
+    brpc::ChannelOptions copt;
+    copt.protocol = brpc::PROTOCOL_HTTP;
+    copt.connection_type = brpc::CONNECTION_TYPE_POOLED;
+    copt.connection_group = connection_group;
+    copt.max_retry = 0;
+    ASSERT_EQ(0, channel->Init(ep, &copt));
+}
+
+void CallVersion(brpc::Channel* channel, brpc::Controller* cntl) {
+    cntl->http_request().uri() = "/version";
+    cntl->http_request().set_method(brpc::HTTP_METHOD_GET);
+    channel->CallMethod(NULL, cntl, NULL, NULL, NULL);
+}
+
+void CallHttpEcho(brpc::Channel* channel, brpc::Controller* cntl) {
+    cntl->http_request().uri() = "/EchoService/Echo";
+    cntl->http_request().set_method(brpc::HTTP_METHOD_POST);
+    cntl->request_attachment().append(R"({"message":"hello"})");
+    channel->CallMethod(NULL, cntl, NULL, NULL, NULL);
+}
+
+int AllocateFreePortOrDie() {
+    butil::fd_guard fd(tcp_listen(butil::EndPoint(butil::my_ip(), 0)));
+    EXPECT_GE(fd, 0);
+    butil::EndPoint point;
+    EXPECT_EQ(0, butil::get_local_side(fd, &point));
+    return point.port;
+}
+
 TEST_F(ServerTest, auth) {
     butil::EndPoint ep;
     ASSERT_EQ(0, str2endpoint("127.0.0.1:8613", &ep));
@@ -2061,11 +2094,87 @@ TEST_F(ServerTest, auth) {
     ASSERT_NE(cntl.response_attachment().to_string().find(g_unauthorized_error_text),
               std::string::npos);
 
+    brpc::Channel builtin_chan;
+    InitHttpPooledChannel(&builtin_chan, ep, "builtin_auth_public");
+    cntl.Reset();
+    CallVersion(&builtin_chan, &cntl);
+    ASSERT_TRUE(cntl.Failed());
+    ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, cntl.http_response().status_code());
+    ASSERT_NE(cntl.response_attachment().to_string().find(g_unauthorized_error_text),
+              std::string::npos);
+
     g_verify_success = true;
     cntl.Reset();
     cntl.http_request().SetHeader("Authorization", "123");
     TestHttpAuth(ep, cntl, brpc::HTTP_STATUS_OK, false);
 
+    brpc::Channel builtin_auth_chan;
+    InitHttpPooledChannel(&builtin_auth_chan, ep, "builtin_auth_public_ok");
+    cntl.Reset();
+    cntl.http_request().SetHeader("Authorization", "123");
+    CallVersion(&builtin_auth_chan, &cntl);
+    ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+    ASSERT_EQ(brpc::HTTP_STATUS_OK, cntl.http_response().status_code());
+
+    ASSERT_EQ(0, server.Stop(0));
+    ASSERT_EQ(0, server.Join());
+}
+
+TEST_F(ServerTest, builtin_http_request_skips_auth_on_internal_port) {
+    butil::EndPoint ep;
+    ASSERT_EQ(0, str2endpoint("127.0.0.1:0", &ep));
+
+    brpc::Server server;
+    EchoServiceImpl service;
+    ASSERT_EQ(0, server.AddService(&service, brpc::SERVER_DOESNT_OWN_SERVICE));
+
+    MyAuthenticator auth;
+    brpc::ServerOptions opt;
+    opt.auth = &auth;
+    opt.internal_port = AllocateFreePortOrDie();
+    ASSERT_EQ(0, server.Start(ep, &opt));
+    ep = server.listen_address();
+    const butil::EndPoint internal_ep(ep.ip, opt.internal_port);
+
+    const bool saved_verify_success = g_verify_success;
+    g_verify_success = false;
+
+    {
+        brpc::Channel direct_channel;
+        InitHttpPooledChannel(&direct_channel, ep, "direct_unauth");
+
+        brpc::Controller direct_cntl;
+        CallHttpEcho(&direct_channel, &direct_cntl);
+        ASSERT_TRUE(direct_cntl.Failed());
+        ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, direct_cntl.http_response().status_code());
+        ASSERT_NE(direct_cntl.response_attachment().to_string().find(g_unauthorized_error_text),
+                  std::string::npos);
+    }
+
+    {
+        brpc::Channel builtin_channel;
+        InitHttpPooledChannel(&builtin_channel, ep, "builtin_public");
+
+        brpc::Controller version_cntl;
+        CallVersion(&builtin_channel, &version_cntl);
+        ASSERT_TRUE(version_cntl.Failed());
+        ASSERT_EQ(brpc::HTTP_STATUS_FORBIDDEN, version_cntl.http_response().status_code());
+        ASSERT_NE(version_cntl.response_attachment().to_string().find(g_unauthorized_error_text),
+                  std::string::npos);
+    }
+
+    {
+        brpc::Channel internal_builtin_channel;
+        InitHttpPooledChannel(&internal_builtin_channel, internal_ep, "builtin_internal");
+
+        brpc::Controller internal_version_cntl;
+        CallVersion(&internal_builtin_channel, &internal_version_cntl);
+        ASSERT_FALSE(internal_version_cntl.Failed()) << internal_version_cntl.ErrorText();
+        ASSERT_EQ(brpc::HTTP_STATUS_OK,
+                  internal_version_cntl.http_response().status_code());
+    }
+
+    g_verify_success = saved_verify_success;
     ASSERT_EQ(0, server.Stop(0));
     ASSERT_EQ(0, server.Join());
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

When `ServerOptions.auth` is enabled, builtin HTTP requests received from the public listening port are currently handled differently from other public HTTP requests. This makes auth behavior inconsistent between builtin endpoints and regular service endpoints, especially when builtin services and business services share the same listener.

This PR makes auth handling more consistent by distinguishing requests coming from `internal_port` from requests coming from the public server port.

### What is changed and the side effects?

Changed:

- Update HTTP request verification logic so builtin requests received from the public server port also go through auth when `ServerOptions.auth` is enabled.
- Keep the existing behavior for builtin requests received from `internal_port`, which continue to bypass auth as before.

Side effects:
- Public builtin HTTP endpoints now follow the same auth policy as other public HTTP endpoints when auth is enabled.

- Performance effects:
  - Negligible. The change only adds auth verification for builtin HTTP requests received from the public port.

- Breaking backward compatibility: 
  - There is a behavior change for deployments that expose builtin HTTP services on the public server port while enabling `ServerOptions.auth`: unauthenticated access to those builtin endpoints will now be rejected.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).