### PR TITLE
bounds-check OnUserControlMessage like sibling control handlers

### DIFF
--- a/src/brpc/policy/rtmp_protocol.cpp
+++ b/src/brpc/policy/rtmp_protocol.cpp
@@ -1925,8 +1925,8 @@ bool RtmpChunkStream::OnSetPeerBandwidth(
 
 bool RtmpChunkStream::OnUserControlMessage(
     const RtmpMessageHeader& mh, butil::IOBuf* msg_body, Socket* socket) {
-    if (mh.message_length > 32) {
-        RTMP_ERROR(socket, mh) << "No user control message long as "
+    if (mh.message_length < 2 || mh.message_length > 32) {
+        RTMP_ERROR(socket, mh) << "Invalid user control message length="
                                << mh.message_length << " bytes";
         return false;
     }

--- a/src/brpc/policy/rtmp_protocol.cpp
+++ b/src/brpc/policy/rtmp_protocol.cpp
@@ -1925,7 +1925,7 @@ bool RtmpChunkStream::OnSetPeerBandwidth(
 
 bool RtmpChunkStream::OnUserControlMessage(
     const RtmpMessageHeader& mh, butil::IOBuf* msg_body, Socket* socket) {
-    if (mh.message_length < 2 || mh.message_length > 32) {
+    if (mh.message_length < 2u || mh.message_length > 32u) {
         RTMP_ERROR(socket, mh) << "Invalid user control message length="
                                << mh.message_length << " bytes";
         return false;


### PR DESCRIPTION
the sibling control-message handlers (OnSetChunkSize, OnAck, OnWindowAckSize, OnSetPeerBandwidth) all validate message_length before touching the body, but OnUserControlMessage only caps the upper bound at 32. reading the code, a user control message with length 0 or 1 reads the 2-byte event type past the end of the stack buffer, and message_length - 2 underflows (uint32_t) to roughly 4G for the event_data StringPiece. require at least 2 bytes up front like the siblings do.