### PR TITLE
fix out-of-bounds read parsing AVC SPS in ParseSPS

### DIFF
--- a/src/brpc/rtmp.cpp
+++ b/src/brpc/rtmp.cpp
@@ -612,7 +612,7 @@ butil::Status AVCDecoderConfigurationRecord::Create(const void* data, size_t len
             return butil::Status(EINVAL, "Not enough data to decode SPS");
         }
         if (sps_length > 0) {
-            butil::Status st = ParseSPS(buf.data() + 2, sps_length);
+            butil::Status st = ParseSPS(buf.substr(2, sps_length), sps_length);
             if (!st.ok()) {
                 return st;
             }

--- a/test/brpc_rtmp_unittest.cpp
+++ b/test/brpc_rtmp_unittest.cpp
@@ -729,6 +729,25 @@ TEST(RtmpTest, amf_rejects_deep_nested_ecma_arrays) {
     EXPECT_TRUE(brpc::ReadAMFObject(&valid_obj, &istream2));
 }
 
+// Create() copies the record into a non-NUL-terminated buffer, so the SPS must
+// be parsed with an explicitly-sized view. A crafted sequence header whose SPS
+// body has no zero byte used to make ParseSPS run strlen off the end of that
+// buffer (an out-of-bounds read, caught here under ASan).
+TEST(RtmpTest, avc_seq_header_sps_without_zero_byte) {
+    const uint16_t sps_length = 70; // keep the record above the small-array cap
+    butil::IOBuf buf;
+    const char head[6] = { 0x01, 0x64, 0x00, 0x28, (char)0xff, (char)0xe1 };
+    buf.append(head, sizeof(head)); // version/profile/level, lengthSizeMinus1=3, numSPS=1
+    const char len_be[2] = { (char)(sps_length >> 8), (char)(sps_length & 0xff) };
+    buf.append(len_be, sizeof(len_be));
+    std::string sps(sps_length, (char)0x67); // NAL header 0x67 then non-zero filler
+    buf.append(sps);
+
+    brpc::AVCDecoderConfigurationRecord avc;
+    // Only requirement: the call must not read past the copied record.
+    avc.Create(buf);
+}
+
 TEST(RtmpTest, successfully_play_streams) {
     PlayingDummyService rtmp_service;
     brpc::Server server;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`AVCDecoderConfigurationRecord::Create` copies the sequence header into a buffer that is not NUL-terminated (`DEFINE_SMALL_ARRAY`), then calls `ParseSPS(buf.data() + 2, sps_length)`. `ParseSPS` takes a `butil::StringPiece`, so the bare `const char*` is turned into one through the implicit `StringPiece(const char*)` constructor, which runs `strlen`. When a publisher sends an AVC sequence header whose SPS body has no zero byte, that `strlen` walks off the end of the copied record and reads out of bounds. The path is reachable from untrusted RTMP video input.

### What is changed and the side effects?

Changed:

Pass `buf.substr(2, sps_length)` so `ParseSPS` receives an explicitly sized view and no `strlen` runs. It is the same idiom already used a few lines below when pushing into `sps_list`. I also added a regression test that feeds a zero-free SPS body, which trips ASan on the old code and stays clean after the fix.

Side effects:
- Performance effects: none.

- Breaking backward compatibility: none. The reads inside `ParseSPS` were already bounded by `sps_length`, so valid sequence headers parse exactly as before.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).