### PR TITLE
fix use-after-free of the new block in SingleIOBuf::assign

### DIFF
--- a/src/butil/single_iobuf.cpp
+++ b/src/butil/single_iobuf.cpp
@@ -226,7 +226,13 @@ bool SingleIOBuf::assign(const IOBuf& buf, uint32_t msg_size) {
         if (!b) {
             return false;
         }
-        reset();
+        // Only drop the reference to the previously assigned data here.
+        // reset() would also release _cur_block, which alloc_block_by_size()
+        // has just set to `b', leaving `b' dangling.
+        if (_cur_ref.block != NULL) {
+            _cur_ref.block->dec_ref();
+            _cur_ref.block = NULL;
+        }
         char* out = b->data + b->size;
         const size_t nref = buf.backing_block_num();
         uint32_t last_len = msg_size;

--- a/test/iobuf_unittest.cpp
+++ b/test/iobuf_unittest.cpp
@@ -1952,6 +1952,34 @@ TEST_F(IOBufTest, single_iobuf) {
     ASSERT_TRUE(p != nullptr);
 }
 
+TEST_F(IOBufTest, single_iobuf_assign_large_multi_block) {
+    // The message spans more than one BlockRef of the source IOBuf and does
+    // not fit in a default-sized block, so assign() has to concatenate it
+    // into a dedicated block.
+    const uint32_t n1 = 5000;
+    const uint32_t n2 = 6000;
+    char* d1 = (char*)malloc(n1);
+    memset(d1, 'a', n1);
+    char* d2 = (char*)malloc(n2);
+    memset(d2, 'b', n2);
+    butil::IOBuf buf;
+    buf.append_user_data(d1, n1, NULL);
+    buf.append_user_data(d2, n2, NULL);
+    ASSERT_EQ(2, buf.backing_block_num());
+
+    butil::SingleIOBuf sbuf;
+    ASSERT_TRUE(sbuf.assign(buf, n1 + n2));
+    ASSERT_EQ(n1 + n2, sbuf.get_length());
+    ASSERT_EQ(std::string(n1, 'a') + std::string(n2, 'b'),
+              std::string((const char*)sbuf.get_begin(), n1 + n2));
+
+    // Assigning again on top of an already assigned SingleIOBuf.
+    ASSERT_TRUE(sbuf.assign(buf, n1 + n2));
+    ASSERT_EQ(n1 + n2, sbuf.get_length());
+    ASSERT_EQ(std::string(n1, 'a') + std::string(n2, 'b'),
+              std::string((const char*)sbuf.get_begin(), n1 + n2));
+}
+
 TEST_F(IOBufTest, as_input_stream_basic) {
     butil::IOBuf buf;
     buf.append("hello world");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:
`SingleIOBuf::assign()` takes the concatenating path when the message spans more than one `BlockRef` of the source `IOBuf`, and that path frees the block it is about to write into.

1. `alloc_block_by_size(msg_size)` stores the block it returns in the member `_cur_block`, and for a freshly created block that member holds the only reference.
2. `reset()` then runs on the next line and releases `_cur_block`. For a message bigger than the default block size it calls `dec_ref()`, `nshared` goes 1 to 0 and the block is freed; for a smaller one the block goes back into the TLS pool where another owner can take it.
3. The rest of the function still writes `msg_size` bytes into `b`, bumps `b->size`, stores `b` in `_cur_ref` and `inc_ref()`s it. `_cur_ref` keeps the dangling pointer, so the later `reset()` or the destructor dec-refs it a second time.

ASAN on a source `IOBuf` of two 5000/6000 byte blocks with `msg_size = 11000`:

```
ERROR: AddressSanitizer: heap-use-after-free on address 0x626000000118
READ of size 8 at 0x626000000118 thread T0
    #0 butil::SingleIOBuf::assign(butil::IOBuf const&, unsigned int) single_iobuf.cpp:230
freed by thread T0 here:
    #1 butil::IOBuf::Block::dec_ref() iobuf_inl.h:544
    #2 butil::SingleIOBuf::reset() single_iobuf.cpp:193
    #3 butil::SingleIOBuf::assign(butil::IOBuf const&, unsigned int) single_iobuf.cpp:229
previously allocated by thread T0 here:
    #2 butil::SingleIOBuf::alloc_block_by_size(unsigned int) single_iobuf.cpp:126
```

### What is changed and the side effects?

Changed:
Drop only the stale `_cur_ref` reference instead of calling `reset()`. `alloc_block_by_size()` already releases the old `_cur_block` when it cannot be reused, so the reference that had to go here is the one to the previously assigned data. The single-`BlockRef` fast path above and `assign_user_data()` are unaffected, they already release before acquiring. `reallocate_downward()` orders its `dec_ref()` after the copy and is fine as is.

`single_iobuf_assign_large_multi_block` in `iobuf_unittest.cpp` covers it: it reports the trace above on the current tree and passes with the change, and the other 59 `IOBufTest` cases still pass under ASAN.

Side effects:
- Performance effects: none. Keeping `_cur_block` lets a repeated `assign()` reuse the same block, which the old code could not do since it released it every time.

- Breaking backward compatibility: none.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
