### PR TITLE
cast to unsigned char in ctype calls on untrusted request bytes

### DIFF
--- a/src/brpc/http_method.cpp
+++ b/src/brpc/http_method.cpp
@@ -102,7 +102,7 @@ const char *HttpMethod2Str(HttpMethod method) {
 }
 
 bool Str2HttpMethod(const char* method_str, HttpMethod* method) {
-    const char fc = ::toupper(*method_str);
+    const char fc = ::toupper(static_cast<unsigned char>(*method_str));
     if (fc == 'G') {
         if (strcasecmp(method_str + 1, /*G*/"ET") == 0) {
             *method = HTTP_METHOD_GET;

--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -434,7 +434,7 @@ RedisCommandConsumeState RedisCommandParser::ConsumeImpl(butil::IOBuf& buf,
         const auto first_arg = static_cast<char*>(arena->allocate(offset));
         memcpy(first_arg, copy_str, offset);
         for (size_t i = 0; i < offset; ++i) {
-            first_arg[i] = tolower(first_arg[i]);
+            first_arg[i] = tolower(static_cast<unsigned char>(first_arg[i]));
         }
         _args.push_back(butil::StringPiece(first_arg, offset));
         if (offset == crlf_pos) {
@@ -538,7 +538,7 @@ RedisCommandConsumeState RedisCommandParser::ConsumeImpl(butil::IOBuf& buf,
     if (_index == 0) {
         // convert it to lowercase when it is command name
         for (int i = 0; i < len; ++i) {
-            d[i] = ::tolower(d[i]);
+            d[i] = ::tolower(static_cast<unsigned char>(d[i]));
         }
     }
     char crlf[2];


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 

Problem Summary:

While tracing how a brpc redis server handles RESP command names, I saw the command name lowercased with `tolower` over a raw `char`. Those bytes come straight off the socket through `RedisCommandParser::Consume`, so any byte in 0x80-0xFF reaches the loop as a negative `char`. Passing a negative value other than `EOF` to a `<ctype.h>` function is undefined behaviour, because the argument has to be representable as `unsigned char`; on some libc builds the ctype macro indexes before the lookup table, which is exactly the kind of thing a fuzzer or a hardened build will flag. The same shape sits in both parser paths (the inline-command path and the bulk-string path) and in `Str2HttpMethod`, which hands the first byte of an attacker-supplied HTTP/2 `:method` pseudo-header to `toupper`.

The root cause is just the missing cast, and the codebase already knows the correct idiom: the array-size guard a few lines up uses `std::isalpha(static_cast<unsigned char>(*pfc))`, and `uri.cpp` casts before its ctype calls too. Left unfixed this is latent UB on every redis server and h2 endpoint, harmless on glibc today but not portable and noisy under UBSan, so I have brought the three sites in line with the existing idiom.

### What is changed and the side effects?

Changed:

Cast each untrusted byte to `unsigned char` before the ctype call in `src/brpc/redis_command.cpp` (both command-name paths) and `src/brpc/http_method.cpp`. Valid ASCII commands and methods behave exactly as before, so there is no observable behaviour change to test against.

Side effects:
- Performance effects: none.

- Breaking backward compatibility: none.
