### PR TITLE
refactor(bvar): expand metric constructor macro

### DIFF
--- a/src/bvar/recorder.h
+++ b/src/bvar/recorder.h
@@ -302,7 +302,13 @@ public:
     typedef detail::MinusStat InvOp;
     typedef detail::ReducerSampler<IntRecorder, value_type, Op, InvOp> sampler_type;
 
-    COMMON_VARIABLE_CONSTRUCTOR(IntRecorder);
+    IntRecorder() = default;
+    IntRecorder(const butil::StringPiece& name) {
+        this->expose(name);
+    }
+    IntRecorder(const butil::StringPiece& prefix, const butil::StringPiece& name) {
+        this->expose_as(prefix, name);
+    }
 
     DISALLOW_COPY_AND_MOVE(IntRecorder);
 

--- a/src/bvar/reducer.h
+++ b/src/bvar/reducer.h
@@ -365,7 +365,13 @@ public:
     typedef detail::MinusFrom<value_type> InvOp;
     typedef typename Base::sampler_type sampler_type;
 
-    COMMON_VARIABLE_CONSTRUCTOR(Adder);
+    Adder() = default;
+    Adder(const butil::StringPiece& name) {
+        this->expose(name);
+    }
+    Adder(const butil::StringPiece& prefix, const butil::StringPiece& name) {
+        this->expose_as(prefix, name);
+    }
 };
 #endif // WITH_BABYLON_COUNTER
 
@@ -457,7 +463,13 @@ public:
     typedef detail::VoidOp InvOp;
     typedef typename Base::sampler_type sampler_type;
 
-    COMMON_VARIABLE_CONSTRUCTOR(Maxer);
+    Maxer() = default;
+    Maxer(const butil::StringPiece& name) {
+        this->expose(name);
+    }
+    Maxer(const butil::StringPiece& prefix, const butil::StringPiece& name) {
+        this->expose_as(prefix, name);
+    }
 
 private:
 friend class detail::LatencyRecorderBase;
@@ -524,7 +536,13 @@ public:
     typedef detail::VoidOp InvOp;
     typedef typename Base::sampler_type sampler_type;
 
-    COMMON_VARIABLE_CONSTRUCTOR(Miner);
+    Miner() = default;
+    Miner(const butil::StringPiece& name) {
+        this->expose(name);
+    }
+    Miner(const butil::StringPiece& prefix, const butil::StringPiece& name) {
+        this->expose_as(prefix, name);
+    }
 };
 #endif // WITH_BABYLON_COUNTER
 

--- a/src/bvar/variable.h
+++ b/src/bvar/variable.h
@@ -39,16 +39,6 @@ namespace bvar {
 
 DECLARE_bool(save_series);
 
-#define COMMON_VARIABLE_CONSTRUCTOR(TypeName)                                    \
-    TypeName() = default;                                                        \
-    TypeName(const butil::StringPiece& name) {                                   \
-        this->expose(name);                                                      \
-    }                                                                            \
-    TypeName(const butil::StringPiece& prefix, const butil::StringPiece& name) { \
-        this->expose_as(prefix, name);                                           \
-    }                                                                            \
-
-
 // Bitwise masks of displayable targets 
 enum DisplayFilter {
     DISPLAY_ON_HTML = 1,


### PR DESCRIPTION
## Summary

  - Remove the `COMMON_VARIABLE_CONSTRUCTOR` macro
  - Replace its uses in the Babylon counter variants of `Adder`, `Maxer`, `Miner`, and `IntRecorder` with explicit constructors
  - Preserve the existing constructor behavior for default construction, `expose(name)`, and `expose_as(prefix, name)`

  ## Motivation

  `COMMON_VARIABLE_CONSTRUCTOR` hid public constructors behind macro expansion, making the code harder to read, search, and navigate with regular C++ tooling.

  This change keeps the API behavior unchanged while making the constructors visible at their declaration sites.

  `using Base::Base` was intentionally avoided because it would expose additional internal base constructors in the Babylon counter path and could broaden the public
  API.

  ## Testing

  - `cmake --build build --target brpc-static -j6`
  - `git diff --check`
  - `rg COMMON_VARIABLE_CONSTRUCTOR . -g '!build/**'`

  ## Notes

  The `WITH_BABYLON_COUNTER` path was not compiled locally because the available Bazel setup is missing the repository-required Bazel `7.2.1` binary.
