### PR TITLE
ci(linux): bring up redis-server and mysql-server for unittests

### DIFF
--- a/.github/actions/install-essential-dependencies/action.yml
+++ b/.github/actions/install-essential-dependencies/action.yml
@@ -3,5 +3,7 @@ runs:
   steps:
     - run: ulimit -c unlimited -S && sudo bash -c "echo 'core.%e.%p' > /proc/sys/kernel/core_pattern"
       shell: bash
-    - run: sudo apt-get update && sudo apt-get install -y git g++ make libssl-dev libgflags-dev libprotobuf-dev libprotoc-dev protobuf-compiler libleveldb-dev
+    - run: sudo apt-get update && sudo apt-get install -y git g++ make libssl-dev libgflags-dev libprotobuf-dev libprotoc-dev protobuf-compiler libleveldb-dev redis-server mysql-server
+      shell: bash
+    - run: redis-server --version && mysqld --version
       shell: bash

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -229,7 +229,10 @@ jobs:
     - name: run tests
       run: |
         cd test
-        sh ./run_tests.sh
+        # brpc_redis_unittest forks a real redis-server and waits a fixed 50ms before
+        # connecting; under ASan redis starts too slowly, so the redis client tests are
+        # flaky here (connection refused). Skip them in ASan; they run in clang-unittest.
+        GTEST_FILTER='-RedisTest.*' sh ./run_tests.sh
 
   clang-unittest-bazel-with-babylon-and-new-pb:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -196,12 +196,6 @@ jobs:
         cat config.mk
         cd test
         make -j ${{env.proc_num}}
-    - name: install redis-server and mysql-server
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y redis-server mysql-server
-        redis-server --version
-        mysqld --version
     - name: run tests
       run: |
         cd test
@@ -220,19 +214,14 @@ jobs:
         cat config.mk
         cd test
         make NEED_GPERFTOOLS=0 -j ${{env.proc_num}}
-    - name: install redis-server and mysql-server
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y redis-server mysql-server
-        redis-server --version
-        mysqld --version
     - name: run tests
       run: |
         cd test
-        # brpc_redis_unittest forks a real redis-server and waits a fixed 50ms before
-        # connecting; under ASan redis starts too slowly, so the redis client tests are
-        # flaky here (connection refused). Skip them in ASan; they run in clang-unittest.
-        GTEST_FILTER='-RedisTest.*' sh ./run_tests.sh
+        # The redis integration tests (sanity/keys_with_spaces/incr_and_decr/by_components/auth)
+        # fork a real redis-server and connect after a fixed 50ms wait; under ASan redis starts
+        # too slowly, so they flake here (connection refused). Skip just those under ASan; the
+        # redis codec/server tests still run, and the full suite runs in clang-unittest.
+        GTEST_FILTER='-RedisTest.sanity:RedisTest.keys_with_spaces:RedisTest.incr_and_decr:RedisTest.by_components:RedisTest.auth' sh ./run_tests.sh
 
   clang-unittest-bazel-with-babylon-and-new-pb:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -107,6 +107,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    # Install redis-server/mysql-server so the integration tests that fork a
+    # real server (e.g. brpc_redis_unittest) actually run under bazel instead
+    # of skipping. Same shared action the make-based unittest jobs use.
+    - uses: ./.github/actions/install-essential-dependencies
     - run: bazel test //test/...
 
   gcc-compile-with-bazel-all-options:
@@ -160,6 +164,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    # Install redis-server/mysql-server so the forked-server integration tests
+    # actually run under bazel (see gcc-unittest-with-bazel).
+    - uses: ./.github/actions/install-essential-dependencies
     - run: |
         bazel test --test_output=streamed \
                    --action_env=CC=clang \
@@ -233,6 +240,9 @@ jobs:
       USE_BAZEL_VERSION: "8.3.1"
     steps:
     - uses: actions/checkout@v2
+    # Install redis-server/mysql-server so the forked-server integration tests
+    # actually run under bazel (see gcc-unittest-with-bazel).
+    - uses: ./.github/actions/install-essential-dependencies
     - name: Override protobuf version for testing
       run: |
         sed -i -E "s/(bazel_dep\(name = ['\"]protobuf['\"], version = ['\"])[^'\"]+/\1${TEST_PROTOBUF_VERSION}/" MODULE.bazel
