### PR TITLE
reject zero-length padded DATA frame in H2Context::OnData

### DIFF
--- a/src/brpc/policy/http2_rpc_protocol.cpp
+++ b/src/brpc/policy/http2_rpc_protocol.cpp
@@ -701,6 +701,10 @@ H2ParseResult H2Context::OnData(
     uint32_t frag_size = frame_head.payload_size;
     uint8_t pad_length = 0;
     if (frame_head.flags & H2_FLAGS_PADDED) {
+        if (frag_size == 0) {
+            LOG(ERROR) << "Invalid payload_size=" << frame_head.payload_size;
+            return MakeH2Error(H2_FRAME_SIZE_ERROR);
+        }
         --frag_size;
         pad_length = LoadUint8(it);
     }


### PR DESCRIPTION
A DATA frame with the PADDED flag but Length 0 underflows frag_size here. `--frag_size` wraps the uint32_t to 0xFFFFFFFF, the `frag_size < pad_length` check then passes, and the bogus size reaches append_and_forward, which swallows the rest of the connection buffer as one DATA payload and feeds ~4GiB into the flow-control counter. OnHeaders already rejects this case; OnData was missing the same guard. Fix returns FRAME_SIZE_ERROR per RFC 7540 6.1 when a padded frame has no room for the pad-length byte.