### PR TITLE
fix SetHostSocket when add stream failed

### DIFF
--- a/src/brpc/stream.cpp
+++ b/src/brpc/stream.cpp
@@ -672,7 +672,7 @@ int Stream::SetHostSocket(Socket *host_socket) {
         }
         _host_socket = ptr.release();
     });
-    return 0;
+    return _host_socket != NULL ? 0 : -1;
 }
 
 void Stream::FillSettings(StreamSettings *settings) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: introduced by PR https://github.com/apache/brpc/pull/2938 .

Problem Summary:

Stream::SetHostSocket performs host-socket binding inside std::call_once, which makes the first execution result effectively global for all later callers. If AddStream(id()) fails during that first attempt, the lambda returns without setting _host_socket, but the once_flag is still consumed. After that, subsequent callers cannot retry the binding logic and may only observe the post-state through the function return value. This creates a broken state where the stream is not actually attached to any host socket, while later code paths still assume the binding has succeeded, eventually triggering _host_socket == NULL checks or null-dereference style crashes.

Changed:

return _host_socket != NULL ? 0 : -1;

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
