### PR TITLE
fix(build): clean up redundant warning sources

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,7 +86,7 @@ if(BUILD_SHARED_LIBS)
     endif()
     SET_TARGET_PROPERTIES(brpc-shared PROPERTIES OUTPUT_NAME brpc CLEAN_DIRECT_OUTPUT 1)
 
-    target_link_libraries(protoc-gen-mcpack PRIVATE brpc-shared ${DYNAMIC_LIB} pthread)
+    target_link_libraries(protoc-gen-mcpack PRIVATE brpc-shared ${DYNAMIC_LIB})
 
     install(TARGETS brpc-shared
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -94,7 +94,7 @@ if(BUILD_SHARED_LIBS)
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             )
 else()
-    target_link_libraries(protoc-gen-mcpack PRIVATE brpc-static ${DYNAMIC_LIB} pthread)
+    target_link_libraries(protoc-gen-mcpack PRIVATE brpc-static ${DYNAMIC_LIB})
 endif()
 
 

--- a/src/brpc/builtin/rpcz_service.cpp
+++ b/src/brpc/builtin/rpcz_service.cpp
@@ -188,21 +188,6 @@ static void PrintAnnotations(
     SpanInfoExtractor** extractors, int num_extr, const RpczSpan* span) {
     int64_t anno_time;
     std::string a;
-    const char* span_type_str = "Span";
-    if (span) {
-        switch (span->type()) {
-        case SPAN_TYPE_SERVER:
-            span_type_str = "ServerSpan";
-            break;
-        case SPAN_TYPE_CLIENT:
-            span_type_str = "ClientSpan";
-            break;
-        case SPAN_TYPE_BTHREAD:
-            span_type_str = "BthreadSpan";
-            break;
-        }
-    }
-
     // TODO: Going through all extractors is not strictly correct because 
     // later extractors may have earlier annotations.
     for (int i = 0; i < num_extr; ++i) {

--- a/src/brpc/couchbase.cpp
+++ b/src/brpc/couchbase.cpp
@@ -46,7 +46,7 @@ namespace brpc {
 // Couchbase protocol constants
 namespace {
 [[maybe_unused]] constexpr uint32_t APPLE_VBUCKET_COUNT = 64;
-constexpr uint32_t DEFAULT_VBUCKET_COUNT = 1024;
+[[maybe_unused]] constexpr uint32_t DEFAULT_VBUCKET_COUNT = 1024;
 constexpr int CONNECTION_ID_SIZE = 33;
 constexpr size_t RANDOM_ID_HEX_SIZE = 67;  // 33 bytes * 2 + null terminator
 }  // namespace

--- a/src/brpc/couchbase.cpp
+++ b/src/brpc/couchbase.cpp
@@ -45,8 +45,8 @@ namespace brpc {
 
 // Couchbase protocol constants
 namespace {
-[[maybe_unused]] constexpr uint32_t APPLE_VBUCKET_COUNT = 64;
-[[maybe_unused]] constexpr uint32_t DEFAULT_VBUCKET_COUNT = 1024;
+constexpr uint32_t APPLE_VBUCKET_COUNT ALLOW_UNUSED = 64;
+constexpr uint32_t DEFAULT_VBUCKET_COUNT ALLOW_UNUSED = 1024;
 constexpr int CONNECTION_ID_SIZE = 33;
 constexpr size_t RANDOM_ID_HEX_SIZE = 67;  // 33 bytes * 2 + null terminator
 }  // namespace

--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -167,8 +167,6 @@ inline iov_function get_pwritev_func() {
 
 #else   // ARCH_CPU_X86_64
 
-#warning "We don't check if the kernel supports SYS_preadv or SYS_pwritev on non-X86_64, use implementation on pread/pwrite directly."
-
 inline iov_function get_preadv_func() {
     return user_preadv;
 }


### PR DESCRIPTION
• Remove redundant pthread linkage from protoc-gen-mcpack targets and quiet compiler warnings from unused rpcz/couchbase code paths and non-x86 iobuf builds.

  ### What problem does this PR solve?

  Issue Number: resolve

  Problem Summary:
  This PR cleans up redundant build configuration and compiler warning sources. `protoc-gen-mcpack` already links through the configured dynamic/static brpc target and
  dynamic libraries, so the explicit `pthread` linkage is unnecessary. A few warning-only code paths also produced noise from unused rpcz/couchbase symbols and the non-
  x86 iobuf fallback warning.

  ### What is changed and the side effects?

  Changed:
  - Removed explicit `pthread` linkage from `protoc-gen-mcpack` CMake targets.
  - Removed an unused `span_type_str` block from rpcz annotation printing.
  - Marked `DEFAULT_VBUCKET_COUNT` as `[[maybe_unused]]`.
  - Removed the non-x86_64 `#warning` from iobuf fallback code.
  - Ensured `src/brpc/couchbase.cpp` ends with a newline.

  Side effects:
  - Performance effects: None expected.
  - Breaking backward compatibility: None expected.

  ---
  ### Check List:
  - Please make sure your changes are compilable.
  - When providing us with a new feature, it is best to add related tests.
  - Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).