### PR TITLE
fix: prevent null dereference in fuzz test socket initialization

### DIFF
--- a/test/fuzzing/fuzz_baidu_rpc.cpp
+++ b/test/fuzzing/fuzz_baidu_rpc.cpp
@@ -33,6 +33,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseRpcMessage(&buf, sock, false, NULL);
     return 0;
 }

--- a/test/fuzzing/fuzz_common.h
+++ b/test/fuzzing/fuzz_common.h
@@ -32,10 +32,10 @@ inline brpc::Socket* get_fuzz_socket() {
     if (!initialized) {
         brpc::SocketOptions options;
         options.remote_side = butil::EndPoint(butil::IP_ANY, 7777);
-        if (brpc::Socket::Create(options, &sid) == 0) {
-            brpc::Socket::Address(sid, &sock_ptr);
+        if (brpc::Socket::Create(options, &sid) == 0 &&
+            brpc::Socket::Address(sid, &sock_ptr) == 0) {
+            initialized = true;
         }
-        initialized = true;
     }
 
     return sock_ptr.get();

--- a/test/fuzzing/fuzz_couchbase.cpp
+++ b/test/fuzzing/fuzz_couchbase.cpp
@@ -33,6 +33,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseCouchbaseMessage(&buf, sock, false, NULL);
     return 0;
 }

--- a/test/fuzzing/fuzz_esp.cpp
+++ b/test/fuzzing/fuzz_esp.cpp
@@ -34,6 +34,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseEspMessage(&buf, sock, false, NULL);
 
     return 0;

--- a/test/fuzzing/fuzz_hulu.cpp
+++ b/test/fuzzing/fuzz_hulu.cpp
@@ -34,6 +34,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseHuluMessage(&buf, sock, false, NULL);
 
     return 0;

--- a/test/fuzzing/fuzz_memcache.cpp
+++ b/test/fuzzing/fuzz_memcache.cpp
@@ -33,6 +33,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseMemcacheMessage(&buf, sock, false, NULL);
     return 0;
 }

--- a/test/fuzzing/fuzz_mongo.cpp
+++ b/test/fuzzing/fuzz_mongo.cpp
@@ -33,6 +33,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseMongoMessage(&buf, sock, false, NULL);
     return 0;
 }

--- a/test/fuzzing/fuzz_shead.cpp
+++ b/test/fuzzing/fuzz_shead.cpp
@@ -34,6 +34,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseNsheadMessage(&buf, sock, false, NULL);
 
     return 0;

--- a/test/fuzzing/fuzz_sofa.cpp
+++ b/test/fuzzing/fuzz_sofa.cpp
@@ -36,6 +36,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseSofaMessage(&buf, sock, false, NULL);
     return 0;
 }

--- a/test/fuzzing/fuzz_streaming.cpp
+++ b/test/fuzzing/fuzz_streaming.cpp
@@ -33,6 +33,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     buf.append(input);
 
     brpc::Socket* sock = get_fuzz_socket();
+    if (sock == NULL) {
+        return 0;
+    }
     brpc::policy::ParseStreamingMessage(&buf, sock, false, NULL);
     return 0;
 }


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: Fix #3114

`get_fuzz_socket()` in `test/fuzzing/fuzz_common.h` sets `initialized = true` unconditionally after the first attempt, even when `Socket::Create()` or `Socket::Address()` fails. This causes all subsequent calls to return `NULL`, and the fuzz harnesses pass this `NULL` pointer directly to protocol parse functions (e.g., `ParseHuluMessage`), which dereference it via `socket->remote_side()`, triggering a SEGV.

## What is changed and how it works?

1. **`fuzz_common.h`**: Move `initialized = true` inside the success branch so that `get_fuzz_socket()` retries socket creation on failure instead of permanently returning `NULL`.

2. **All 9 fuzz test files**: Add a `NULL` check for the socket pointer before calling the parse function. If socket creation fails after retry, the test gracefully returns 0 instead of crashing.

## Check List

- [x] Tests (fuzz test syntax verification passes for all 9 modified files)
- [x] No API changes
- [x] No breaking changes

## Side effects

None. Changes are limited to fuzz test harness code.