### PR TITLE
Support end-to-end ECE negotiation in RDMA handshake V3

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -266,4 +266,4 @@ jobs:
         bazel test --action_env=CC=clang --config=rdma \
                    --define with_bthread_tracer=true \
                    --define with_babylon_counter=true \
-                   //test/... --test_arg=--gtest_filter=-RdmaRpcTest.*
+                   //test/...

--- a/src/brpc/rdma/rdma_endpoint.cpp
+++ b/src/brpc/rdma/rdma_endpoint.cpp
@@ -66,7 +66,6 @@ DEFINE_bool(rdma_use_polling, false, "Use polling mode for RDMA.");
 DEFINE_int32(rdma_poller_num, 1, "Poller number in RDMA polling mode.");
 DEFINE_bool(rdma_poller_yield, false, "Yield thread in RDMA polling mode.");
 DEFINE_bool(rdma_disable_bthread, false, "Disable bthread in RDMA");
-DEFINE_bool(rdma_ece, false, "Open ece in RDMA, should use this feature when rdma nics are from the same merchant.");
 
 static const size_t IOBUF_BLOCK_HEADER_LEN = 32; // implementation-dependent
 
@@ -155,6 +154,8 @@ void RdmaEndpoint::Reset() {
     DeallocateResources();
 
     _state = UNINIT;
+    _handshake_version = 0;
+    _outgoing_ece.reset();
     _resource = NULL;
     _send_cq_events = 0;
     _recv_cq_events = 0;
@@ -262,9 +263,9 @@ static const int WAIT_TIMEOUT_MS = 50;
 
 // Drive an EAGAIN-aware read loop to completion (exactly `len` bytes).
 // `read_once(offset, remaining)` performs ONE underlying read attempt:
-//   - returns > 0  : number of bytes consumed (added to running total);
-//   - returns = 0  : end-of-stream (the loop fails with EEOF);
-//   - returns < 0  : errno set; EAGAIN is handled here via butex_wait,
+//   returns > 0  : number of bytes consumed (added to running total);
+//   returns = 0  : end-of-stream (the loop fails with EEOF);
+//   returns < 0  : errno set; EAGAIN is handled here via butex_wait,
 //                   any other errno bubbles up.
 // `offset` is bytes already received in THIS call (initially 0); the
 // callable uses it to choose the next write target (e.g. `(char*)buf
@@ -464,7 +465,7 @@ void* RdmaEndpoint::ProcessHandshakeAtClient(void* arg) {
     } else {
         ep->ApplyRemoteHello(remote);
         ep->_state = C_BRINGUP_QP;
-        if (ep->BringUpQp(remote.lid, remote.gid, remote.qp_num) < 0) {
+        if (ep->BringUpQp(remote, /*is_server=*/false) < 0) {
             LOG(WARNING) << "Fail to bringup QP, fallback to tcp:"
                          << s->description();
             rdma_transport->_rdma_state = RdmaTransport::RDMA_OFF;
@@ -563,7 +564,7 @@ ParseResult RdmaEndpoint::ExecuteServerHandshake(butil::IOBuf* source, Socket* s
                 negotiated = false;
             } else {
                 ep->_state = S_BRINGUP_QP;
-                if (ep->BringUpQp(remote.lid, remote.gid, remote.qp_num) < 0) {
+                if (ep->BringUpQp(remote, /*is_server=*/true) < 0) {
                     LOG(WARNING) << "Fail to bringup QP, fallback to tcp:"
                                  << s->description();
                     negotiated = false;
@@ -1135,7 +1136,7 @@ int RdmaEndpoint::AllocateResources() {
     return 0;
 }
 
-int RdmaEndpoint::BringUpQp(uint16_t lid, ibv_gid gid, uint32_t qp_num) {
+int RdmaEndpoint::BringUpQp(const ParsedHello& remote, bool is_server) {
     if (BAIDU_UNLIKELY(g_skip_rdma_init)) {
         // For UT
         return 0;
@@ -1157,18 +1158,23 @@ int RdmaEndpoint::BringUpQp(uint16_t lid, ibv_gid gid, uint32_t qp_num) {
         return -1;
     }
 
-    if (FLAGS_rdma_ece) {
-        struct ibv_ece ece;
-        int err = IbvQueryEce(_resource->qp, &ece);
+    // ECE negotiation, done while the QP is in INIT state (must be set
+    // before the RTR transition).
+    //
+    // End-to-end model:
+    //   Server: `remote->ece' is the client's queried ECE; set it here,
+    //           then after RTS we query the reduced/negotiated ECE and
+    //           send it back in the server hello.
+    //   Client: `remote->ece' is the server's reduced ECE;
+    //           just set it here.
+    bool use_ece = true;
+    if (IbvSetEce != NULL && remote.ece.has_value()) {
+        ibv_ece ece = *remote.ece;
+        int err = IbvSetEce(_resource->qp, &ece);
         if (err != 0) {
-            LOG(WARNING) << "Fail to IbvQueryEce: " << berror(err);
-            return -1;
-        }
-        // ToDo: should check if remote qp support ece
-        err = IbvSetEce(_resource->qp, &ece);
-        if (err != 0) {
-            LOG(WARNING) << "Fail to IbvSetEce: " << berror(err);
-            return -1;
+            use_ece = false;
+            LOG(WARNING) << "Fail to IbvSetEce, continue without ECE: "
+                         << berror(err);
         }
     }
 
@@ -1179,18 +1185,18 @@ int RdmaEndpoint::BringUpQp(uint16_t lid, ibv_gid gid, uint32_t qp_num) {
 
     attr.qp_state = IBV_QPS_RTR;
     attr.path_mtu = IBV_MTU_1024;  // TODO: support more mtu in future
-    attr.ah_attr.grh.dgid = gid;
+    attr.ah_attr.grh.dgid = remote.gid;
     attr.ah_attr.grh.flow_label = 0;
     attr.ah_attr.grh.sgid_index = GetRdmaGidIndex();
     attr.ah_attr.grh.hop_limit = MAX_HOP_LIMIT;
     attr.ah_attr.grh.traffic_class = 0;
-    attr.ah_attr.dlid = lid;
+    attr.ah_attr.dlid = remote.lid;
     attr.ah_attr.sl = 0;
     attr.ah_attr.src_path_bits = 0;
     attr.ah_attr.static_rate = 0;
     attr.ah_attr.is_global = 1;
     attr.ah_attr.port_num = GetRdmaPortNum();
-    attr.dest_qp_num = qp_num;
+    attr.dest_qp_num = remote.qp_num;
     attr.rq_psn = 0;
     attr.max_dest_rd_atomic = 0;
     attr.min_rnr_timer = 0;  // We do not allow rnr error
@@ -1223,6 +1229,20 @@ int RdmaEndpoint::BringUpQp(uint16_t lid, ibv_gid gid, uint32_t qp_num) {
     if (err != 0) {
         LOG(WARNING) << "Fail to modify QP from RTR to RTS: " << berror(err);
         return -1;
+    }
+
+    // On the server side, now that the QP reached RTS, query the reduced/negotiated
+    // ECE (the subset of enhancements supported by both peers) so it can be returned
+    // to the client in the server hello.
+    if (is_server && use_ece && IbvQueryEce != NULL && remote.ece.has_value()) {
+        ibv_ece ece;
+        int qerr = IbvQueryEce(_resource->qp, &ece);
+        if (qerr == 0) {
+            _outgoing_ece = ece;
+        } else {
+            LOG(WARNING) << "Fail to IbvQueryEce(negotiated), "
+                            "continue without ECE: " << berror(qerr);
+        }
     }
 
     return 0;

--- a/src/brpc/rdma/rdma_endpoint.h
+++ b/src/brpc/rdma/rdma_endpoint.h
@@ -29,6 +29,7 @@
 #include "butil/iobuf.h"
 #include "butil/macros.h"
 #include "butil/containers/mpsc_queue.h"
+#include "butil/containers/optional.h"
 #include "brpc/socket.h"
 #include "brpc/rdma/rdma_handshake_server.h"
 
@@ -101,8 +102,8 @@ friend class RdmaHandshakeServerV3;
 friend RemoteHelloResult v2_wire::ReadBodyAndNegotiate(RdmaEndpoint*, ParsedHello*);
 friend int v2_wire::DrainBytes(RdmaEndpoint*, size_t);
 friend void v3_wire::FillLocalRdmaHello(const RdmaEndpoint*, RdmaHello*);
-friend int  v3_wire::ReadAndParseV3Hello(RdmaEndpoint*, RdmaHello*);
-friend int  v3_wire::WriteV3Hello(RdmaEndpoint*, const RdmaHello&);
+friend int v3_wire::ReadAndParseV3Hello(RdmaEndpoint*, RdmaHello*);
+friend int v3_wire::WriteV3Hello(RdmaEndpoint*, const RdmaHello&);
 public:
     explicit RdmaEndpoint(Socket* s);
     ~RdmaEndpoint() override;
@@ -230,15 +231,14 @@ private:
     // peer's hello has been validated.
     void ApplyRemoteHello(const ParsedHello& remote);
 
-    // Bringup the QP from RESET state to RTS state
+    // Bringup the QP from RESET state to RTS state.
     // Arguments:
-    //     lid: remote LID
-    //     gid: remote GID
-    //     qp_num: remote QP number
-    // Return:
-    //     0:   success
-    //     -1:  failed, errno set
-    int BringUpQp(uint16_t lid, ibv_gid gid, uint32_t qp_num);
+    //   remote: parsed remote hello. Provides the remote LID/GID/QP
+    //           number for the RTR transition, and (on v3) the peer's
+    //           ECE to set during the INIT->RTR transition.
+    //   is_server: true on the server side, false on the client side.
+    // Returns 0 on success, -1 on failed and errno set.
+    int BringUpQp(const ParsedHello& remote, bool is_server);
 
     // Get event from comp channel and ack the events
     int GetAndAckEvents(SocketUniquePtr& s);
@@ -270,6 +270,13 @@ private:
     //   2 = v2 "RDMA"
     //   3 = v3 "RDM3"
     int _handshake_version;
+
+    // ECE payload to advertise in the next local hello:
+    //   Client: the locally queried ECE capabilities (filled
+    //           before C_HELLO_SEND);
+    //   Server: the reduced/negotiated ECE queried after the
+    //           QP reached RTS (filled in BringUpQp).
+    butil::optional<ibv_ece> _outgoing_ece;
 
     // rdma resource
     RdmaResource* _resource;

--- a/src/brpc/rdma/rdma_handshake.cpp
+++ b/src/brpc/rdma/rdma_handshake.cpp
@@ -50,6 +50,15 @@ extern const uint16_t MIN_BLOCK_SIZE;
 extern uint32_t g_rdma_recv_block_size;
 extern bool g_skip_rdma_init;
 
+extern int (*IbvQueryEce)(ibv_qp*, ibv_ece*);
+
+DEFINE_bool(rdma_ece, false, "Enable end-to-end ECE (Enhanced Connection Establishment) "
+                             "negotiation in the RDMA v3 handshake. Automatically degrades "
+                             "to no-ECE when the peer, the local libibverbs, or set_ece "
+                             "does not support it. Acts as a kill switch (default off).");
+
+DECLARE_bool(rdma_trace_verbose);
+
 namespace v2_wire {
 
 void HelloMessage::Serialize(void* data) const {
@@ -293,6 +302,22 @@ void FillLocalRdmaHello(const RdmaEndpoint* ep, RdmaHello* msg) {
         // Only happens in UT
         msg->set_qp_num(0);
     }
+
+    // Advertise ECE only when enabled. Role-dependent payload:
+    //   Client hello: the locally queried ECE capabilities;
+    //   Server hello: the reduced/negotiated ECE queried after RTS.
+    // When the relevant ECE is not valid (disabled, unsupported, or query
+    // failed) the field is simply omitted and the peer degrades to no-ECE.
+    // Advertise ECE if there is anything to advertise. The endpoint pre-fills
+    // _outgoing_ece in a role-specific way: client side stores its locally
+    // queried capabilities; server side stores the reduced/negotiated ECE
+    // after RTS. nullopt -> omit the field (peer degrades to no-ECE).
+    if (FLAGS_rdma_ece && ep->_outgoing_ece.has_value()) {
+        RdmaEce* ece = msg->mutable_ece();
+        ece->set_vendor_id(ep->_outgoing_ece->vendor_id);
+        ece->set_options(ep->_outgoing_ece->options);
+        ece->set_comp_mask(ep->_outgoing_ece->comp_mask);
+    }
 }
 
 int ReadAndParseV3Hello(RdmaEndpoint* ep, RdmaHello* out) {
@@ -348,11 +373,33 @@ void TranslateHello(const RdmaHello& msg, ParsedHello* out) {
     out->lid = static_cast<uint16_t>(msg.lid());
     fast_memcpy(out->gid.raw, msg.gid().data(), sizeof(out->gid.raw));
     out->qp_num = msg.qp_num();
+    if (FLAGS_rdma_ece && msg.has_ece()) {
+        ibv_ece ece;
+        ece.vendor_id = msg.ece().vendor_id();
+        ece.options   = msg.ece().options();
+        ece.comp_mask = msg.ece().comp_mask();
+        out->ece = ece;
+    }
 }
 
 }  // namespace v3_wire
 
 int RdmaHandshakeClientV3::SendLocalHello() {
+    // Query local ECE capabilities so they can be advertised in the client
+    // hello. v3-only. Best-effort: any failure or missing API just means we
+    // won't advertise ECE (the peer then degrades to no-ECE establishment).
+    if (FLAGS_rdma_ece && IbvQueryEce != NULL &&
+        _ep->_resource && _ep->_resource->qp) {
+        ibv_ece ece;
+        if (IbvQueryEce(_ep->_resource->qp, &ece) == 0) {
+            _ep->_outgoing_ece = ece;
+        } else {
+            LOG_IF(WARNING, FLAGS_rdma_trace_verbose)
+                << "Fail to IbvQueryEce on client, ECE not advertised: "
+                << _ep->_socket->description();
+        }
+    }
+
     RdmaHello local_msg{};
     v3_wire::FillLocalRdmaHello(_ep, &local_msg);
     return v3_wire::WriteV3Hello(_ep, local_msg);

--- a/src/brpc/rdma/rdma_handshake.h
+++ b/src/brpc/rdma/rdma_handshake.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <infiniband/verbs.h>
 #include "butil/macros.h"
+#include "butil/containers/optional.h"
 #include "brpc/rdma/rdma_handshake_constants.h"
 
 namespace butil {
@@ -46,6 +47,12 @@ struct ParsedHello {
     uint16_t lid;
     ibv_gid  gid;
     uint32_t qp_num;
+    // ECE (Enhanced Connection Establishment), v3 handshake only.
+    // nullopt means the peer did not advertise any ECE (either it disabled
+    // ECE, its lib does not support ECE, or it is a v2 peer). When engaged:
+    //   - on the server side: the client's queried ECE capabilities;
+    //   - on the client side: the server's reduced/negotiated ECE.
+    butil::optional<ibv_ece> ece;
 };
 
 // Result of reading/parsing a peer's hello (see ReceiveAndParseRemoteHello).

--- a/src/brpc/rdma/rdma_handshake.proto
+++ b/src/brpc/rdma/rdma_handshake.proto
@@ -43,4 +43,23 @@ message RdmaHello {
     // Must be exactly 16 bytes (sizeof(ibv_gid)).
     required bytes  gid        = 5;
     required uint32 qp_num     = 6;
+
+    // ECE negotiation
+    // Optional: present only when both the local lib (rdma-core >= v35)
+    // and FLAGS_rdma_ece enable end-to-end ECE negotiation. When the
+    // field is absent the receiver falls back to no-ECE establishment.
+    //
+    // Semantics differ by sender role:
+    //   Client hello: carries the client's locally queried
+    //                   ECE capabilities.
+    //   Server hello: carries the REDUCED/negotiated ECE
+    //                   queried after the QP reached RTS.
+    optional RdmaEce ece = 7;
+}
+
+// Mirrors struct ibv_ece { uint32 vendor_id; uint32 options; uint32 comp_mask; }.
+message RdmaEce {
+    required uint32 vendor_id = 1;
+    required uint32 options   = 2;
+    required uint32 comp_mask = 3;
 }

--- a/src/brpc/rdma/rdma_helper.cpp
+++ b/src/brpc/rdma/rdma_helper.cpp
@@ -340,12 +340,21 @@ static void OnRdmaAsyncEvent(Socket* m) {
     } while (true);
 }
 
-#define LoadSymbol(handle, func, symbol) \
-    *(void**)(&func) = dlsym(handle, symbol); \
-    if (!func) { \
+#define LoadSymbol(handle, func, symbol)                 \
+    *(void**)(&func) = dlsym(handle, symbol);            \
+    if (!func) {                                         \
         LOG(ERROR) << "Fail to find symbol: " << symbol; \
-        return -1; \
+        return -1;                                       \
     }
+
+// Soft-load an OPTIONAL symbol: if the symbol is missing (e.g. the
+// installed libibverbs predates rdma-core v35 which introduced the ECE
+// APIs), leave the function pointer NULL and continue instead of failing
+// the whole RDMA initialization. Callers MUST null-check before use.
+#define LoadSymbolOptional(handle, func, symbol) \
+    *(void**)(&func) = dlsym(handle, symbol);    \
+    LOG_IF(WARNING, func == NULL)                \
+        << "Optional symbol not found (feature disabled): " << symbol;
 
 static int ReadRdmaDynamicLib() {
     const static char* const kRdmaLibs[] = {
@@ -392,8 +401,12 @@ static int ReadRdmaDynamicLib() {
     LoadSymbol(g_handle_ibverbs, IbvGetAsyncEvent, "ibv_get_async_event");
     LoadSymbol(g_handle_ibverbs, IbvAckAsyncEvent, "ibv_ack_async_event");
     LoadSymbol(g_handle_ibverbs, IbvEventTypeStr, "ibv_event_type_str");
-    LoadSymbol(g_handle_ibverbs, IbvQueryEce, "ibv_query_ece");
-    LoadSymbol(g_handle_ibverbs, IbvSetEce, "ibv_set_ece");
+    // ECE APIs were introduced in symbol version IBVERBS_1.10.
+    // Load them optionally so that running against an older
+    // libibverbs keeps RDMA working (ECE simply stays disabled)
+    // instead of failing the whole initialization.
+    LoadSymbolOptional(g_handle_ibverbs, IbvQueryEce, "ibv_query_ece");
+    LoadSymbolOptional(g_handle_ibverbs, IbvSetEce, "ibv_set_ece");
 
     return 0;
 }

--- a/test/brpc_rdma_unittest.cpp
+++ b/test/brpc_rdma_unittest.cpp
@@ -62,6 +62,7 @@ namespace rdma {
 DECLARE_bool(rdma_trace_verbose);
 DECLARE_int32(rdma_memory_pool_max_regions);
 DECLARE_int32(rdma_client_handshake_version);
+DECLARE_bool(rdma_ece);
 
 extern ibv_cq* (*IbvCreateCq)(ibv_context*, int, void*, ibv_comp_channel*, int);
 extern int (*IbvDestroyCq)(ibv_cq*);
@@ -1760,6 +1761,161 @@ TEST_F(RdmaTest, v3_server_invalid_sq_size_falls_back) {
     usleep(100000);
     ASSERT_EQ(NULL, GetSocketFromServer(0));
 
+    StopServer();
+}
+
+// RAII guard to toggle FLAGS_rdma_ece for a single test and restore it.
+class EceFlagGuard {
+public:
+    explicit EceFlagGuard(bool v) : _saved(rdma::FLAGS_rdma_ece) {
+        rdma::FLAGS_rdma_ece = v;
+    }
+    ~EceFlagGuard() {
+        rdma::FLAGS_rdma_ece = _saved;
+    }
+private:
+    bool _saved;
+};
+
+// Build a valid v3 hello that also carries an ECE block.
+rdma::RdmaHello MakeValidV3HelloWithEce(uint32_t vendor_id,
+                                        uint32_t options,
+                                        uint32_t comp_mask) {
+    rdma::RdmaHello msg = MakeValidV3Hello();
+    rdma::RdmaEce* ece = msg.mutable_ece();
+    ece->set_vendor_id(vendor_id);
+    ece->set_options(options);
+    ece->set_comp_mask(comp_mask);
+    return msg;
+}
+
+// Read the server's v3 reply hello (4B magic + 4B pb_size + body) and parse
+// it into `reply`. Asserts the framing along the way.
+static void ReadServerV3Reply(int fd, rdma::RdmaHello* reply) {
+    uint8_t reply_hdr[8];
+    ASSERT_EQ(8, read(fd, reply_hdr, 8));
+    ASSERT_EQ(0, memcmp(reply_hdr, "RDM3", 4));
+    uint32_t reply_pb_size = butil::NetToHost32(*reinterpret_cast<uint32_t*>(reply_hdr + 4));
+    ASSERT_GT(reply_pb_size, 0u);
+    ASSERT_LE(reply_pb_size, 4096u);
+    std::string reply_body(reply_pb_size, '\0');
+    ASSERT_EQ((ssize_t)reply_pb_size,
+              read(fd, &reply_body[0], reply_pb_size));
+    ASSERT_TRUE(reply->ParseFromString(reply_body));
+}
+
+// A client hello carrying ECE must not break the server handshake: with ECE
+// enabled the server still parses the hello and advances to S_ACK_WAIT.
+TEST_F(RdmaTest, v3_server_accepts_client_hello_with_ece) {
+    EceFlagGuard ece_flag_guard(true);
+    StartServer();
+
+    sockaddr_in addr;
+    bzero((char*)&addr, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(PORT);
+    butil::fd_guard sockfd(socket(AF_INET, SOCK_STREAM, 0));
+    ASSERT_TRUE(sockfd >= 0);
+    ASSERT_EQ(0, connect(sockfd, (sockaddr*)&addr, sizeof(sockaddr)));
+    usleep(100000);
+    Socket* s = GetSocketFromServer(0);
+    ASSERT_TRUE(s != NULL);
+
+    rdma::RdmaHello msg = MakeValidV3HelloWithEce(0x02c9, 0x1, 0x0);
+    std::string packet = MakeV3Packet(msg);
+    ASSERT_EQ((ssize_t)packet.size(),
+              write(sockfd, packet.data(), packet.size()));
+    usleep(100000);
+
+    ASSERT_EQ(rdma::RdmaEndpoint::S_ACK_WAIT,
+              static_cast<RdmaTransport*>(s->_transport.get())->_rdma_ep->_state);
+
+    rdma::RdmaHello reply;
+    ReadServerV3Reply(sockfd, &reply);
+
+    // ACK flags=0 -> clean FALLBACK_TCP so the test ends without hardware.
+    uint32_t flags = butil::HostToNet32(0);
+    ASSERT_EQ((ssize_t)sizeof(flags), write(sockfd, &flags, sizeof(flags)));
+    usleep(100000);
+    ASSERT_EQ(rdma::RdmaEndpoint::FALLBACK_TCP,
+              static_cast<RdmaTransport*>(s->_transport.get())->_rdma_ep->_state);
+
+    sockfd.reset(-1);
+    usleep(100000);
+    ASSERT_EQ(NULL, GetSocketFromServer(0));
+    StopServer();
+}
+
+// When ECE negotiation is disabled, the server reply must NOT advertise ECE,
+// even if the client advertised it (FillLocalRdmaHello degrade branch #1).
+TEST_F(RdmaTest, v3_server_reply_has_no_ece_when_disabled) {
+    EceFlagGuard ece_flag_guard(false);
+    StartServer();
+
+    sockaddr_in addr;
+    bzero((char*)&addr, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(PORT);
+    butil::fd_guard sockfd(socket(AF_INET, SOCK_STREAM, 0));
+    ASSERT_TRUE(sockfd >= 0);
+    ASSERT_EQ(0, connect(sockfd, (sockaddr*)&addr, sizeof(sockaddr)));
+    usleep(100000);
+    Socket* s = GetSocketFromServer(0);
+    ASSERT_TRUE(s != NULL);
+
+    rdma::RdmaHello msg = MakeValidV3HelloWithEce(0x02c9, 0x1, 0x0);
+    std::string packet = MakeV3Packet(msg);
+    ASSERT_EQ((ssize_t)packet.size(),
+              write(sockfd, packet.data(), packet.size()));
+    usleep(100000);
+
+    rdma::RdmaHello reply;
+    ReadServerV3Reply(sockfd, &reply);
+    EXPECT_FALSE(reply.has_ece());
+
+    uint32_t flags = butil::HostToNet32(0);
+    ASSERT_EQ((ssize_t)sizeof(flags), write(sockfd, &flags, sizeof(flags)));
+    usleep(100000);
+
+    sockfd.reset(-1);
+    usleep(100000);
+    StopServer();
+}
+
+// When ECE is enabled but there is no negotiated result (UT skips the real QP
+// bring-up, so the server never fills _outgoing_ece), the server reply must
+// still NOT advertise ECE (FillLocalRdmaHello degrade branch #2 -> degrade-safe).
+TEST_F(RdmaTest, v3_server_reply_has_no_ece_without_hw_negotiation) {
+    EceFlagGuard ece_flag_guard(true);
+    StartServer();
+
+    sockaddr_in addr;
+    bzero((char*)&addr, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(PORT);
+    butil::fd_guard sockfd(socket(AF_INET, SOCK_STREAM, 0));
+    ASSERT_TRUE(sockfd >= 0);
+    ASSERT_EQ(0, connect(sockfd, (sockaddr*)&addr, sizeof(sockaddr)));
+    usleep(100000);
+    Socket* s = GetSocketFromServer(0);
+    ASSERT_TRUE(s != NULL);
+
+    rdma::RdmaHello msg = MakeValidV3HelloWithEce(0x02c9, 0x1, 0x0);
+    std::string packet = MakeV3Packet(msg);
+    ASSERT_EQ((ssize_t)packet.size(),
+              write(sockfd, packet.data(), packet.size()));
+    usleep(100000);
+
+    rdma::RdmaHello reply;
+    ReadServerV3Reply(sockfd, &reply);
+    EXPECT_FALSE(reply.has_ece());
+
+    uint32_t flags = butil::HostToNet32(0);
+    ASSERT_EQ((ssize_t)sizeof(flags), write(sockfd, &flags, sizeof(flags)));
+    usleep(100000);
+
+    sockfd.reset(-1);
+    usleep(100000);
     StopServer();
 }
 

--- a/test/brpc_socket_unittest.cpp
+++ b/test/brpc_socket_unittest.cpp
@@ -1590,8 +1590,9 @@ TEST_F(SocketTest, tcp_user_timeout) {
         brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::Socket::Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
         CheckTCPUserTimeout(ptr->fd(), 0);
+        ASSERT_EQ(0, ptr->SetFailed());
     }
 
     {
@@ -1603,8 +1604,9 @@ TEST_F(SocketTest, tcp_user_timeout) {
         brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::Socket::Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
         CheckTCPUserTimeout(ptr->fd(), tcp_user_timeout_ms);
+        ASSERT_EQ(0, ptr->SetFailed());
     }
 
     brpc::FLAGS_socket_tcp_user_timeout_ms = 2000;
@@ -1615,8 +1617,9 @@ TEST_F(SocketTest, tcp_user_timeout) {
         brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
         CheckTCPUserTimeout(ptr->fd(), brpc::FLAGS_socket_tcp_user_timeout_ms);
+        ASSERT_EQ(0, ptr->SetFailed());
     }
     {
         int tcp_user_timeout_ms = 3000;
@@ -1627,8 +1630,9 @@ TEST_F(SocketTest, tcp_user_timeout) {
         brpc::SocketId id = brpc::INVALID_SOCKET_ID;
         ASSERT_EQ(0, brpc::get_or_new_client_side_messenger()->Create(options, &id));
         brpc::SocketUniquePtr ptr;
-        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr)) << "id=" << id;
+        ASSERT_EQ(0, brpc::Socket::Address(id, &ptr));
         CheckTCPUserTimeout(ptr->fd(), tcp_user_timeout_ms);
+        ASSERT_EQ(0, ptr->SetFailed());
     }
 
     messenger->StopAccept(0);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

In #3255, `BringUpQp()` only did a local `ibv_query_ece` + `ibv_set_ece`
roundtrip and never exchanged ECE capabilities with the peer.

### What is changed and the side effects?

Changed:

This PR implements an end-to-end ECE negotiation in the v3 handshake.

- Client (`RdmaHandshakeClientV3::SendLocalHello`): query local ECE, 
   store it in `_outgoing_ece`, advertise it in the v3 hello.
- Server (`BringUpQp`): apply the client's ECE during INIT->RTR (`ibv_set_ece`). 
   After QP reaches RTS, `ibv_query_ece` to obtain the reduced/negotiated ECE 
   (the subset both peers support) and store it in `_outgoing_ece`.
- Server (`SendLocalHello` → `FillLocalRdmaHello`): advertise the negotiated ECE
   in the reply hello.
- Client (`BringUpQp`): apply the server's reduced ECE during INIT->RTR.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