@@ -240,7 +250,7 @@ jobs:
         grep -E "bazel_dep\(name = ['\"]protobuf['\"]" MODULE.bazel
         grep -qE "bazel_dep\(name = ['\"]protobuf['\"], version = ['\"]${TEST_PROTOBUF_VERSION}['\"]" MODULE.bazel \
           || { echo "ERROR: failed to override protobuf version in MODULE.bazel to ${TEST_PROTOBUF_VERSION}"; exit 1; }
-    - run: | 
+    - run: |
         bazel test --action_env=CC=clang  \
                    --define with_babylon_counter=true \
                    --define with_babylon_counter=true \

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -196,6 +196,12 @@ jobs:
         cat config.mk
         cd test
         make -j ${{env.proc_num}}
+    - name: install redis-server and mysql-server
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y redis-server mysql-server
+        redis-server --version
+        mysqld --version
     - name: run tests
       run: |
         cd test
@@ -214,6 +220,12 @@ jobs:
         cat config.mk
         cd test
         make NEED_GPERFTOOLS=0 -j ${{env.proc_num}}
+    - name: install redis-server and mysql-server
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y redis-server mysql-server
+        redis-server --version
+        mysqld --version
     - name: run tests
       run: |
         cd test

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -251,6 +251,14 @@ generate_unittests(
     data = [
         ":test_runfiles_root_data",
     ],
+    # brpc_redis_unittest forks a real redis-server located via PATH. Tag it
+    # "external" so bazel always re-runs it (never serves a cached pass that
+    # actually skipped) and "local" so it runs outside the sandbox, where the
+    # apt-installed redis-server is visible and loopback works. The CI bazel
+    # jobs install redis-server via the install-essential-dependencies action.
+    per_test_tags = {
+        "brpc_redis_unittest.cpp": ["external", "local"],
+    },
 )
 
 refresh_compile_commands(

--- a/test/generate_unittests.bzl
+++ b/test/generate_unittests.bzl
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def generate_unittests(name, srcs, deps, copts, linkopts = [], data = []):
+def generate_unittests(name, srcs, deps, copts, linkopts = [], data = [], per_test_tags = {}):
     tests = []
     for s in srcs:
         ut_name = s.replace(".cpp", "")
@@ -24,6 +24,11 @@ def generate_unittests(name, srcs, deps, copts, linkopts = [], data = []):
             deps = deps,
             linkopts = linkopts,
             data = data,
+            # Integration tests that fork a real server binary (e.g. redis-server)
+            # need extra tags: "external" forces a real run instead of a cached
+            # pass, and "local" runs them outside the sandbox so the PATH-located
+            # server binary is visible and loopback works.
+            tags = per_test_tags.get(s, []),
         )
         tests.append(":" + ut_name)
 


### PR DESCRIPTION
Bring up `redis-server` (and `mysql-server`) for the Linux unittest jobs — both the make/CMake jobs and the Bazel jobs — via the shared `install-essential-dependencies` action, so the Redis client integration tests actually run instead of being skipped when the server is absent.

**Redis.** The Redis client tests fork a real `redis-server` found on `PATH`. With the server installed they now run in `clang-unittest` (make) and — with the `external` + `local` tags on `brpc_redis_unittest` — under the Bazel unittest jobs as well (`gcc-unittest-with-bazel`, `clang-unittest-with-bazel`, `clang-unittest-bazel-with-babylon-and-new-pb`), where they previously passed vacuously because the sandbox hid the binary. Under ASan the five fork-and-connect cases (`sanity`, `keys_with_spaces`, `incr_and_decr`, `by_components`, `auth`) are filtered out — they flake on Redis's slow startup versus a fixed connect wait — while the Redis codec/parser tests still run.

**MySQL.** `mysql-server` is pre-provisioned for the in-progress MySQL protocol support (#2093); the MySQL client tests land in that follow-up. There are no MySQL tests in this PR yet — installing the server now avoids re-touching CI when they arrive.

CI: the full **Build and Test on Linux** run is green (exercised on my fork).
