### PR TITLE
Fix static initialization order fiasco in AdaptiveMaxConcurrency

### DIFF
--- a/src/brpc/adaptive_max_concurrency.cpp
+++ b/src/brpc/adaptive_max_concurrency.cpp
@@ -25,18 +25,15 @@
 
 namespace brpc {
 
-const std::string AdaptiveMaxConcurrency::UNLIMITED = "unlimited";
-const std::string AdaptiveMaxConcurrency::CONSTANT = "constant";
-
 AdaptiveMaxConcurrency::AdaptiveMaxConcurrency()
-    : _value(UNLIMITED)
+    : _value(UNLIMITED())
     , _max_concurrency(0) {
 }
 
 AdaptiveMaxConcurrency::AdaptiveMaxConcurrency(int max_concurrency)
     : _max_concurrency(0) {
     if (max_concurrency <= 0) {
-        _value = UNLIMITED;
+        _value = UNLIMITED();
         _max_concurrency = 0;
     } else {
         _value = butil::string_printf("%d", max_concurrency);
@@ -83,7 +80,7 @@ void AdaptiveMaxConcurrency::operator=(const butil::StringPiece& value) {
 
 void AdaptiveMaxConcurrency::operator=(int max_concurrency) {
     if (max_concurrency <= 0) {
-        _value = UNLIMITED;
+        _value = UNLIMITED();
         _max_concurrency = 0;
     } else {
         _value = butil::string_printf("%d", max_concurrency);
@@ -105,9 +102,9 @@ void AdaptiveMaxConcurrency::operator=(const TimeoutConcurrencyConf& value) {
 
 const std::string& AdaptiveMaxConcurrency::type() const {
     if (_max_concurrency > 0) {
-        return CONSTANT;
+        return CONSTANT();
     } else if (_max_concurrency == 0) {
-        return UNLIMITED;
+        return UNLIMITED();
     } else {
         return _value;
     }

--- a/src/brpc/adaptive_max_concurrency.h
+++ b/src/brpc/adaptive_max_concurrency.h
@@ -65,9 +65,17 @@ public:
     // "unlimited", "constant" or "user-defined"
     const std::string& type() const;
 
-    // Get strings filled with "unlimited" and "constant"
-    static const std::string UNLIMITED;// = "unlimited";
-    static const std::string CONSTANT;// = "constant";
+    // Use Meyers' Singleton to avoid static initialization order fiasco:
+    // global AdaptiveMaxConcurrency objects in other translation units may
+    // depend on these strings during their construction.
+    static const std::string& UNLIMITED() {
+        static const std::string s_unlimited = "unlimited";
+        return s_unlimited;
+    }
+    static const std::string& CONSTANT() {
+        static const std::string s_constant = "constant";
+        return s_constant;
+    }
 
     void SetConcurrencyLimiter(ConcurrencyLimiter* cl) { _cl = cl; }
 

--- a/src/brpc/policy/constant_concurrency_limiter.cpp
+++ b/src/brpc/policy/constant_concurrency_limiter.cpp
@@ -43,7 +43,7 @@ int ConstantConcurrencyLimiter::ResetMaxConcurrency(
 
 ConstantConcurrencyLimiter*
 ConstantConcurrencyLimiter::New(const AdaptiveMaxConcurrency& amc) const {
-    CHECK_EQ(amc.type(), AdaptiveMaxConcurrency::CONSTANT);
+    CHECK_EQ(amc.type(), AdaptiveMaxConcurrency::CONSTANT());
     return new ConstantConcurrencyLimiter(static_cast<int>(amc));
 }
 

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -754,7 +754,7 @@ static int get_port_from_fd(int fd) {
 
 bool Server::CreateConcurrencyLimiter(const AdaptiveMaxConcurrency& amc,
                                       ConcurrencyLimiter** out) {
-    if (amc.type() == AdaptiveMaxConcurrency::UNLIMITED) {
+    if (amc.type() == AdaptiveMaxConcurrency::UNLIMITED()) {
         *out = NULL;
         return true;
     }
@@ -1075,7 +1075,7 @@ int Server::StartInternal(const butil::EndPoint& endpoint,
             it->second.status->SetConcurrencyLimiter(NULL);
         } else {
             const AdaptiveMaxConcurrency* amc = &it->second.max_concurrency;
-            if (amc->type() == AdaptiveMaxConcurrency::UNLIMITED) {
+            if (amc->type() == AdaptiveMaxConcurrency::UNLIMITED()) {
                 amc = &_options.method_max_concurrency;
             }
             ConcurrencyLimiter* cl = NULL;

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -717,7 +717,7 @@ friend class Controller;
     int SetServiceMaxConcurrency(T* service) {
         if (NULL != service && NULL != service->_status) {
             const AdaptiveMaxConcurrency* amc = &service->_max_concurrency;
-            if (amc->type() == AdaptiveMaxConcurrency::UNLIMITED) {
+            if (amc->type() == AdaptiveMaxConcurrency::UNLIMITED()) {
                 amc = &_options.method_max_concurrency;
             }
             ConcurrencyLimiter* cl = NULL;

--- a/test/brpc_adaptive_class_unittest.cpp
+++ b/test/brpc_adaptive_class_unittest.cpp
@@ -31,13 +31,13 @@ const std::string kPooled = "PoOled";
 TEST(AdaptiveMaxConcurrencyTest, ShouldConvertCorrectly) {
     brpc::AdaptiveMaxConcurrency amc(0);
 
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::UNLIMITED, amc.type());
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::UNLIMITED, amc.value());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::UNLIMITED(), amc.type());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::UNLIMITED(), amc.value());
     EXPECT_EQ(0, int(amc));
-    EXPECT_TRUE(amc == brpc::AdaptiveMaxConcurrency::UNLIMITED);
+    EXPECT_TRUE(amc == brpc::AdaptiveMaxConcurrency::UNLIMITED());
 
     amc = 10;
-    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::CONSTANT, amc.type());
+    EXPECT_EQ(brpc::AdaptiveMaxConcurrency::CONSTANT(), amc.type());
     EXPECT_EQ("10", amc.value());
     EXPECT_EQ(10, int(amc));
     EXPECT_EQ(amc, "10");


### PR DESCRIPTION
## Fix

Fixes #3271

Replace class-static `std::string` members (`UNLIMITED` and `CONSTANT`) with Meyers' Singleton pattern (function-local statics) to avoid static initialization order fiasco.

This issue was discovered during RISC-V porting and testing of BRPC. Different toolchains and linkers (GCC, Clang, cross-compilation toolchains for RISC-V, etc.) may produce different static initialization orders, making this bug manifest on some platforms but not others.

```cpp
// Before:
static const std::string UNLIMITED;

// After:
static const std::string& UNLIMITED() {
    static const std::string s_unlimited = "unlimited";
    return s_unlimited;
}
```

## Changes

- `src/brpc/adaptive_max_concurrency.h` — Static members → static member functions
- `src/brpc/adaptive_max_concurrency.cpp` — Remove definitions, add `()` to calls
- `src/brpc/server.cpp` / `server.h` — Update references
- `src/brpc/policy/constant_concurrency_limiter.cpp` — Update references
- `test/brpc_adaptive_class_unittest.cpp` — Update test references

Full library build passes. This fix benefits all architectures including x86_64, ARM64, and RISC-V.