### PR TITLE
Fix empty Redis command array parsing

### DIFF
--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -517,14 +517,22 @@ RedisCommandConsumeState RedisCommandParser::ConsumeImpl(butil::IOBuf& buf,
             return CONSUME_STATE_ERROR;
         }
         buf.pop_front(crlf_pos + 2/*CRLF*/);
+        if (value == 0) {
+            LOG(ERROR) << "Empty redis command array";
+            *err = PARSE_ERROR_ABSOLUTELY_WRONG;
+            return CONSUME_STATE_ERROR;
+        }
         _parsing_array = true;
         _length = value;
         _index = 0;
         _args.resize(value);
         return CONSUME_STATE_CONTINUE;
     }
-    CHECK(_index < _length) << "a complete command has been parsed. "
-                               "impl of RedisCommandParser::Parse is buggy";
+    if (_index >= _length) {
+        LOG(ERROR) << "Too many bulk strings in redis command";
+        *err = PARSE_ERROR_ABSOLUTELY_WRONG;
+        return CONSUME_STATE_ERROR;
+    }
     const int64_t len = value;  // `value' is length of the string
     if (len < 0) {
         LOG(ERROR) << "string in command is nil!";

--- a/test/brpc_redis_unittest.cpp
+++ b/test/brpc_redis_unittest.cpp
@@ -673,6 +673,19 @@ TEST_F(RedisTest, command_parser) {
     }
 }
 
+TEST(RedisCommandParserTest, reject_empty_resp_array_command) {
+    brpc::RedisCommandParser parser;
+    butil::IOBuf buf;
+    std::vector<butil::StringPiece> command_out;
+    butil::Arena arena;
+
+    // Empty RESP arrays are not valid commands and must not leave the parser in
+    // a state that accepts following bulk strings.
+    buf.append("*0\r\n$1\r\nx\r\n");
+    ASSERT_EQ(brpc::PARSE_ERROR_ABSOLUTELY_WRONG,
+              parser.Consume(buf, &command_out, &arena));
+}
+
 // Regression test for issue #3109: the inline redis protocol must not consume
 // the HTTP/2 connection preface as a command, otherwise protocol auto-detection
 // never falls through to HTTP/2 and gRPC clients fail with "connection closed


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: null

Problem Summary:

The Redis command parser accepted an empty RESP array as the start of a command
and kept parsing subsequent bulk strings as array elements. Since an empty array
has no command name or arguments, this input should be rejected by the parser.

### What is changed and the side effects?

Changed:

- Reject empty RESP command arrays in `RedisCommandParser`.
- Replace the internal array index `CHECK` with an explicit parse error before
  writing parsed bulk strings into the argument vector.
- Add a parser regression test for empty RESP arrays followed by bulk strings.

Side effects:
- Performance effects: None expected.

- Breaking backward compatibility: Empty RESP arrays are now rejected as invalid
  Redis commands.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
