### PR TITLE
fix char-signedness out-of-bounds read in url and header lookup tables

### DIFF
--- a/src/brpc/uri.cpp
+++ b/src/brpc/uri.cpp
@@ -168,7 +168,7 @@ int URI::SetHttpURL(const char* url) {
     bool need_scheme = true;
     bool need_user_info = true;
     for (; true; ++p) {
-        const char action = g_url_parsing_fast_action_map[(int)*p];
+        const char action = g_url_parsing_fast_action_map[(signed char)*p];
         if (action == URI_PARSE_CONTINUE) {
             continue;
         }
@@ -256,7 +256,7 @@ int ParseURL(const char* url,
     bool need_scheme = true;
     bool need_user_info = true;
     for (; true; ++p) {
-        const char action = g_url_parsing_fast_action_map[(int)*p];
+        const char action = g_url_parsing_fast_action_map[(signed char)*p];
         if (action == URI_PARSE_CONTINUE) {
             continue;
         }

--- a/src/butil/containers/case_ignored_flat_map.h
+++ b/src/butil/containers/case_ignored_flat_map.h
@@ -29,7 +29,11 @@ namespace butil {
 // note: using char caused crashes on ubuntu 20.04 aarch64 (VM on apple M1)
 inline char ascii_tolower(int/*note*/ c) {
     extern const signed char* const g_tolower_map;
-    return g_tolower_map[c];
+    // g_tolower_map is biased by +128 and sized for a signed-char index
+    // ([-128,127]). Callers pass a `char`; on platforms where `char` is
+    // unsigned (aarch64, riscv64) a byte >= 0x80 arrives here as 128..255 and
+    // indexes past the 256-entry table. Fold back into signed-char range.
+    return g_tolower_map[(signed char)c];
 }
 
 struct CaseIgnoredHasher {

--- a/test/brpc_uri_unittest.cpp
+++ b/test/brpc_uri_unittest.cpp
@@ -303,6 +303,28 @@ TEST(URITest, invalid_query) {
     ASSERT_EQ("a-b-c:def", uri.query());
 }
 
+TEST(URITest, high_bit_bytes) {
+    // Bytes >= 0x80 (e.g. UTF-8 in the host/path) index the +128-biased
+    // action table. On unsigned-char platforms they would read past the
+    // 256-entry table; this trips a buffer-overflow read under ASan without
+    // the signed-char fold. They are ordinary characters for the parser.
+    brpc::URI uri;
+    const std::string url =
+        "http://user:passwd@\xc3\xa9.example.com/\xc3\xa9?k=\xc3\xa9#\xc3\xa9";
+    ASSERT_EQ(0, uri.SetHttpURL(url)) << uri.status();
+    ASSERT_EQ("\xc3\xa9.example.com", uri.host());
+    ASSERT_EQ("/\xc3\xa9", uri.path());
+    ASSERT_EQ("k=\xc3\xa9", uri.query());
+    ASSERT_EQ("\xc3\xa9", uri.fragment());
+
+    std::string scheme;
+    std::string host_out;
+    int port_out = -1;
+    ASSERT_EQ(0, brpc::ParseURL(url.c_str(), &scheme, &host_out, &port_out));
+    ASSERT_EQ("http", scheme);
+    ASSERT_EQ("\xc3\xa9.example.com", host_out);
+}
+
 TEST(URITest, print_url) {
     brpc::URI uri;
 

--- a/test/flat_map_unittest.cpp
+++ b/test/flat_map_unittest.cpp
@@ -245,6 +245,16 @@ TEST_F(FlatMapTest, to_lower) {
         ASSERT_EQ((char)::tolower(c), butil::ascii_tolower(c)) << "c=" << c;
     }
 
+    // Real callers (header names, HPACK) reach ascii_tolower with a `char`.
+    // On unsigned-char platforms a byte >= 0x80 promotes to 128..255, which
+    // would index past the +128-biased 256-entry map. Exercise every byte
+    // value as a `char` and check the result against a safe reference; this
+    // trips a buffer-overflow read under ASan without the signed-char fold.
+    for (int i = 0; i < 256; ++i) {
+        const char ch = (char)i;
+        ASSERT_EQ((char)::tolower(i), butil::ascii_tolower(ch)) << "i=" << i;
+    }
+
     const size_t input_len = 102;
     char input[input_len + 1];
     char input2[input_len + 1];


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

Two +128-biased 256-entry lookup tables are read out of bounds when an input byte has the high bit set, on builds where `char` is unsigned (aarch64, riscv64).

1. `g_url_parsing_fast_action_map` (`uri.cpp`, used by `URI::SetHttpURL` and `ParseURL`) is indexed with `(int)*p`, where `*p` walks the untrusted request-URI. On an unsigned-`char` platform a byte in `0x80..0xFF` gives index `128..255`, so `raw[256..383]` is read, up to 127 bytes past the table.
2. `g_tolower_map` (`ascii_tolower` in `case_ignored_flat_map.h`) has the same +128 bias and is indexed by the promoted `char` argument. It is reached from `CaseIgnoredHasher` over HTTP header names and from HPACK, so the same high-bit byte over-reads the 256-entry table. The note already there records an aarch64 char-signedness crash; making the parameter `int` did not fix it, because a `char` argument still promotes to `0..255`.

On x86_64 (`char` signed) both indices fall in `[-128,127]` and stay in bounds, which is why the current CI does not surface it.

### What is changed and the side effects?

Changed:

Fold the index back into signed-char range at the three lookup sites with a `(signed char)` cast. The table layout is untouched and behavior on signed-`char` platforms is unchanged. Verified with an ASan build under `-funsigned-char`: a URL host byte `0xC3` and a header-name byte `>= 0x80` each trip a buffer-overflow before the change and run clean after, and `ascii_tolower` output matches the expected value for all 256 byte values.

Side effects:
- Performance effects: none (a single cast).

- Breaking backward compatibility: no.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
