### PR TITLE
[DRAFT][ci] Install mysql-server for MySQL handshake integration tests

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -196,6 +196,17 @@ jobs:
         cat config.mk
         cd test
         make -j ${{env.proc_num}}
+    - name: install mysql-server
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mysql-server
+        # The distro packages mysqld under /usr/sbin; expose it on PATH so
+        # the handshake integration test's `which mysqld` probe finds it.
+        # The test spins up its own throwaway instance, so stop the system
+        # service to free the default port.
+        sudo ln -sf /usr/sbin/mysqld /usr/local/bin/mysqld
+        sudo service mysql stop || true
+        mysqld --version
     - name: run tests
       run: |
         cd test
@@ -214,6 +225,17 @@ jobs:
         cat config.mk
         cd test
         make NEED_GPERFTOOLS=0 -j ${{env.proc_num}}
+    - name: install mysql-server
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mysql-server
+        # The distro packages mysqld under /usr/sbin; expose it on PATH so
+        # the handshake integration test's `which mysqld` probe finds it.
+        # The test spins up its own throwaway instance, so stop the system
+        # service to free the default port.
+        sudo ln -sf /usr/sbin/mysqld /usr/local/bin/mysqld
+        sudo service mysql stop || true
+        mysqld --version
     - name: run tests
       run: |
         cd test


### PR DESCRIPTION
Installs `mysql-server` in the two make-based Linux unittest jobs (`clang-unittest`, `clang-unittest-asan`) so the MySQL auth handshake integration test can run in CI instead of self-skipping. The test (added in #3310) brings up a throwaway `mysqld` via the `which`-then-spawn pattern from `test/brpc_redis_unittest.cpp`; this step symlinks `mysqld` onto PATH and stops the system service so the test owns the default port. Split out of #3310 to keep that PR's diff to the codec + tests. Depends on #3310 landing first (the test it enables ships there); harmless until then — it just installs an unused package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)