### PR TITLE
fix: guard SO_BINDTODEVICE

### DIFF
--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -1272,12 +1272,18 @@ int Socket::Connect(const timespec* abstime,
     // We need to do async connect (to manage the timeout by ourselves).
     CHECK_EQ(0, butil::make_non_blocking(sockfd));
     if (!_device_name.empty()) {
+#ifdef SO_BINDTODEVICE
         if (setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
                        _device_name.c_str(), _device_name.size()) < 0) {
             PLOG(ERROR) << "Fail to set SO_BINDTODEVICE of fd=" << sockfd
                         << " to device_name=" << _device_name;
             return -1;
         }
+#else
+        LOG(ERROR) << "SO_BINDTODEVICE (device_name=" << _device_name
+                   << ") is not supported on this platform";
+        return -1;
+#endif
     }
     if (local_side().ip != butil::IP_ANY) {
         struct sockaddr_storage cli_addr;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary: MacOS 14 doesn't have `SO_BINDTODEVICE` and so guard it only if it is defined.

### What is changed and the side effects?

Changed: Check the `SO_BINDTODEVICE` is defined or not.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
