### PR TITLE
avoid undefined shift in hpack DecodeInteger on crafted integer

### DIFF
--- a/src/brpc/details/hpack.cpp
+++ b/src/brpc/details/hpack.cpp
@@ -554,7 +554,8 @@ inline ssize_t DecodeInteger(butil::IOBufBytesIterator& iter,
         // once m reaches 64 the `<< m` shift is undefined behavior. Refuse the
         // over-long encoding before that happens.
         if (m >= 32) {
-            LOG(ERROR) << "Source stream is likely malformed";
+            LOG_EVERY_SECOND(ERROR) << "Over-long HPACK integer encoding, "
+                                       "continuation octets would overflow the shift";
             return -1;
         }
         cur_byte = *iter;

--- a/src/brpc/details/hpack.cpp
+++ b/src/brpc/details/hpack.cpp
@@ -547,6 +547,16 @@ inline ssize_t DecodeInteger(butil::IOBufBytesIterator& iter,
         if (!iter) {
             return 0;
         }
+        // A well-formed integer below MAX_HPACK_INTEGER fits in a few
+        // continuation octets. A run of 0x80 octets (continuation bit set,
+        // payload bits zero) leaves tmp unchanged, so the `tmp <
+        // MAX_HPACK_INTEGER` guard below never trips while m keeps growing;
+        // once m reaches 64 the `<< m` shift is undefined behavior. Refuse the
+        // over-long encoding before that happens.
+        if (m >= 32) {
+            LOG(ERROR) << "Source stream is likely malformed";
+            return -1;
+        }
         cur_byte = *iter;
         in_bytes++;
         tmp += static_cast<uint64_t>(cur_byte & 0x7f) << m;

--- a/test/brpc_hpack_unittest.cpp
+++ b/test/brpc_hpack_unittest.cpp
@@ -96,6 +96,27 @@ TEST_F(HPackTest, dynamic_table_size_update_before_header) {
     ASSERT_EQ("GET", h.value);
 }
 
+TEST_F(HPackTest, integer_with_overlong_continuation) {
+    brpc::HPacker p;
+    ASSERT_EQ(0, p.Init(4096));
+
+    // Indexed header field whose index is encoded with a 7-bit prefix of all
+    // ones (0xFF) followed by a long run of 0x80 continuation octets. Each
+    // 0x80 carries a zero payload, so the decoded value never grows past its
+    // MAX_HPACK_INTEGER guard, but the per-octet shift amount does. Decode must
+    // reject this as malformed instead of shifting by 64+ bits.
+    butil::IOBuf buf;
+    uint8_t encoded[1 + 20];
+    encoded[0] = 0xFF;
+    for (size_t i = 1; i < sizeof(encoded); ++i) {
+        encoded[i] = 0x80;
+    }
+    buf.append(encoded, sizeof(encoded));
+
+    brpc::HPacker::Header h;
+    ASSERT_LT(p.Decode(&buf, &h), 0);
+}
+
 // Copied test cases from example of rfc7541
 TEST_F(HPackTest, header_with_indexing) {
     brpc::HPacker p1;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
`DecodeInteger` keeps consuming HPACK continuation octets while `tmp < MAX_HPACK_INTEGER`. A run of `0x80` octets carries a zero payload, so `tmp` never grows and that guard never trips, while the shift amount `m` keeps climbing; once `m` reaches 64 the `<< m` on a `uint64_t` is undefined behavior. UBSan reports `shift exponent 70 is too large for 64-bit type`. It is reachable from any HTTP/2 or gRPC peer via a crafted HEADERS frame whose index is encoded as `0xFF` followed by continuation octets.

### What is changed and the side effects?

Changed:
Reject the over-long encoding once `m` reaches 32, before the shift can leave the type width. A valid integer below `MAX_HPACK_INTEGER` needs only a handful of continuation octets, so no well-formed input is turned away. A regression test in `brpc_hpack_unittest.cpp` decodes `0xFF` plus a long run of `0x80` and checks it is rejected.

Side effects:
- Performance effects: one extra comparison per continuation octet, no measurable change.

- Breaking backward compatibility: none.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
