### PR TITLE
fix: replace RISC-V cpu_relax fence.i with pause hint for spin-wait

### DIFF
--- a/src/bthread/processor.h
+++ b/src/bthread/processor.h
@@ -29,7 +29,14 @@
 #if defined(ARCH_CPU_ARM_FAMILY)
 # define cpu_relax() asm volatile("yield\n": : :"memory")
 #elif defined(ARCH_CPU_RISCV_FAMILY)
-# define cpu_relax() asm volatile("fence.i\n": : :"memory")
+// Use the pause hint (Zihintpause extension). Encoding 0x0100000F
+// (fence 0, 1) is a HINT on all RISC-V implementations: it never traps
+// and is ignored on CPUs without Zihintpause. On CPUs with Zihintpause
+// it provides a multi-cycle stall hint that reduces power and improves
+// resource fairness during spin-wait loops. Matches the Linux kernel's
+// RISC-V cpu_relax() behavior. .word is used instead of .insn or the
+// pause mnemonic for maximum assembler compatibility.
+# define cpu_relax() asm volatile(".word 0x0100000f\n": : :"memory")
 #elif defined(ARCH_CPU_LOONGARCH64_FAMILY)
 # define cpu_relax() asm volatile("nop\n": : :"memory");
 #else


### PR DESCRIPTION
## Description

`fence.i` is an instruction-synchronization barrier on RISC-V that flushes the instruction cache. Using it in `cpu_relax()` for spin-wait loops is unnecessarily heavy — it should only be used after writing code (e.g., JIT compilation, self-modifying code).

## Fix

Replace `fence.i` with the pause hint (Zihintpause extension, encoding `0x0100000F`). The encoding `fence 0, 1` is a HINT on all RISC-V implementations: it never traps and is ignored on CPUs without Zihintpause. On CPUs with Zihintpause it provides a multi-cycle stall hint that reduces power and improves resource fairness during spin loops. Matches the RISC-V Linux kernel's `ALT_RISCV_PAUSE()` behavior.

`.word 0x0100000f` is used instead of the `pause` mnemonic for maximum assembler compatibility, avoiding dependency on the `pause` mnemonic (requires `zihintpause` in `-march`) or the `.insn` directive (requires recent binutils/Clang).

## Verification

- Compiled standalone test file containing `.word 0x0100000f` on RISC-V 64-bit server (SG2044, rv64gcv) with GCC 12.3.1 and Clang (both tested with `-march=rv64gc`, `rv64gcv`, and `rv64gcv_zihintpause`)
- Disassembly confirmed `pause` encoding `0x0100000f` emitted in all cases
- Cross-compilation with `riscv64-linux-gnu-g++` (GCC 13) also confirmed correct encoding

## References

- [RISC-V Linux kernel cpu_relax](https://github.com/torvalds/linux/blob/master/arch/riscv/include/asm/vdso/processor.h)
- [Zihintpause specification](https://github.com/riscv/riscv-isa-manual/blob/main/src/zihintpause.adoc)
