### PR TITLE
build(example): extract shared CMake dependency helper for examples

### DIFF
--- a/example/asynchronous_echo_c++/CMakeLists.txt
+++ b/example/asynchronous_echo_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(asynchronous_echo_client client.cpp ${PROTO_SRC})
 brpc_example_configure_target(asynchronous_echo_client)

--- a/example/auto_concurrency_limiter/CMakeLists.txt
+++ b/example/auto_concurrency_limiter/CMakeLists.txt
@@ -22,78 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${CMAKE_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER cl_test.proto)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_RegisterThriftProtocol"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(asynchronous_echo_client client.cpp ${PROTO_SRC})
 brpc_example_configure_target(asynchronous_echo_client)

--- a/example/backup_request_c++/CMakeLists.txt
+++ b/example/backup_request_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(backup_request_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(backup_request_client)

--- a/example/baidu_proxy_and_generic_call/CMakeLists.txt
+++ b/example/baidu_proxy_and_generic_call/CMakeLists.txt
@@ -22,76 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(echo_client)

--- a/example/bthread_tag_echo_c++/CMakeLists.txt
+++ b/example/bthread_tag_echo_c++/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(echo_client)

--- a/example/cancel_c++/CMakeLists.txt
+++ b/example/cancel_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(cancel_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(cancel_client)

--- a/example/cascade_echo_c++/CMakeLists.txt
+++ b/example/cascade_echo_c++/CMakeLists.txt
@@ -22,83 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(cascade_echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(cascade_echo_client)

--- a/example/cmake/BrpcExample.cmake
+++ b/example/cmake/BrpcExample.cmake
@@ -27,6 +27,88 @@ function(brpc_example_append_existing_dirs out_var)
     set(${out_var} ${_dirs} PARENT_SCOPE)
 endfunction()
 
+macro(brpc_example_find_common_deps out_libs)
+    execute_process(
+        COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
+        OUTPUT_VARIABLE OUTPUT_PATH
+    )
+
+    if(OUTPUT_PATH)
+        list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
+    endif()
+
+    find_package(Threads REQUIRED)
+    find_package(Protobuf REQUIRED)
+
+    # Search for libthrift* by best effort. If it is not found and brpc is
+    # compiled with thrift protocol enabled, a link error would be reported.
+    find_library(THRIFT_LIB NAMES thrift)
+    if(NOT THRIFT_LIB)
+        set(THRIFT_LIB "")
+    endif()
+
+    find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
+    if(LINK_SO)
+        find_library(BRPC_LIB NAMES brpc)
+    else()
+        find_library(BRPC_LIB NAMES libbrpc.a brpc)
+    endif()
+    if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
+        message(FATAL_ERROR "Fail to find brpc")
+    endif()
+
+    find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
+    find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
+    if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
+        message(FATAL_ERROR "Fail to find gflags")
+    endif()
+
+    find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
+    find_library(LEVELDB_LIB NAMES leveldb)
+    if((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
+        message(FATAL_ERROR "Fail to find leveldb")
+    endif()
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
+        set(OPENSSL_ROOT_DIR
+            "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
+        )
+    endif()
+
+    find_package(OpenSSL REQUIRED)
+
+    set(_common_libs
+        Threads::Threads
+        ${GFLAGS_LIBRARY}
+        ${PROTOBUF_LIBRARIES}
+        ${LEVELDB_LIB}
+        ${OPENSSL_CRYPTO_LIBRARY}
+        ${OPENSSL_SSL_LIBRARY}
+        ${THRIFT_LIB}
+        dl
+    )
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        set(_common_libs ${_common_libs}
+            pthread
+            "-framework CoreFoundation"
+            "-framework CoreGraphics"
+            "-framework CoreData"
+            "-framework CoreText"
+            "-framework Security"
+            "-framework Foundation"
+            "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
+            "-Wl,-U,_ProfilerStart"
+            "-Wl,-U,_ProfilerStop"
+            "-Wl,-U,__Z13GetStackTracePPvii"
+            "-Wl,-U,_mallctl"
+            "-Wl,-U,_malloc_stats_print"
+        )
+    endif()
+
+    set(${out_libs} ${_common_libs})
+endmacro()
+
 function(brpc_example_configure_target target_name)
     brpc_example_append_existing_dirs(_include_dirs
         ${CMAKE_CURRENT_BINARY_DIR}

--- a/example/dynamic_partition_echo_c++/CMakeLists.txt
+++ b/example/dynamic_partition_echo_c++/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(dynamic_partition_echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(dynamic_partition_echo_client)

--- a/example/echo_c++/CMakeLists.txt
+++ b/example/echo_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(echo_client)

--- a/example/grpc_c++/CMakeLists.txt
+++ b/example/grpc_c++/CMakeLists.txt
@@ -22,83 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER helloworld.proto)
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_RegisterThriftProtocol"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(server server.cpp ${PROTO_SRC} ${PROTO_HEADER} )
 brpc_example_configure_target(server)

--- a/example/http_c++/CMakeLists.txt
+++ b/example/http_c++/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER http.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(http_client http_client.cpp)
 brpc_example_configure_target(http_client)

--- a/example/memcache_c++/CMakeLists.txt
+++ b/example/memcache_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(memcache_client client.cpp)
 brpc_example_configure_target(memcache_client)

--- a/example/multi_threaded_echo_c++/CMakeLists.txt
+++ b/example/multi_threaded_echo_c++/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(echo_client)

--- a/example/multi_threaded_echo_fns_c++/CMakeLists.txt
+++ b/example/multi_threaded_echo_fns_c++/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(multi_threaded_echo_fns_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(multi_threaded_echo_fns_client)

--- a/example/mysql_c++/CMakeLists.txt
+++ b/example/mysql_c++/CMakeLists.txt
@@ -1,148 +1,41 @@
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.16...3.28)
 project(mysql_c++ C CXX)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 # Install dependencies:
 # With apt:
-# sudo apt-get install libreadline-dev 
+# sudo apt-get install libreadline-dev
 # sudo apt-get install ncurses-dev
 # With yum:
 # sudo yum install readline-devel
 # sudo yum install ncurses-devel
 
-option(EXAMPLE_LINK_SO "Whether examples are linked dynamically" OFF)
+option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-set(CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-
-include(FindThreads)
-include(FindProtobuf)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
 find_library(THRIFTNB_LIB NAMES thriftnb)
-if (NOT THRIFTNB_LIB)
+if(NOT THRIFTNB_LIB)
     set(THRIFTNB_LIB "")
 endif()
 
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(EXAMPLE_LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-include_directories(${BRPC_INCLUDE_PATH})
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-include_directories(${GFLAGS_INCLUDE_PATH})
-
-execute_process(
-    COMMAND bash -c "grep \"namespace [_A-Za-z0-9]\\+ {\" ${GFLAGS_INCLUDE_PATH}/gflags/gflags_declare.h | head -1 | awk '{print $2}' | tr -d '\n'"
-    OUTPUT_VARIABLE GFLAGS_NS
-)
-if(${GFLAGS_NS} STREQUAL "GFLAGS_NAMESPACE")
-    execute_process(
-        COMMAND bash -c "grep \"#define GFLAGS_NAMESPACE [_A-Za-z0-9]\\+\" ${GFLAGS_INCLUDE_PATH}/gflags/gflags_declare.h | head -1 | awk '{print $3}' | tr -d '\n'"
-        OUTPUT_VARIABLE GFLAGS_NS
-    )
-endif()
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    include(CheckFunctionExists)
-    CHECK_FUNCTION_EXISTS(clock_gettime HAVE_CLOCK_GETTIME)
-    if(NOT HAVE_CLOCK_GETTIME)
-        set(DEFINE_CLOCK_GETTIME "-DNO_CLOCK_GETTIME_IN_MAC")
-    endif()
-endif()
-
-set(CMAKE_CPP_FLAGS "${DEFINE_CLOCK_GETTIME} -DGFLAGS_NS=${GFLAGS_NS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CPP_FLAGS} -DNDEBUG -O2 -D__const__= -pipe -W -Wall -Wno-unused-parameter -fPIC -fno-omit-frame-pointer")
-
-if(CMAKE_VERSION VERSION_LESS "3.1.3")
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif()
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif()
-else()
-    set(CMAKE_CXX_STANDARD 11)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-include_directories(${LEVELDB_INCLUDE_PATH})
-
-find_library(SSL_LIB NAMES ssl)
-if (NOT SSL_LIB)
-    message(FATAL_ERROR "Fail to find ssl")
-endif()
-
-find_library(CRYPTO_LIB NAMES crypto)
-if (NOT CRYPTO_LIB)
-    message(FATAL_ERROR "Fail to find crypto")
-endif()
-
-# find_path(MYSQL_INCLUDE_PATH NAMES mysql/mysql.h)
-# find_library(MYSQL_LIB NAMES mysqlclient)
-# if (NOT MYSQL_LIB)
-#     message(FATAL_ERROR "Fail to find mysqlclient")
-# endif()
-# include_directories(${MYSQL_INCLUDE_PATH})
-
-set(DYNAMIC_LIB
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${SSL_LIB}
-    ${CRYPTO_LIB}
-    ${THRIFT_LIB}
-    ${THRIFTNB_LIB}
-#    ${MYSQL_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop")
-endif()
-
-add_executable(mysql_cli mysql_cli.cpp)
-add_executable(mysql_tx mysql_tx.cpp)
-add_executable(mysql_stmt mysql_stmt.cpp)
-add_executable(mysql_press mysql_press.cpp)
-# add_executable(mysqlclient_press mysqlclient_press.cpp)
+list(APPEND DYNAMIC_LIB ${THRIFTNB_LIB})
 
 set(AUX_LIB readline ncurses)
-target_link_libraries(mysql_cli ${BRPC_LIB} ${DYNAMIC_LIB} ${AUX_LIB})
-target_link_libraries(mysql_tx ${BRPC_LIB} ${DYNAMIC_LIB})
-target_link_libraries(mysql_stmt ${BRPC_LIB} ${DYNAMIC_LIB})
-target_link_libraries(mysql_press ${BRPC_LIB} ${DYNAMIC_LIB})
-# target_link_libraries(mysqlclient_press ${BRPC_LIB} ${DYNAMIC_LIB})
+
+add_executable(mysql_cli mysql_cli.cpp)
+brpc_example_configure_target(mysql_cli)
+add_executable(mysql_tx mysql_tx.cpp)
+brpc_example_configure_target(mysql_tx)
+add_executable(mysql_stmt mysql_stmt.cpp)
+brpc_example_configure_target(mysql_stmt)
+add_executable(mysql_press mysql_press.cpp)
+brpc_example_configure_target(mysql_press)
+# add_executable(mysqlclient_press mysqlclient_press.cpp)
+
+target_link_libraries(mysql_cli PRIVATE ${BRPC_LIB} ${DYNAMIC_LIB} ${AUX_LIB})
+target_link_libraries(mysql_tx PRIVATE ${BRPC_LIB} ${DYNAMIC_LIB})
+target_link_libraries(mysql_stmt PRIVATE ${BRPC_LIB} ${DYNAMIC_LIB})
+target_link_libraries(mysql_press PRIVATE ${BRPC_LIB} ${DYNAMIC_LIB})
+# target_link_libraries(mysqlclient_press PRIVATE ${BRPC_LIB} ${DYNAMIC_LIB})

--- a/example/mysql_c++/mysql_cli.cpp
+++ b/example/mysql_c++/mysql_cli.cpp
@@ -87,7 +87,7 @@ static int cli_getc(FILE* stream) {
 
 int main(int argc, char* argv[]) {
     // Parse gflags. We recommend you to use gflags as well.
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
     // A Channel represents a communication line to a Server. Notice that
     // Channel is thread-safe and can be shared by all threads in your program.

--- a/example/mysql_c++/mysql_press.cpp
+++ b/example/mysql_c++/mysql_press.cpp
@@ -114,7 +114,7 @@ static void* sender(void* void_args) {
 
 int main(int argc, char* argv[]) {
     // Parse gflags. We recommend you to use gflags as well.
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
     // A Channel represents a communication line to a Server. Notice that
     // Channel is thread-safe and can be shared by all threads in your program.

--- a/example/mysql_c++/mysql_stmt.cpp
+++ b/example/mysql_c++/mysql_stmt.cpp
@@ -145,7 +145,7 @@ static void* access_mysql(void* void_args) {
 
 int main(int argc, char* argv[]) {
     // Parse gflags. We recommend you to use gflags as well.
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
     // A Channel represents a communication line to a Server. Notice that
     // Channel is thread-safe and can be shared by all threads in your program.

--- a/example/mysql_c++/mysql_tx.cpp
+++ b/example/mysql_c++/mysql_tx.cpp
@@ -83,7 +83,7 @@ static bool access_mysql(brpc::Channel& channel, const std::vector<std::string>&
 
 int main(int argc, char* argv[]) {
     // Parse gflags. We recommend you to use gflags as well.
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
     // A Channel represents a communication line to a Server. Notice that
     // Channel is thread-safe and can be shared by all threads in your program.

--- a/example/mysql_c++/mysqlclient_press.cpp
+++ b/example/mysql_c++/mysqlclient_press.cpp
@@ -120,7 +120,7 @@ static void* sender(void* void_args) {
 
 int main(int argc, char* argv[]) {
     // Parse gflags. We recommend you to use gflags as well.
-    GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
 
     if (FLAGS_dummy_port >= 0) {
         brpc::StartDummyServerAt(FLAGS_dummy_port);

--- a/example/nshead_extension_c++/CMakeLists.txt
+++ b/example/nshead_extension_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(nshead_extension_client client.cpp)
 brpc_example_configure_target(nshead_extension_client)

--- a/example/nshead_pb_extension_c++/CMakeLists.txt
+++ b/example/nshead_pb_extension_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(nshead_pb_extension_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(nshead_pb_extension_client)

--- a/example/parallel_echo_c++/CMakeLists.txt
+++ b/example/parallel_echo_c++/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(parallel_echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(parallel_echo_client)

--- a/example/partition_echo_c++/CMakeLists.txt
+++ b/example/partition_echo_c++/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(client)

--- a/example/rdma_performance/CMakeLists.txt
+++ b/example/rdma_performance/CMakeLists.txt
@@ -22,92 +22,16 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER test.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_WITH_RDMA ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
 find_path(RDMA_INCLUDE_PATH NAMES infiniband/verbs.h)
 find_library(RDMA_LIB NAMES ibverbs)
 if ((NOT RDMA_INCLUDE_PATH) OR (NOT RDMA_LIB))
     message(FATAL_ERROR "Fail to find ibverbs")
 endif()
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
+list(APPEND DYNAMIC_LIB ${RDMA_LIB})
 
 add_executable(client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(client)

--- a/example/redis_c++/CMakeLists.txt
+++ b/example/redis_c++/CMakeLists.txt
@@ -30,87 +30,11 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
-
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    ${GPERFTOOLS_LIBRARIES}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
+list(APPEND DYNAMIC_LIB ${GPERFTOOLS_LIBRARIES})
 
 add_executable(redis_cli redis_cli.cpp)
 brpc_example_configure_target(redis_cli)

--- a/example/rpcz_echo_c++/CMakeLists.txt
+++ b/example/rpcz_echo_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(rpcz_echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(rpcz_echo_client)

--- a/example/selective_echo_c++/CMakeLists.txt
+++ b/example/selective_echo_c++/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(selective_echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(selective_echo_client)

--- a/example/session_data_and_thread_local/CMakeLists.txt
+++ b/example/session_data_and_thread_local/CMakeLists.txt
@@ -22,89 +22,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
 find_path(GPERFTOOLS_INCLUDE_DIR NAMES gperftools/heap-profiler.h)
 find_library(GPERFTOOLS_LIBRARIES NAMES tcmalloc_and_profiler)
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
 set(BRPC_EXAMPLE_ENABLE_CPU_PROFILER ON)
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(session_data_and_thread_local_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(session_data_and_thread_local_client)

--- a/example/streaming_batch_echo_c++/CMakeLists.txt
+++ b/example/streaming_batch_echo_c++/CMakeLists.txt
@@ -22,81 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-        COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-        OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-        Threads::Threads
-        ${GFLAGS_LIBRARY}
-        ${PROTOBUF_LIBRARIES}
-        ${LEVELDB_LIB}
-        ${OPENSSL_CRYPTO_LIBRARY}
-        ${OPENSSL_SSL_LIBRARY}
-        ${THRIFT_LIB}
-        dl
-)
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-            pthread
-            "-framework CoreFoundation"
-            "-framework CoreGraphics"
-            "-framework CoreData"
-            "-framework CoreText"
-            "-framework Security"
-            "-framework Foundation"
-            "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-            "-Wl,-U,_ProfilerStart"
-            "-Wl,-U,_ProfilerStop"
-            "-Wl,-U,__Z13GetStackTracePPvii")
-endif()
 
 add_executable(streaming_batch_echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(streaming_batch_echo_client)

--- a/example/streaming_echo_c++/CMakeLists.txt
+++ b/example/streaming_echo_c++/CMakeLists.txt
@@ -22,84 +22,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cmake/BrpcExample.cmake)
 
 option(LINK_SO "Whether examples are linked dynamically" OFF)
 
-execute_process(
-    COMMAND bash -c "find ${PROJECT_SOURCE_DIR}/../.. -type d -regex \".*output/include$\" | head -n1 | xargs dirname | tr -d '\n'"
-    OUTPUT_VARIABLE OUTPUT_PATH
-)
+brpc_example_find_common_deps(DYNAMIC_LIB)
 
-if(OUTPUT_PATH)
-    list(PREPEND CMAKE_PREFIX_PATH ${OUTPUT_PATH})
-endif()
-
-find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER echo.proto)
-
-# Search for libthrift* by best effort. If it is not found and brpc is
-# compiled with thrift protocol enabled, a link error would be reported.
-find_library(THRIFT_LIB NAMES thrift)
-if (NOT THRIFT_LIB)
-    set(THRIFT_LIB "")
-endif()
-
-find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-if(LINK_SO)
-    find_library(BRPC_LIB NAMES brpc)
-else()
-    find_library(BRPC_LIB NAMES libbrpc.a brpc)
-endif()
-if((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
-    message(FATAL_ERROR "Fail to find brpc")
-endif()
-
-find_path(GFLAGS_INCLUDE_PATH gflags/gflags.h)
-find_library(GFLAGS_LIBRARY NAMES gflags libgflags)
-if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
-    message(FATAL_ERROR "Fail to find gflags")
-endif()
-
-find_path(LEVELDB_INCLUDE_PATH NAMES leveldb/db.h)
-find_library(LEVELDB_LIB NAMES leveldb)
-if ((NOT LEVELDB_INCLUDE_PATH) OR (NOT LEVELDB_LIB))
-    message(FATAL_ERROR "Fail to find leveldb")
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT OPENSSL_ROOT_DIR)
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
-endif()
-
-find_package(OpenSSL REQUIRED)
-
-set(DYNAMIC_LIB
-    Threads::Threads
-    ${GFLAGS_LIBRARY}
-    ${PROTOBUF_LIBRARIES}
-    ${LEVELDB_LIB}
-    ${OPENSSL_CRYPTO_LIBRARY}
-    ${OPENSSL_SSL_LIBRARY}
-    ${THRIFT_LIB}
-    dl
-    )
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(DYNAMIC_LIB ${DYNAMIC_LIB}
-        pthread
-        "-framework CoreFoundation"
-        "-framework CoreGraphics"
-        "-framework CoreData"
-        "-framework CoreText"
-        "-framework Security"
-        "-framework Foundation"
-        "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
-        "-Wl,-U,_ProfilerStart"
-        "-Wl,-U,_ProfilerStop"
-        "-Wl,-U,__Z13GetStackTracePPvii"
-        "-Wl,-U,_mallctl"
-        "-Wl,-U,_malloc_stats_print"
-    )
-endif()
 
 add_executable(streaming_echo_client client.cpp ${PROTO_SRC} ${PROTO_HEADER})
 brpc_example_configure_target(streaming_echo_client)


### PR DESCRIPTION
### What problem does this PR solve?

  Problem Summary:

  Example `CMakeLists.txt` files duplicate the same dependency discovery and link setup (brpc, protobuf, gflags, leveldb, openssl, thrift, Darwin flags). That makes
  MySQL and other examples hard to maintain and easy to drift.

  ### What is changed and the side effects?
  Changed:
  - Add `brpc_example_find_common_deps` in `example/cmake/BrpcExample.cmake` to centralize common dependency lookup and `DYNAMIC_LIB` construction.
  - Migrate MySQL and other example `CMakeLists.txt` files to call the helper, removing duplicated find/link boilerplate.
  - Implement the helper as a CMake `macro` so variables such as `CMAKE_PREFIX_PATH`, include paths, and library lists propagate to the caller scope.
  - Keep example-specific deps local (e.g. MySQL readline/ncurses/thriftnb, redis/http gperftools).
  Side effects:
  - Performance effects: None expected (build-system only).
  - Breaking backward compatibility: Low risk. Example CMake entry points are simplified; users who build examples via each directory's `CMakeLists.txt` should use
  `brpc_example_find_common_deps` / existing `BrpcExample.cmake` helpers instead of the removed duplicated blocks. `LINK_SO` behavior is preserved.
  ---

  ### Check List:
  - Please make sure your changes are compilable.
  - When providing us with a new feature, it is best to add related tests.
  - Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).