### PR TITLE
Limit AMF string and array parsing

### DIFF
--- a/src/brpc/amf.cpp
+++ b/src/brpc/amf.cpp
@@ -27,11 +27,35 @@
 namespace brpc {
 
 DEFINE_int32(amf_max_depth, 128, "Maximum nesting depth for AMF objects and arrays");
+DEFINE_int32(amf_max_string_size, 64 * 1024 * 1024,
+             "Maximum byte size for AMF strings");
+DEFINE_int32(amf_max_array_size, 1024 * 1024,
+             "Maximum element count for AMF arrays");
 
 static bool CheckAMFDepth(int depth) {
     if (depth > FLAGS_amf_max_depth) {
         LOG(ERROR) << "AMF exceeds max depth! max="
                    << FLAGS_amf_max_depth << ", actually=" << depth;
+        return false;
+    }
+    return true;
+}
+
+static bool CheckAMFStringSize(uint32_t len) {
+    if (FLAGS_amf_max_string_size < 0 ||
+        len > (uint32_t)FLAGS_amf_max_string_size) {
+        LOG(ERROR) << "AMF string exceeds max size! max="
+                   << FLAGS_amf_max_string_size << ", actually=" << len;
+        return false;
+    }
+    return true;
+}
+
+static bool CheckAMFArraySize(uint32_t count) {
+    if (FLAGS_amf_max_array_size < 0 ||
+        count > (uint32_t)FLAGS_amf_max_array_size) {
+        LOG(ERROR) << "AMF array exceeds max size! max="
+                   << FLAGS_amf_max_array_size << ", actually=" << count;
         return false;
     }
     return true;
@@ -268,8 +292,12 @@ static bool ReadAMFShortStringBody(std::string* str, AMFInputStream* stream) {
         LOG(ERROR) << "stream is not long enough";
         return false;
     }
+    if (!CheckAMFStringSize(len)) {
+        return false;
+    }
     str->resize(len);
     if (len != 0 && stream->cutn(&(*str)[0], len) != len) {
+        str->clear();
         LOG(ERROR) << "stream is not long enough";
         return false;
     }
@@ -282,8 +310,12 @@ static bool ReadAMFLongStringBody(std::string* str, AMFInputStream* stream) {
         LOG(ERROR) << "stream is not long enough";
         return false;
     }
+    if (!CheckAMFStringSize(len)) {
+        return false;
+    }
     str->resize(len);
     if (len != 0 && stream->cutn(&(*str)[0], len) != len) {
+        str->clear();
         LOG(ERROR) << "stream is not long enough";
         return false;
     }
@@ -584,6 +616,9 @@ static bool ReadAMFEcmaArrayBody(google::protobuf::Message* message,
         LOG(ERROR) << "stream is not long enough";
         return false;
     }
+    if (!CheckAMFArraySize(count)) {
+        return false;
+    }
     const google::protobuf::Descriptor* desc = message->GetDescriptor();
     std::string name;
     for (uint32_t i = 0; i < count; ++i) {
@@ -760,6 +795,9 @@ static bool ReadAMFEcmaArrayBody(AMFObject* obj, AMFInputStream* stream, int dep
         LOG(ERROR) << "stream is not long enough";
         return false;
     }
+    if (!CheckAMFArraySize(count)) {
+        return false;
+    }
     std::string name;
     for (uint32_t i = 0; i < count; ++i) {
         if (!ReadAMFShortStringBody(&name, stream)) {
@@ -890,6 +928,9 @@ static bool ReadAMFArrayBody(AMFArray* arr, AMFInputStream* stream, int depth) {
     uint32_t count = 0;
     if (stream->cut_u32(&count) != 4u) {
         LOG(ERROR) << "stream is not long enough";
+        return false;
+    }
+    if (!CheckAMFArraySize(count)) {
         return false;
     }
     for (uint32_t i = 0; i < count; ++i) {

--- a/test/brpc_rtmp_unittest.cpp
+++ b/test/brpc_rtmp_unittest.cpp
@@ -37,6 +37,8 @@
 
 namespace brpc {
 DECLARE_int32(amf_max_depth);
+DECLARE_int32(amf_max_string_size);
+DECLARE_int32(amf_max_array_size);
 }
 
 int main(int argc, char* argv[]) {
@@ -57,6 +59,20 @@ public:
 
 private:
     int32_t _old_depth;
+};
+
+class ScopedAMFLimit {
+public:
+    ScopedAMFLimit(int32_t* flag, int32_t value) : _flag(flag), _old_value(*flag) {
+        *_flag = value;
+    }
+    ~ScopedAMFLimit() {
+        *_flag = _old_value;
+    }
+
+private:
+    int32_t* _flag;
+    int32_t _old_value;
 };
 
 void AppendAMFStrictArrayHeader(std::string* out, uint32_t count) {
@@ -84,6 +100,14 @@ void AppendAMFShortStringBody(std::string* out, const char* name) {
     out->push_back((char)((len >> 8) & 0xFF));
     out->push_back((char)(len & 0xFF));
     out->append(name, len);
+}
+
+void AppendAMFLongStringHeader(std::string* out, uint32_t len) {
+    out->push_back((char)brpc::AMF_MARKER_LONG_STRING);
+    out->push_back((char)((len >> 24) & 0xFF));
+    out->push_back((char)((len >> 16) & 0xFF));
+    out->push_back((char)((len >> 8) & 0xFF));
+    out->push_back((char)(len & 0xFF));
 }
 
 void AppendAMFObjectEnd(std::string* out) {
@@ -595,6 +619,56 @@ TEST(RtmpTest, amf) {
     ASSERT_EQ("foo", info3.code());
     ASSERT_EQ("bar", info3.level());
     ASSERT_EQ("heheda", info3.description());
+}
+
+TEST(RtmpTest, amf_rejects_oversized_string_before_growing_output) {
+    std::string req_buf;
+    AppendAMFLongStringHeader(&req_buf, 16);
+    req_buf.append("short", 5);
+
+    google::protobuf::io::ArrayInputStream zc_stream(req_buf.data(), req_buf.size());
+    brpc::AMFInputStream istream(&zc_stream);
+    std::string result = "unchanged";
+    EXPECT_FALSE(brpc::ReadAMFString(&result, &istream));
+    EXPECT_TRUE(result.empty());
+
+    ScopedAMFLimit scoped_limit(&brpc::FLAGS_amf_max_string_size, 4);
+    std::string capped_buf;
+    AppendAMFLongStringHeader(&capped_buf, 5);
+    capped_buf.append("hello", 5);
+
+    google::protobuf::io::ArrayInputStream zc_stream2(capped_buf.data(),
+                                                     capped_buf.size());
+    brpc::AMFInputStream istream2(&zc_stream2);
+    EXPECT_FALSE(brpc::ReadAMFString(&result, &istream2));
+}
+
+TEST(RtmpTest, amf_rejects_oversized_ecma_array_count) {
+    ScopedAMFLimit scoped_limit(&brpc::FLAGS_amf_max_array_size, 1);
+
+    std::string req_buf;
+    AppendAMFEcmaArrayHeader(&req_buf, 2);
+    AppendAMFShortStringBody(&req_buf, "x");
+    req_buf.push_back((char)brpc::AMF_MARKER_NULL);
+
+    google::protobuf::io::ArrayInputStream zc_stream(req_buf.data(), req_buf.size());
+    brpc::AMFInputStream istream(&zc_stream);
+    brpc::AMFObject obj;
+    EXPECT_FALSE(brpc::ReadAMFObject(&obj, &istream));
+}
+
+TEST(RtmpTest, amf_rejects_oversized_strict_array_count) {
+    ScopedAMFLimit scoped_limit(&brpc::FLAGS_amf_max_array_size, 1);
+
+    std::string req_buf;
+    AppendAMFStrictArrayHeader(&req_buf, 2);
+    req_buf.push_back((char)brpc::AMF_MARKER_NULL);
+
+    google::protobuf::io::ArrayInputStream zc_stream(req_buf.data(), req_buf.size());
+    brpc::AMFInputStream istream(&zc_stream);
+    brpc::AMFArray arr;
+    EXPECT_FALSE(brpc::ReadAMFArray(&arr, &istream));
+    EXPECT_EQ(0u, arr.size());
 }
 
 TEST(RtmpTest, amf_rejects_deep_nested_arrays) {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: null

Problem Summary:

AMF parsing accepted declared string lengths and array counts directly from the input stream. Malformed RTMP/AMF payloads could make the parser reserve excessive memory or spend a long time walking impossible element counts before discovering that the stream was incomplete.

### What is changed and the side effects?

Changed:

- Add configurable AMF string and array limits.
- Read AMF string bodies incrementally instead of resizing the destination string to the declared length up front.
- Reject ECMA array and strict array counts above the configured limit before parsing their elements.
- Add RTMP AMF unit tests for truncated long strings and oversized array counts.

Side effects:
- Performance effects: AMF string parsing now copies through a small stack buffer, avoiding large zero-fill allocations for malformed payloads.

- Breaking backward compatibility: AMF payloads whose string length or array count exceed the new defaults will be rejected. The defaults are 64 MiB per string and 1,048,576 array elements.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).