### PR TITLE
Enforce body size limits in protocol parsers

### DIFF
--- a/src/brpc/details/http_message.cpp
+++ b/src/brpc/details/http_message.cpp
@@ -39,6 +39,7 @@ DEFINE_bool(http_verbose, false,
 DEFINE_int32(http_verbose_max_body_length, 512,
              "[DEBUG] Max body length printed when -http_verbose is on");
 DECLARE_int64(socket_max_unwritten_bytes);
+DECLARE_uint64(max_body_size);
 
 // Implement callbacks for http parser
 
@@ -254,6 +255,14 @@ int HttpMessage::on_message_complete_cb(http_parser *parser) {
 }
 
 int HttpMessage::OnBody(const char *at, const size_t length) {
+    if (!_read_body_progressively) {
+        if (length > FLAGS_max_body_size ||
+            _body_size > FLAGS_max_body_size - length) {
+            _body_too_large = true;
+            return -1;
+        }
+        _body_size += length;
+    }
     if (_vmsgbuilder) {
         if (_stage != HTTP_ON_BODY) {
             // only add prefix at first entry.

--- a/src/brpc/details/http_message.h
+++ b/src/brpc/details/http_message.h
@@ -71,6 +71,7 @@ public:
     HttpHeader& header() { return _header; }
     const HttpHeader& header() const { return _header; }
     size_t parsed_length() const { return _parsed_length; }
+    bool body_too_large() const { return _body_too_large; }
     
     // Http parser callback functions
     static int on_message_begin(http_parser *);
@@ -115,6 +116,8 @@ private:
     // Read body progressively
     ProgressiveReader* _body_reader{NULL};
     butil::IOBuf _body;
+    size_t _body_size{0};
+    bool _body_too_large{false};
 
     // Store the IOBuf information in `ParseFromIOBuf'
     // for later zero-copy usage in `OnBody'.

--- a/src/brpc/policy/couchbase_protocol.cpp
+++ b/src/brpc/policy/couchbase_protocol.cpp
@@ -39,6 +39,7 @@
 namespace brpc {
 
 DECLARE_bool(enable_rpcz);
+DECLARE_uint64(max_body_size);
 
 namespace policy {
 
@@ -96,6 +97,9 @@ ParseResult ParseCouchbaseMessage(butil::IOBuf* source, Socket* socket,
     }
     const CouchbaseResponseHeader* header = (const CouchbaseResponseHeader*)p;
     uint32_t total_body_length = butil::NetToHost32(header->total_body_length);
+    if (total_body_length > FLAGS_max_body_size) {
+      return MakeParseError(PARSE_ERROR_TOO_BIG_DATA);
+    }
     if (source->size() < sizeof(*header) + total_body_length) {
       return MakeParseError(PARSE_ERROR_NOT_ENOUGH_DATA);
     }

--- a/src/brpc/policy/http2_rpc_protocol.cpp
+++ b/src/brpc/policy/http2_rpc_protocol.cpp
@@ -739,6 +739,9 @@ H2ParseResult H2StreamContext::OnData(
     for (size_t i = 0; i < data.backing_block_num(); ++i) {
         const butil::StringPiece blk = data.backing_block(i);
         if (OnBody(blk.data(), blk.size()) != 0) {
+            if (body_too_large()) {
+                return MakeH2Error(H2_ENHANCE_YOUR_CALM, stream_id());
+            }
             LOG(ERROR) << "Fail to parse data";
             return MakeH2Error(H2_PROTOCOL_ERROR);
         }

--- a/src/brpc/policy/http_rpc_protocol.cpp
+++ b/src/brpc/policy/http_rpc_protocol.cpp
@@ -1217,6 +1217,25 @@ ParseResult ParseHttpMessage(butil::IOBuf *source, Socket *socket,
         // comments in http_message.h
         rc = http_imsg->ParseFromIOBuf(*source);
     }
+    if (rc < 0 && http_imsg->body_too_large()) {
+        if (socket->CreatedByConnect()) {
+            return MakeParseError(PARSE_ERROR_TOO_BIG_DATA);
+        }
+        const int release_rc = socket->ReleaseAdditionalReference();
+        if (release_rc == 0) {
+            butil::IOBuf resp;
+            HttpHeader header;
+            header.set_status_code(HTTP_STATUS_REQUEST_ENTITY_TOO_LARGE);
+            header.SetHeader("Connection", "close");
+            MakeRawHttpResponse(&resp, &header, NULL);
+            Socket::WriteOptions wopt;
+            wopt.ignore_eovercrowded = true;
+            socket->Write(&resp, &wopt);
+        } else if (release_rc > 0) {
+            LOG(ERROR) << "Impossible: Recycled!";
+        }
+        return MakeParseError(PARSE_ERROR_NOT_ENOUGH_DATA);
+    }
     if (http_imsg->is_stage2()) {
         // The header part is already parsed as an intact HTTP message
         // to the ProcessHttpXXX. Here parses the body part.

--- a/src/brpc/policy/memcache_binary_protocol.cpp
+++ b/src/brpc/policy/memcache_binary_protocol.cpp
@@ -40,6 +40,7 @@
 namespace brpc {
 
 DECLARE_bool(enable_rpcz);
+DECLARE_uint64(max_body_size);
 
 namespace policy {
 
@@ -90,6 +91,9 @@ ParseResult ParseMemcacheMessage(butil::IOBuf* source,
         }
         const MemcacheResponseHeader* header = (const MemcacheResponseHeader*)p;
         uint32_t total_body_length = butil::NetToHost32(header->total_body_length);
+        if (total_body_length > FLAGS_max_body_size) {
+            return MakeParseError(PARSE_ERROR_TOO_BIG_DATA);
+        }
         if (source->size() < sizeof(*header) + total_body_length) {
             return MakeParseError(PARSE_ERROR_NOT_ENOUGH_DATA);
         }

--- a/test/brpc_couchbase_unittest.cpp
+++ b/test/brpc_couchbase_unittest.cpp
@@ -16,11 +16,16 @@
 // under the License.
 
 #include <brpc/couchbase.h>
+#include <brpc/policy/couchbase_protocol.h>
+#include <brpc/socket.h>
+#include <butil/sys_byteorder.h>
+#include <butil/iobuf.h>
 #include <butil/logging.h>
 #include <gtest/gtest.h>
 
 namespace brpc {
 DECLARE_int32(idle_timeout_second);
+DECLARE_uint64(max_body_size);
 }
 
 int main(int argc, char* argv[]) {
@@ -33,6 +38,28 @@ namespace {
 
 // Unit Tests - No Server Required
 class CouchbaseUnitTest : public testing::Test {};
+
+TEST_F(CouchbaseUnitTest, RejectOversizedResponseBeforeBufferingBody) {
+  const uint64_t saved_max_body_size = brpc::FLAGS_max_body_size;
+  brpc::FLAGS_max_body_size = 1024;
+
+  brpc::SocketId id;
+  brpc::SocketOptions options;
+  ASSERT_EQ(0, brpc::Socket::Create(options, &id));
+  brpc::SocketUniquePtr socket;
+  ASSERT_EQ(0, brpc::Socket::Address(id, &socket));
+
+  brpc::policy::CouchbaseResponseHeader couchbase_header = {};
+  couchbase_header.magic = brpc::policy::CB_MAGIC_RESPONSE;
+  couchbase_header.total_body_length = butil::HostToNet32(1025);
+  butil::IOBuf couchbase_buf;
+  couchbase_buf.append(&couchbase_header, sizeof(couchbase_header));
+  EXPECT_EQ(brpc::PARSE_ERROR_TOO_BIG_DATA,
+            brpc::policy::ParseCouchbaseMessage(
+                &couchbase_buf, socket.get(), false, NULL).error());
+
+  brpc::FLAGS_max_body_size = saved_max_body_size;
+}
 
 TEST_F(CouchbaseUnitTest, RequestBuilders) {
   brpc::CouchbaseOperations::CouchbaseRequest req;

--- a/test/brpc_couchbase_unittest.cpp
+++ b/test/brpc_couchbase_unittest.cpp
@@ -21,6 +21,7 @@
 #include <butil/sys_byteorder.h>
 #include <butil/iobuf.h>
 #include <butil/logging.h>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 namespace brpc {
@@ -40,7 +41,7 @@ namespace {
 class CouchbaseUnitTest : public testing::Test {};
 
 TEST_F(CouchbaseUnitTest, RejectOversizedResponseBeforeBufferingBody) {
-  const uint64_t saved_max_body_size = brpc::FLAGS_max_body_size;
+  GFLAGS_NAMESPACE::FlagSaver flag_saver;
   brpc::FLAGS_max_body_size = 1024;
 
   brpc::SocketId id;
@@ -58,7 +59,6 @@ TEST_F(CouchbaseUnitTest, RejectOversizedResponseBeforeBufferingBody) {
             brpc::policy::ParseCouchbaseMessage(
                 &couchbase_buf, socket.get(), false, NULL).error());
 
-  brpc::FLAGS_max_body_size = saved_max_body_size;
 }
 
 TEST_F(CouchbaseUnitTest, RequestBuilders) {

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -60,6 +60,7 @@ DECLARE_string(rpc_dump_dir);
 DECLARE_int32(rpc_dump_max_requests_in_one_file);
 DECLARE_bool(allow_chunked_length);
 DECLARE_int32(max_connection_pool_size);
+DECLARE_uint64(max_body_size);
 extern bvar::CollectorSpeedLimit g_rpc_dump_sl;
 }
 
@@ -78,6 +79,18 @@ int main(int argc, char* argv[]) {
 }
 
 namespace {
+
+class MaxBodySizeGuard {
+public:
+    explicit MaxBodySizeGuard(uint64_t value)
+        : _saved(brpc::FLAGS_max_body_size) {
+        brpc::FLAGS_max_body_size = value;
+    }
+    ~MaxBodySizeGuard() { brpc::FLAGS_max_body_size = _saved; }
+
+private:
+    uint64_t _saved;
+};
 
 static const std::string EXP_REQUEST = "hello";
 static const std::string EXP_RESPONSE = "world";
@@ -343,6 +356,41 @@ protected:
     MyEchoService _svc;
     MyAuthenticator _auth;
 };
+
+TEST_F(HttpTest, reject_oversized_http_body) {
+    MaxBodySizeGuard guard(4);
+    butil::IOBuf buf;
+    buf.append("POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello");
+
+    brpc::ParseResult result =
+        brpc::policy::ParseHttpMessage(&buf, _socket.get(), false, NULL);
+    EXPECT_EQ(brpc::PARSE_ERROR_NOT_ENOUGH_DATA, result.error());
+    int bytes_in_pipe = 0;
+    ASSERT_EQ(0, ioctl(_pipe_fds[0], FIONREAD, &bytes_in_pipe));
+    ASSERT_GT(bytes_in_pipe, 0);
+    butil::IOPortal response;
+    ASSERT_EQ(bytes_in_pipe,
+              response.append_from_file_descriptor(_pipe_fds[0], bytes_in_pipe));
+    EXPECT_NE(std::string::npos, response.to_string().find(" 413 "));
+}
+
+TEST_F(HttpTest, reject_oversized_chunked_http_body) {
+    MaxBodySizeGuard guard(4);
+    butil::IOBuf buf;
+    buf.append("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
+               "3\r\nabc\r\n2\r\nde\r\n0\r\n\r\n");
+
+    brpc::ParseResult result =
+        brpc::policy::ParseHttpMessage(&buf, _socket.get(), false, NULL);
+    EXPECT_EQ(brpc::PARSE_ERROR_NOT_ENOUGH_DATA, result.error());
+    int bytes_in_pipe = 0;
+    ASSERT_EQ(0, ioctl(_pipe_fds[0], FIONREAD, &bytes_in_pipe));
+    ASSERT_GT(bytes_in_pipe, 0);
+    butil::IOPortal response;
+    ASSERT_EQ(bytes_in_pipe,
+              response.append_from_file_descriptor(_pipe_fds[0], bytes_in_pipe));
+    EXPECT_NE(std::string::npos, response.to_string().find(" 413 "));
+}
 
 int AllocateFreePortOrDie() {
     butil::fd_guard fd(tcp_listen(butil::EndPoint(butil::my_ip(), 0)));

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -80,18 +80,6 @@ int main(int argc, char* argv[]) {
 
 namespace {
 
-class MaxBodySizeGuard {
-public:
-    explicit MaxBodySizeGuard(uint64_t value)
-        : _saved(brpc::FLAGS_max_body_size) {
-        brpc::FLAGS_max_body_size = value;
-    }
-    ~MaxBodySizeGuard() { brpc::FLAGS_max_body_size = _saved; }
-
-private:
-    uint64_t _saved;
-};
-
 static const std::string EXP_REQUEST = "hello";
 static const std::string EXP_RESPONSE = "world";
 static const std::string EXP_RESPONSE_CONTENT_LENGTH = "1024";
@@ -358,7 +346,8 @@ protected:
 };
 
 TEST_F(HttpTest, reject_oversized_http_body) {
-    MaxBodySizeGuard guard(4);
+    GFLAGS_NAMESPACE::FlagSaver flag_saver;
+    brpc::FLAGS_max_body_size = 4;
     butil::IOBuf buf;
     buf.append("POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello");
 
@@ -375,7 +364,8 @@ TEST_F(HttpTest, reject_oversized_http_body) {
 }
 
 TEST_F(HttpTest, reject_oversized_chunked_http_body) {
-    MaxBodySizeGuard guard(4);
+    GFLAGS_NAMESPACE::FlagSaver flag_saver;
+    brpc::FLAGS_max_body_size = 4;
     butil::IOBuf buf;
     buf.append("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
                "3\r\nabc\r\n2\r\nde\r\n0\r\n\r\n");

--- a/test/brpc_memcache_unittest.cpp
+++ b/test/brpc_memcache_unittest.cpp
@@ -25,6 +25,7 @@
 #include <brpc/socket.h>
 #include <butil/iobuf.h>
 #include <butil/sys_byteorder.h>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 namespace brpc {
@@ -41,7 +42,7 @@ int main(int argc, char* argv[]) {
 namespace {
 
 TEST(MemcacheParserTest, RejectOversizedResponseBeforeBufferingBody) {
-    const uint64_t saved_max_body_size = brpc::FLAGS_max_body_size;
+    GFLAGS_NAMESPACE::FlagSaver flag_saver;
     brpc::FLAGS_max_body_size = 1024;
 
     brpc::SocketId id;
@@ -59,7 +60,6 @@ TEST(MemcacheParserTest, RejectOversizedResponseBeforeBufferingBody) {
               brpc::policy::ParseMemcacheMessage(
                   &buf, socket.get(), false, NULL).error());
 
-    brpc::FLAGS_max_body_size = saved_max_body_size;
 }
 
 static pthread_once_t download_memcached_once = PTHREAD_ONCE_INIT;

--- a/test/brpc_memcache_unittest.cpp
+++ b/test/brpc_memcache_unittest.cpp
@@ -20,10 +20,16 @@
 #include "butil/logging.h"
 #include <brpc/memcache.h>
 #include <brpc/channel.h>
+#include <brpc/policy/memcache_binary_header.h>
+#include <brpc/policy/memcache_binary_protocol.h>
+#include <brpc/socket.h>
+#include <butil/iobuf.h>
+#include <butil/sys_byteorder.h>
 #include <gtest/gtest.h>
 
 namespace brpc {
 DECLARE_int32(idle_timeout_second);
+DECLARE_uint64(max_body_size);
 } 
 
 int main(int argc, char* argv[]) {
@@ -33,6 +39,29 @@ int main(int argc, char* argv[]) {
 }
 
 namespace {
+
+TEST(MemcacheParserTest, RejectOversizedResponseBeforeBufferingBody) {
+    const uint64_t saved_max_body_size = brpc::FLAGS_max_body_size;
+    brpc::FLAGS_max_body_size = 1024;
+
+    brpc::SocketId id;
+    brpc::SocketOptions options;
+    ASSERT_EQ(0, brpc::Socket::Create(options, &id));
+    brpc::SocketUniquePtr socket;
+    ASSERT_EQ(0, brpc::Socket::Address(id, &socket));
+
+    brpc::policy::MemcacheResponseHeader header = {};
+    header.magic = brpc::policy::MC_MAGIC_RESPONSE;
+    header.total_body_length = butil::HostToNet32(1025);
+    butil::IOBuf buf;
+    buf.append(&header, sizeof(header));
+    EXPECT_EQ(brpc::PARSE_ERROR_TOO_BIG_DATA,
+              brpc::policy::ParseMemcacheMessage(
+                  &buf, socket.get(), false, NULL).error());
+
+    brpc::FLAGS_max_body_size = saved_max_body_size;
+}
+
 static pthread_once_t download_memcached_once = PTHREAD_ONCE_INIT;
 static pid_t g_mc_pid = -1;
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: null

Problem Summary:

Some HTTP, memcache, and couchbase parsing paths did not consistently enforce
the global `max_body_size` setting. Non-progressive HTTP messages could buffer
more data than configured, while memcache and couchbase parsers could wait for
an oversized body declared in a response header.

### What is changed and the side effects?

Changed:

- Track the accumulated body size of non-progressive HTTP messages and reject
  data before appending beyond `max_body_size`.
- Return HTTP 413 for oversized HTTP/1 requests and close the connection after
  writing the response.
- Reset only the oversized HTTP/2 stream with `ENHANCE_YOUR_CALM`.
- Reject oversized memcache and couchbase responses immediately after parsing
  their fixed-size headers.
- Add regression tests for fixed-length HTTP, chunked HTTP, memcache, and
  couchbase messages.

Side effects:

- Performance effects: Each non-progressive HTTP body block adds one
  overflow-safe size comparison and addition. Memcache and couchbase add one
  comparison per response. No additional scan, allocation, or copy is added.
- Breaking backward compatibility: Messages larger than `max_body_size` are
  now rejected as documented. Progressive HTTP reading remains unchanged so
  existing bounded-memory streaming transfers can exceed this setting.

### Check List:

- [x] The changes are compilable.
- [x] Regression tests are included.
- [x] The affected test suites pass.