### PR TITLE
guard underflowed value size in couchbase collection responses

### DIFF
--- a/src/brpc/couchbase.cpp
+++ b/src/brpc/couchbase.cpp
@@ -1506,10 +1506,14 @@ bool CouchbaseOperations::CouchbaseResponse::popCollectionId(
 
   if (header.status != 0) {
     // handle error case
-    _buf.pop_front(sizeof(header) + header.extras_length + header.key_length);
     // Possibly read error message from value if present
-    size_t value_size =
-        header.total_body_length - header.extras_length - header.key_length;
+    const int value_size = (int)header.total_body_length -
+                           (int)header.extras_length - (int)header.key_length;
+    if (value_size < 0) {
+      butil::string_printf(&_err, "value_size=%d is negative", value_size);
+      return false;
+    }
+    _buf.pop_front(sizeof(header) + header.extras_length + header.key_length);
     if (value_size > 0) {
       std::string err_msg;
       _buf.cutn(&err_msg, value_size);
@@ -1583,10 +1587,14 @@ bool CouchbaseOperations::CouchbaseResponse::popManifest(
     if (header.key_length != 0) {
       DEBUG_PRINT("Get Collections Manifest response must not have key");
     }
-    _buf.pop_front(sizeof(header) + header.extras_length + header.key_length);
     // Possibly read error message from value if present
-    size_t value_size =
-        header.total_body_length - header.extras_length - header.key_length;
+    const int value_size = (int)header.total_body_length -
+                           (int)header.extras_length - (int)header.key_length;
+    if (value_size < 0) {
+      butil::string_printf(&_err, "value_size=%d is negative", value_size);
+      return false;
+    }
+    _buf.pop_front(sizeof(header) + header.extras_length + header.key_length);
     if (value_size > 0) {
       std::string err_msg;
       _buf.cutn(&err_msg, value_size);
@@ -1599,8 +1607,12 @@ bool CouchbaseOperations::CouchbaseResponse::popManifest(
   }
 
   // Success case: the manifest should be in the value section
-  size_t value_size =
-      header.total_body_length - header.extras_length - header.key_length;
+  const int value_size = (int)header.total_body_length -
+                         (int)header.extras_length - (int)header.key_length;
+  if (value_size < 0) {
+    butil::string_printf(&_err, "value_size=%d is negative", value_size);
+    return false;
+  }
   if (value_size == 0) {
     butil::string_printf(&_err, "No manifest data in response");
     _buf.pop_front(sizeof(header) + header.total_body_length);

--- a/src/brpc/couchbase.cpp
+++ b/src/brpc/couchbase.cpp
@@ -30,6 +30,7 @@ static bool DBUG = false;  // Set to true to enable debug logs
     }                                              \
   } while (0)
 
+#include <cinttypes>
 #include <iostream>
 
 #include "brpc/policy/couchbase_protocol.h"
@@ -1507,10 +1508,12 @@ bool CouchbaseOperations::CouchbaseResponse::popCollectionId(
   if (header.status != 0) {
     // handle error case
     // Possibly read error message from value if present
-    const int value_size = (int)header.total_body_length -
-                           (int)header.extras_length - (int)header.key_length;
+    const int64_t value_size = static_cast<int64_t>(header.total_body_length) -
+                               static_cast<int64_t>(header.extras_length) -
+                               static_cast<int64_t>(header.key_length);
     if (value_size < 0) {
-      butil::string_printf(&_err, "value_size=%d is negative", value_size);
+      butil::string_printf(&_err, "value_size=%" PRId64 " is negative",
+                           value_size);
       return false;
     }
     _buf.pop_front(sizeof(header) + header.extras_length + header.key_length);
@@ -1588,10 +1591,12 @@ bool CouchbaseOperations::CouchbaseResponse::popManifest(
       DEBUG_PRINT("Get Collections Manifest response must not have key");
     }
     // Possibly read error message from value if present
-    const int value_size = (int)header.total_body_length -
-                           (int)header.extras_length - (int)header.key_length;
+    const int64_t value_size = static_cast<int64_t>(header.total_body_length) -
+                               static_cast<int64_t>(header.extras_length) -
+                               static_cast<int64_t>(header.key_length);
     if (value_size < 0) {
-      butil::string_printf(&_err, "value_size=%d is negative", value_size);
+      butil::string_printf(&_err, "value_size=%" PRId64 " is negative",
+                           value_size);
       return false;
     }
     _buf.pop_front(sizeof(header) + header.extras_length + header.key_length);
@@ -1607,10 +1612,12 @@ bool CouchbaseOperations::CouchbaseResponse::popManifest(
   }
 
   // Success case: the manifest should be in the value section
-  const int value_size = (int)header.total_body_length -
-                         (int)header.extras_length - (int)header.key_length;
+  const int64_t value_size = static_cast<int64_t>(header.total_body_length) -
+                             static_cast<int64_t>(header.extras_length) -
+                             static_cast<int64_t>(header.key_length);
   if (value_size < 0) {
-    butil::string_printf(&_err, "value_size=%d is negative", value_size);
+    butil::string_printf(&_err, "value_size=%" PRId64 " is negative",
+                         value_size);
     return false;
   }
   if (value_size == 0) {

--- a/test/brpc_couchbase_unittest.cpp
+++ b/test/brpc_couchbase_unittest.cpp
@@ -98,6 +98,36 @@ TEST_F(CouchbaseUnitTest, ResultStruct) {
   EXPECT_EQ(0x00, result.status_code);
 }
 
+// The header fields are attacker-controlled, extras_length + key_length may
+// exceed total_body_length. popManifest/popCollectionId must not treat the
+// underflowed remainder as a value size and drain the pipelined buffer.
+TEST_F(CouchbaseUnitTest, CollectionResponseWithInconsistentBodyLength) {
+  const std::string next_response(64, 'A');
+
+  brpc::policy::CouchbaseResponseHeader header = {};
+  header.magic = brpc::policy::CB_MAGIC_RESPONSE;
+  header.command = brpc::policy::CB_GET_COLLECTIONS_MANIFEST;
+  header.extras_length = 1;
+  header.total_body_length = 0;
+
+  brpc::CouchbaseOperations::CouchbaseResponse res;
+  res.rawBuffer().append(&header, sizeof(header));
+  res.rawBuffer().append(next_response);
+  std::string manifest = "untouched";
+  EXPECT_FALSE(res.popManifest(&manifest));
+  EXPECT_EQ("untouched", manifest);
+  EXPECT_EQ(sizeof(header) + next_response.size(), res.rawBuffer().size());
+
+  header.command = brpc::policy::CB_COLLECTIONS_GET_CID;
+  header.status = 1;
+  brpc::CouchbaseOperations::CouchbaseResponse res2;
+  res2.rawBuffer().append(&header, sizeof(header));
+  res2.rawBuffer().append(next_response);
+  uint8_t collection_id = 0;
+  EXPECT_FALSE(res2.popCollectionId(&collection_id));
+  EXPECT_EQ(sizeof(header) + next_response.size(), res2.rawBuffer().size());
+}
+
 TEST_F(CouchbaseUnitTest, EdgeCases) {
   brpc::CouchbaseOperations::CouchbaseRequest req;
   req.addRequest("", "value", 0, 0, 0);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

`popCollectionId()` and `popManifest()` in `src/brpc/couchbase.cpp` size the value section with unsigned arithmetic: `header.total_body_length - header.extras_length - header.key_length`. All three fields come straight from the server's response header and nothing cross-checks them, so a reply where `extras_length + key_length` exceeds `total_body_length` wraps the subtraction close to `SIZE_MAX`. `IOBuf::cutn()` clamps to what is available, so the whole remaining pipelined buffer gets swallowed: `popManifest()` hands those bytes back to the caller as the collection manifest, `popCollectionId()` folds them into the error string, and either way the response stream on that connection is out of sync from then on. The sibling parsers in the same file (`popGet`, `popStore`, `popCounter`, `popVersion`) already compute this as a signed `int` and bail out when it is negative; only these two collection parsers were written with `size_t` and no check.

Reproduced against a 24-byte header with `total_body_length=0`, `extras_length=1` followed by 64 bytes of the next response: `popManifest()` returns true with a computed size of 18446744073709551615, copies 63 bytes of the following response into the manifest string and leaves the buffer empty. With this change it returns false and the buffer is untouched.

### What is changed and the side effects?

Changed:

Both functions now use the same signed computation and `< 0` rejection as their siblings, done before `pop_front()` so a malformed reply does not consume anything. Added a regression test to `test/brpc_couchbase_unittest.cpp`.

Side effects:
- Performance effects: none.

- Breaking backward compatibility: no, well-formed responses parse exactly as before.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
