### PR TITLE
refactor(bvar): replace NULL with nullptr

### DIFF
--- a/src/bvar/collector.cpp
+++ b/src/bvar/collector.cpp
@@ -43,10 +43,10 @@ BAIDU_CASSERT(!(COLLECTOR_SAMPLING_BASE & (COLLECTOR_SAMPLING_BASE - 1)),
 // Combine two circular linked list into one.
 struct CombineCollected {
     void operator()(Collected* & s1, Collected* s2) const {
-        if (s2 == NULL) {
+        if (s2 == nullptr) {
             return;
         }
-        if (s1 == NULL) {
+        if (s1 == nullptr) {
             s1 = s2;
             return;
         }
@@ -79,13 +79,13 @@ private:
     static void* run_grab_thread(void* arg) {
         butil::PlatformThread::SetNameSimple("bvar_collector_grabber");
         static_cast<Collector*>(arg)->grab_thread();
-        return NULL;
+        return nullptr;
     }
 
     static void* run_dump_thread(void* arg) {
         butil::PlatformThread::SetNameSimple("bvar_collector_dumper");
         static_cast<Collector*>(arg)->dump_thread();
-        return NULL;
+        return nullptr;
     }
 
     static int64_t get_pending_count(void* arg) {
@@ -121,11 +121,11 @@ Collector::Collector()
     , _ngrab(0)
     , _ndrop(0)
     , _ndump(0) {
-    pthread_mutex_init(&_dump_thread_mutex, NULL);
-    pthread_cond_init(&_dump_thread_cond, NULL);
-    pthread_mutex_init(&_sleep_mutex, NULL);
-    pthread_cond_init(&_sleep_cond, NULL);
-    int rc = pthread_create(&_grab_thread, NULL, run_grab_thread, this);
+    pthread_mutex_init(&_dump_thread_mutex, nullptr);
+    pthread_cond_init(&_dump_thread_cond, nullptr);
+    pthread_mutex_init(&_sleep_mutex, nullptr);
+    pthread_cond_init(&_sleep_cond, nullptr);
+    int rc = pthread_create(&_grab_thread, nullptr, run_grab_thread, this);
     if (rc != 0) {
         LOG(ERROR) << "Fail to create Collector, " << berror(rc);
     } else {
@@ -136,7 +136,7 @@ Collector::Collector()
 Collector::~Collector() {
     if (_created) {
         _stop = true;
-        pthread_join(_grab_thread, NULL);
+        pthread_join(_grab_thread, nullptr);
         _created = false;
     }
     pthread_mutex_destroy(&_dump_thread_mutex);
@@ -150,7 +150,7 @@ static T deref_value(void* arg) {
     return *(T*)arg;
 }
 
-// for limiting samples returning NULL in speed_limit()
+// for limiting samples returning nullptr in speed_limit()
 static CollectorSpeedLimit g_null_speed_limit = BVAR_COLLECTOR_SPEED_LIMIT_INITIALIZER;
 
 void Collector::grab_thread() {
@@ -161,7 +161,7 @@ void Collector::grab_thread() {
     // called inside the separate _dump_thread to prevent a slow callback
     // (caused by busy disk generally) from blocking collecting code too long
     // that pending requests may explode memory.
-    CHECK_EQ(0, pthread_create(&_dump_thread, NULL, run_dump_thread, this));
+    CHECK_EQ(0, pthread_create(&_dump_thread, nullptr, run_dump_thread, this));
 
     // vars
     bvar::PassiveStatus<int64_t> pending_sampled_data(
@@ -199,7 +199,7 @@ void Collector::grab_thread() {
         if (head) {
             butil::LinkNode<Collected> tmp_root;
             head->InsertBeforeAsList(&tmp_root);
-            head = NULL;
+            head = nullptr;
             
             // Group samples by preprocessors.
             for (butil::LinkNode<Collected>* p = tmp_root.next(); p != &tmp_root;) {
@@ -218,13 +218,13 @@ void Collector::grab_thread() {
                     // don't call preprocessor when there's no samples.
                     continue;
                 }
-                if (it->first != NULL) {
+                if (it->first != nullptr) {
                     it->first->process(list);
                 }
                 for (size_t i = 0; i < list.size(); ++i) {
                     Collected* p = list[i];
                     CollectorSpeedLimit* speed_limit = p->speed_limit();
-                    if (speed_limit == NULL) {
+                    if (speed_limit == nullptr) {
                         ++ngrab_map[&g_null_speed_limit];
                     } else {
                         // Add up the samples of certain type.
@@ -280,7 +280,7 @@ void Collector::grab_thread() {
         _stop = true; 
         pthread_cond_signal(&_dump_thread_cond);
     }
-    CHECK_EQ(0, pthread_join(_dump_thread, NULL));
+    CHECK_EQ(0, pthread_join(_dump_thread, nullptr));
 }
 
 void Collector::wakeup_grab_thread() {
@@ -379,7 +379,7 @@ void Collector::dump_thread() {
     while (!_stop) {
         ++round;
         // Get new samples set by grab_thread.
-        butil::LinkNode<Collected>* newhead = NULL;
+        butil::LinkNode<Collected>* newhead = nullptr;
         {
             BAIDU_SCOPED_LOCK(_dump_thread_mutex);
             while (!_stop && _dump_root.next() == &_dump_root) {

--- a/src/bvar/collector.h
+++ b/src/bvar/collector.h
@@ -94,20 +94,20 @@ public:
     virtual void destroy() = 0;
 
     // Returns an object to control #samples collected per second.
-    // If NULL is returned, samples collected per second is limited by a
-    // global speed limit shared with other samples also returning NULL.
+    // If nullptr is returned, samples collected per second is limited by a
+    // global speed limit shared with other samples also returning nullptr.
     // All instances of a subclass of Collected should return a same instance
     // of CollectorSpeedLimit. The instance should remain valid during lifetime
     // of program.
     virtual CollectorSpeedLimit* speed_limit() = 0;
 
-    // If this method returns a non-NULL instance, it will be applied to
+    // If this method returns a non-nullptr instance, it will be applied to
     // samples in batch before dumping. You can sort or shuffle the samples
     // in the impl.
     // All instances of a subclass of Collected should return a same instance
     // of CollectorPreprocessor. The instance should remain valid during
     // lifetime of program.
-    virtual CollectorPreprocessor* preprocessor() { return NULL; }
+    virtual CollectorPreprocessor* preprocessor() { return nullptr; }
 };
 
 // To know if an instance should be sampled.

--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -80,7 +80,7 @@ static bool read_proc_status(ProcStat &stat) {
     // Read status from /proc/self/stat. Information from `man proc' is out of date,
     // see http://man7.org/linux/man-pages/man5/proc.5.html
     butil::ScopedFILE fp("/proc/self/stat", "r");
-    if (NULL == fp) {
+    if (nullptr == fp) {
         static bool ever_printed_stat_err = false;
         if (!ever_printed_stat_err) {
             fprintf(stderr, "WARNING: Fail to open /proc/self/stat, errno=%d. "
@@ -136,7 +136,7 @@ template <typename T>
 class CachedReader {
 public:
     CachedReader() : _mtime_us(0), _cached{} {
-        CHECK_EQ(0, pthread_mutex_init(&_mutex, NULL));
+        CHECK_EQ(0, pthread_mutex_init(&_mutex, nullptr));
     }
     ~CachedReader() {
         pthread_mutex_destroy(&_mutex);
@@ -192,13 +192,13 @@ public:
 #define BVAR_DEFINE_PROC_STAT_FIELD(field)                              \
     PassiveStatus<BVAR_MEMBER_TYPE(&ProcStat::field)> g_##field(        \
         ProcStatReader::get_field<BVAR_MEMBER_TYPE(&ProcStat::field),   \
-        offsetof(ProcStat, field)>, NULL);
+        offsetof(ProcStat, field)>, nullptr);
 
 #define BVAR_DEFINE_PROC_STAT_FIELD2(field, name)                       \
     PassiveStatus<BVAR_MEMBER_TYPE(&ProcStat::field)> g_##field(        \
         name,                                                           \
         ProcStatReader::get_field<BVAR_MEMBER_TYPE(&ProcStat::field),   \
-        offsetof(ProcStat, field)>, NULL);
+        offsetof(ProcStat, field)>, nullptr);
 
 // ==================================================
 
@@ -217,7 +217,7 @@ static bool read_proc_memory(ProcMemory &m) {
     errno = 0;
 #if defined(OS_LINUX)
     butil::ScopedFILE fp("/proc/self/statm", "r");
-    if (NULL == fp) {
+    if (nullptr == fp) {
         PLOG_ONCE(WARNING) << "Fail to open /proc/self/statm";
         return false;
     }
@@ -271,7 +271,7 @@ public:
     PassiveStatus<BVAR_MEMBER_TYPE(&ProcMemory::field)> g_##field(      \
         name,                                                           \
         ProcMemoryReader::get_field<BVAR_MEMBER_TYPE(&ProcMemory::field), \
-        offsetof(ProcMemory, field)>, NULL);
+        offsetof(ProcMemory, field)>, nullptr);
 
 // ==================================================
 
@@ -284,7 +284,7 @@ struct LoadAverage {
 static bool read_load_average(LoadAverage &m) {
 #if defined(OS_LINUX)
     butil::ScopedFILE fp("/proc/loadavg", "r");
-    if (NULL == fp) {
+    if (nullptr == fp) {
         PLOG_ONCE(WARNING) << "Fail to open /proc/loadavg";
         return false;
     }
@@ -331,7 +331,7 @@ public:
     PassiveStatus<BVAR_MEMBER_TYPE(&LoadAverage::field)> g_##field(     \
         name,                                                           \
         LoadAverageReader::get_field<BVAR_MEMBER_TYPE(&LoadAverage::field), \
-        offsetof(LoadAverage, field)>, NULL);
+        offsetof(LoadAverage, field)>, nullptr);
 
 // ==================================================
 
@@ -437,7 +437,7 @@ struct ProcIO {
 static bool read_proc_io(ProcIO* s) {
 #if defined(OS_LINUX)
     butil::ScopedFILE fp("/proc/self/io", "r");
-    if (NULL == fp) {
+    if (nullptr == fp) {
         static bool ever_printed_io_err = false;
         if (!ever_printed_io_err) {
             fprintf(stderr, "WARNING: Fail to open /proc/self/io, errno=%d. "
@@ -488,7 +488,7 @@ public:
 #define BVAR_DEFINE_PROC_IO_FIELD(field)                                \
     PassiveStatus<BVAR_MEMBER_TYPE(&ProcIO::field)> g_##field(          \
         ProcIOReader::get_field<BVAR_MEMBER_TYPE(&ProcIO::field),       \
-        offsetof(ProcIO, field)>, NULL);
+        offsetof(ProcIO, field)>, nullptr);
 
 // ==================================================
 // Refs:
@@ -550,7 +550,7 @@ struct DiskStat {
 static bool read_disk_stat(DiskStat* s) {
 #if defined(OS_LINUX)
     butil::ScopedFILE fp("/proc/diskstats", "r");
-    if (NULL == fp) {
+    if (nullptr == fp) {
         PLOG_ONCE(WARNING) << "Fail to open /proc/diskstats";
         return false;
     }
@@ -598,7 +598,7 @@ public:
 #define BVAR_DEFINE_DISK_STAT_FIELD(field)                              \
     PassiveStatus<BVAR_MEMBER_TYPE(&DiskStat::field)> g_##field(        \
         DiskStatReader::get_field<BVAR_MEMBER_TYPE(&DiskStat::field),   \
-        offsetof(DiskStat, field)>, NULL);
+        offsetof(DiskStat, field)>, nullptr);
 
 // =====================================
 
@@ -663,13 +663,13 @@ public:
 #define BVAR_DEFINE_RUSAGE_FIELD(field)                                 \
     PassiveStatus<BVAR_MEMBER_TYPE(&rusage::field)> g_##field(          \
         RUsageReader::get_field<BVAR_MEMBER_TYPE(&rusage::field),       \
-        offsetof(rusage, field)>, NULL);                                \
+        offsetof(rusage, field)>, nullptr);                                \
     
 #define BVAR_DEFINE_RUSAGE_FIELD2(field, name)                          \
     PassiveStatus<BVAR_MEMBER_TYPE(&rusage::field)> g_##field(          \
         name,                                                           \
         RUsageReader::get_field<BVAR_MEMBER_TYPE(&rusage::field),       \
-        offsetof(rusage, field)>, NULL);                                \
+        offsetof(rusage, field)>, nullptr);                                \
 
 // ======================================
 
@@ -688,7 +688,7 @@ static void get_username(std::ostream& os, void*) {
 }
 
 PassiveStatus<std::string> g_username(
-    "process_username", get_username, NULL);
+    "process_username", get_username, nullptr);
 
 BVAR_DEFINE_PROC_STAT_FIELD(minflt);
 PerSecond<PassiveStatus<unsigned long> > g_minflt_second(
@@ -699,7 +699,7 @@ BVAR_DEFINE_PROC_STAT_FIELD2(priority, "process_priority");
 BVAR_DEFINE_PROC_STAT_FIELD2(nice, "process_nice");
 
 BVAR_DEFINE_PROC_STAT_FIELD2(num_threads, "process_thread_count");
-PassiveStatus<int> g_fd_num("process_fd_count", print_fd_count, NULL);
+PassiveStatus<int> g_fd_num("process_fd_count", print_fd_count, nullptr);
 
 BVAR_DEFINE_PROC_MEMORY_FIELD(size, "process_memory_virtual");
 BVAR_DEFINE_PROC_MEMORY_FIELD(resident, "process_memory_resident");
@@ -734,12 +734,12 @@ PerSecond<PassiveStatus<size_t> > g_disk_write_second(
 
 BVAR_DEFINE_RUSAGE_FIELD(ru_utime);
 BVAR_DEFINE_RUSAGE_FIELD(ru_stime);
-PassiveStatus<timeval> g_uptime("process_uptime", get_uptime, NULL);
+PassiveStatus<timeval> g_uptime("process_uptime", get_uptime, nullptr);
 
 static int get_core_num(void*) {
     return sysconf(_SC_NPROCESSORS_ONLN);
 }
-PassiveStatus<int> g_core_num("system_core_count", get_core_num, NULL);
+PassiveStatus<int> g_core_num("system_core_count", get_core_num, nullptr);
 
 struct TimePercent {
     int64_t time_us;
@@ -769,7 +769,7 @@ static TimePercent get_cputime_percent(void*) {
                        butil::timeval_to_microseconds(g_uptime.get_value()) };
     return tp;
 }
-PassiveStatus<TimePercent> g_cputime_percent(get_cputime_percent, NULL);
+PassiveStatus<TimePercent> g_cputime_percent(get_cputime_percent, nullptr);
 Window<PassiveStatus<TimePercent>, SERIES_IN_SECOND> g_cputime_percent_second(
     "process_cpu_usage", &g_cputime_percent, FLAGS_bvar_dump_interval);
 
@@ -778,7 +778,7 @@ static TimePercent get_stime_percent(void*) {
                        butil::timeval_to_microseconds(g_uptime.get_value()) };
     return tp;
 }
-PassiveStatus<TimePercent> g_stime_percent(get_stime_percent, NULL);
+PassiveStatus<TimePercent> g_stime_percent(get_stime_percent, nullptr);
 Window<PassiveStatus<TimePercent>, SERIES_IN_SECOND> g_stime_percent_second(
     "process_cpu_usage_system", &g_stime_percent, FLAGS_bvar_dump_interval);
 
@@ -787,7 +787,7 @@ static TimePercent get_utime_percent(void*) {
                        butil::timeval_to_microseconds(g_uptime.get_value()) };
     return tp;
 }
-PassiveStatus<TimePercent> g_utime_percent(get_utime_percent, NULL);
+PassiveStatus<TimePercent> g_utime_percent(get_utime_percent, nullptr);
 Window<PassiveStatus<TimePercent>, SERIES_IN_SECOND> g_utime_percent_second(
     "process_cpu_usage_user", &g_utime_percent, FLAGS_bvar_dump_interval);
 
@@ -811,11 +811,11 @@ PerSecond<PassiveStatus<long> > cs_vol_second(
 PerSecond<PassiveStatus<long> > cs_invol_second(
     "process_context_switches_involuntary_second", &g_ru_nivcsw);
 
-PassiveStatus<std::string> g_cmdline("process_cmdline", get_cmdline, NULL);
+PassiveStatus<std::string> g_cmdline("process_cmdline", get_cmdline, nullptr);
 PassiveStatus<std::string> g_kernel_version(
-    "kernel_version", get_kernel_version, NULL);
+    "kernel_version", get_kernel_version, nullptr);
 
-static std::string* s_gcc_version = NULL;
+static std::string* s_gcc_version = nullptr;
 pthread_once_t g_gen_gcc_version_once = PTHREAD_ONCE_INIT;
 
 void gen_gcc_version() {
@@ -866,7 +866,7 @@ void get_gcc_version(std::ostream& os, void*) {
 }
 
 // =============================================
-PassiveStatus<std::string> g_gcc_version("gcc_version", get_gcc_version, NULL);
+PassiveStatus<std::string> g_gcc_version("gcc_version", get_gcc_version, nullptr);
 
 void get_work_dir(std::ostream& os, void*) {
     butil::FilePath path;
@@ -874,7 +874,7 @@ void get_work_dir(std::ostream& os, void*) {
     LOG_IF(WARNING, !rc) << "Fail to GetCurrentDirectory";
     os << path.value();
 }
-PassiveStatus<std::string> g_work_dir("process_work_dir", get_work_dir, NULL);
+PassiveStatus<std::string> g_work_dir("process_work_dir", get_work_dir, nullptr);
 
 #undef BVAR_MEMBER_TYPE
 #undef BVAR_DEFINE_PROC_STAT_FIELD

--- a/src/bvar/detail/agent_group.h
+++ b/src/bvar/detail/agent_group.h
@@ -123,20 +123,20 @@ public:
                 }
             }
         }
-        return NULL;
+        return nullptr;
     }
 
     // Note: May return non-null for unexist id, see notes on ThreadBlock
     inline static Agent* get_or_create_tls_agent(AgentId id) {
         if (__builtin_expect(id < 0, 0)) {
             CHECK(false) << "Invalid id=" << id;
-            return NULL;
+            return nullptr;
         }
-        if (_s_tls_blocks == NULL) {
+        if (_s_tls_blocks == nullptr) {
             _s_tls_blocks = new (std::nothrow) std::vector<ThreadBlock *>;
-            if (__builtin_expect(_s_tls_blocks == NULL, 0)) {
+            if (__builtin_expect(_s_tls_blocks == nullptr, 0)) {
                 LOG(FATAL) << "Fail to create vector, " << berror();
-                return NULL;
+                return nullptr;
             }
             butil::thread_atexit(_destroy_tls_blocks);
         }
@@ -146,10 +146,10 @@ public:
             _s_tls_blocks->resize(std::max(block_id + 1, 32ul));
         }
         ThreadBlock* tb = (*_s_tls_blocks)[block_id];
-        if (tb == NULL) {
+        if (tb == nullptr) {
             ThreadBlock *new_block = new (std::nothrow) ThreadBlock;
-            if (__builtin_expect(new_block == NULL, 0)) {
-                return NULL;
+            if (__builtin_expect(new_block == nullptr, 0)) {
+                return nullptr;
             }
             tb = new_block;
             (*_s_tls_blocks)[block_id] = new_block;
@@ -166,7 +166,7 @@ private:
             delete (*_s_tls_blocks)[i];
         }
         delete _s_tls_blocks;
-        _s_tls_blocks = NULL;
+        _s_tls_blocks = nullptr;
     }
 
     inline static std::deque<AgentId> &_get_free_ids() {
@@ -187,14 +187,14 @@ template <typename Agent>
 pthread_mutex_t AgentGroup<Agent>::_s_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 template <typename Agent>
-std::deque<AgentId>* AgentGroup<Agent>::_s_free_ids = NULL;
+std::deque<AgentId>* AgentGroup<Agent>::_s_free_ids = nullptr;
 
 template <typename Agent>
 AgentId AgentGroup<Agent>::_s_agent_kinds = 0;
 
 template <typename Agent>
 __thread std::vector<typename AgentGroup<Agent>::ThreadBlock *>
-*AgentGroup<Agent>::_s_tls_blocks = NULL;
+*AgentGroup<Agent>::_s_tls_blocks = nullptr;
 
 }  // namespace detail
 }  // namespace bvar

--- a/src/bvar/detail/combiner.h
+++ b/src/bvar/detail/combiner.h
@@ -167,7 +167,7 @@ friend class GlobalValue<self_type>;
     struct Agent : public butil::LinkNode<Agent> {
         ~Agent() {
             self_shared_type c = combiner.lock();
-            if (NULL != c) {
+            if (nullptr != c) {
                 c->commit_and_erase(this);
             }
         }
@@ -206,8 +206,8 @@ friend class GlobalValue<self_type>;
         // NOTE: Only available to non-atomic types.
         template <typename Op>
         void merge_global(const Op &op, self_shared_type& c) {
-            const self_shared_type& c_ref = NULL != c ? c : combiner.lock();
-            if (NULL != c_ref) {
+            const self_shared_type& c_ref = nullptr != c ? c : combiner.lock();
+            if (nullptr != c_ref) {
                 GlobalValue<self_type> g(this, c_ref.get());
                 element.merge_global(op, g);
             }
@@ -304,7 +304,7 @@ friend class GlobalValue<self_type>;
 
     // Always called from the thread owning the agent.
     void commit_and_erase(Agent* agent) {
-        if (NULL == agent) {
+        if (nullptr == agent) {
             return;
         }
         ElementTp local;
@@ -318,7 +318,7 @@ friend class GlobalValue<self_type>;
 
     // Always called from the thread owning the agent
     void commit_and_clear(Agent* agent) {
-        if (NULL == agent) {
+        if (nullptr == agent) {
             return;
         }
         ElementTp prev;
@@ -333,9 +333,9 @@ friend class GlobalValue<self_type>;
         if (!agent) {
             // Create the agent
             agent = AgentGroup::get_or_create_tls_agent(_id);
-            if (NULL == agent) {
+            if (nullptr == agent) {
                 LOG(FATAL) << "Fail to create agent";
-                return NULL;
+                return nullptr;
             }
         }
         if (!agent->combiner.expired()) {
@@ -369,7 +369,7 @@ friend class GlobalValue<self_type>;
     //     // non-pod, internal allocations should be released.
     //     for (butil::LinkNode<Agent>* node = _agents.head();
     //          node != _agents.end();) {
-    //         node->value()->reset(ElementTp(), NULL);
+    //         node->value()->reset(ElementTp(), nullptr);
     //         butil::LinkNode<Agent>* const saved_next = node->next();
     //         node->RemoveFromList();
     //         node = saved_next;

--- a/src/bvar/detail/percentile.cpp
+++ b/src/bvar/detail/percentile.cpp
@@ -86,14 +86,14 @@ private:
 };
 
 Percentile::Percentile()
-    : _combiner(std::make_shared<combiner_type>()), _sampler(NULL) {}
+    : _combiner(std::make_shared<combiner_type>()), _sampler(nullptr) {}
 
 Percentile::~Percentile() {
     // Have to destroy sampler first to avoid the race between destruction and
     // sampler
-    if (_sampler != NULL) {
+    if (_sampler != nullptr) {
         _sampler->destroy();
-        _sampler = NULL;
+        _sampler = nullptr;
     }
 }
 

--- a/src/bvar/detail/percentile.h
+++ b/src/bvar/detail/percentile.h
@@ -305,7 +305,7 @@ friend class AddLatency;
             if (rhs._intervals[i] && !rhs._intervals[i]->empty()) {
                 _intervals[i] = new PercentileInterval<SAMPLE_SIZE>(*rhs._intervals[i]);
             } else {
-                _intervals[i] = NULL;
+                _intervals[i] = nullptr;
             }
         }
     }
@@ -340,7 +340,7 @@ friend class AddLatency;
             return 0;
         }
         for (size_t i = 0; i < NUM_INTERVALS; ++i) {
-            if (_intervals[i] == NULL) {
+            if (_intervals[i] == nullptr) {
                 continue;
             }
             PercentileInterval<SAMPLE_SIZE>& invl = *_intervals[i];
@@ -461,7 +461,7 @@ template <size_t size1> friend class PercentileSamples;
 
     // Get/create interval on-demand.
     PercentileInterval<SAMPLE_SIZE>& get_interval_at(size_t index) {
-        if (_intervals[index] == NULL) {
+        if (_intervals[index] == nullptr) {
             _intervals[index] = new PercentileInterval<SAMPLE_SIZE>;
         }
         return *_intervals[index];
@@ -525,7 +525,7 @@ public:
 
     // The sampler for windows over percentile.
     sampler_type* get_sampler() {
-        if (NULL == _sampler) {
+        if (nullptr == _sampler) {
             _sampler = new sampler_type(this);
             _sampler->schedule();
         }
@@ -538,7 +538,7 @@ public:
     
     Percentile& operator<<(int64_t latency);
 
-    bool valid() const { return _combiner != NULL && _combiner->valid(); }
+    bool valid() const { return _combiner != nullptr && _combiner->valid(); }
     
     // This name is useful for warning negative latencies in operator<<
     void set_debug_name(const butil::StringPiece& name) {
@@ -580,7 +580,7 @@ public:
 
     DISALLOW_COPY_AND_MOVE(Percentile);
     ~Percentile() noexcept {
-        if (NULL != _sampler) {
+        if (nullptr != _sampler) {
             _sampler->destroy();
         }
     }
@@ -589,7 +589,7 @@ public:
     InvOp inv_op() const { return InvOp(); }
 
     sampler_type* get_sampler() {
-        if (NULL == _sampler) {
+        if (nullptr == _sampler) {
             _sampler = new sampler_type(this);
             _sampler->schedule();
         }
@@ -614,7 +614,7 @@ public:
 
 private:
     babylon::ConcurrentSampler _concurrent_sampler;
-    sampler_type* _sampler{NULL};
+    sampler_type* _sampler{nullptr};
     std::string _debug_name;
 };
 #endif // WITH_BABYLON_COUNTER

--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -34,10 +34,10 @@ const int WARN_NOSLEEP_THRESHOLD = 2;
 // Combine two circular linked list into one.
 struct CombineSampler {
     void operator()(Sampler* & s1, Sampler* s2) const {
-        if (s2 == NULL) {
+        if (s2 == nullptr) {
             return;
         }
-        if (s1 == NULL) {
+        if (s1 == nullptr) {
             s1 = s2;
             return;
         }
@@ -71,7 +71,7 @@ public:
     ~SamplerCollector() {
         if (_created) {
             _stop = true;
-            pthread_join(_tid, NULL);
+            pthread_join(_tid, nullptr);
             _created = false;
         }
     }
@@ -89,14 +89,14 @@ private:
     }
 
     void create_sampling_thread() {
-        const int rc = pthread_create(&_tid, NULL, sampling_thread, this);
+        const int rc = pthread_create(&_tid, nullptr, sampling_thread, this);
         if (rc != 0) {
             LOG(FATAL) << "Fail to create sampling_thread, " << berror(rc);
         } else {
             _created = true;
             if (!registered_atfork) {
                 registered_atfork = true;
-                pthread_atfork(NULL, NULL, child_callback_atfork);
+                pthread_atfork(nullptr, nullptr, child_callback_atfork);
             }
         }
     }
@@ -111,7 +111,7 @@ private:
     static void* sampling_thread(void* arg) {
         butil::PlatformThread::SetNameSimple("bvar_sampler");
         static_cast<SamplerCollector*>(arg)->run();
-        return NULL;
+        return nullptr;
     }
 
     static double get_cumulated_time(void* arg) {
@@ -126,8 +126,8 @@ private:
 };
 
 #ifndef UNIT_TEST
-static PassiveStatus<double>* s_cumulated_time_bvar = NULL;
-static bvar::PerSecond<bvar::PassiveStatus<double> >* s_sampling_thread_usage_bvar = NULL;
+static PassiveStatus<double>* s_cumulated_time_bvar = nullptr;
+static bvar::PerSecond<bvar::PassiveStatus<double> >* s_sampling_thread_usage_bvar = nullptr;
 #endif
 
 DEFINE_int32(bvar_sampler_thread_start_delay_us, 10000, "bvar sampler thread start delay us");
@@ -141,11 +141,11 @@ void SamplerCollector::run() {
     //   may be abandoned at any time after forking.
     // * They can't created inside the constructor of SamplerCollector as well,
     //   which results in deadlock.
-    if (s_cumulated_time_bvar == NULL) {
+    if (s_cumulated_time_bvar == nullptr) {
         s_cumulated_time_bvar =
             new PassiveStatus<double>(get_cumulated_time, this);
     }
-    if (s_sampling_thread_usage_bvar == NULL) {
+    if (s_sampling_thread_usage_bvar == nullptr) {
         s_sampling_thread_usage_bvar =
             new bvar::PerSecond<bvar::PassiveStatus<double> >(
                     "bvar_sampler_collector_usage", s_cumulated_time_bvar, 10);

--- a/src/bvar/detail/sampler.h
+++ b/src/bvar/detail/sampler.h
@@ -108,7 +108,7 @@ public:
                 std::max(_q.capacity() * 2, (size_t)_window_size + 1);
             const size_t memsize = sizeof(Sample<T>) * new_cap;
             void* mem = malloc(memsize);
-            if (NULL == mem) {
+            if (nullptr == mem) {
                 return;
             }
             butil::BoundedQueue<Sample<T> > new_q(
@@ -151,7 +151,7 @@ public:
             return false;
         }
         Sample<T>* oldest = _q.bottom(window_size);
-        if (NULL == oldest) {
+        if (nullptr == oldest) {
             oldest = _q.top();
         }
         Sample<T>* latest = _q.bottom();
@@ -199,7 +199,7 @@ public:
             return;
         }
         Sample<T>* oldest = _q.bottom(window_size);
-        if (NULL == oldest) {
+        if (nullptr == oldest) {
             oldest = _q.top();
         }
         for (int i = 1; true; ++i) {

--- a/src/bvar/detail/series.h
+++ b/src/bvar/detail/series.h
@@ -105,7 +105,7 @@ public:
         , _nminute(0)
         , _nhour(0)
         , _nday(0) {
-        pthread_mutex_init(&_mutex, NULL);
+        pthread_mutex_init(&_mutex, nullptr);
     }
     ~SeriesBase() {
         pthread_mutex_destroy(&_mutex);
@@ -230,7 +230,7 @@ public:
 template <typename T, typename Op>
 void Series<T, Op>::describe(std::ostream& os,
                              const std::string* vector_names) const {
-    CHECK(vector_names == NULL);
+    CHECK(vector_names == nullptr);
     pthread_mutex_lock(&this->_mutex);
     const int second_begin = this->_nsecond;
     const int minute_begin = this->_nminute;

--- a/src/bvar/gflag.cpp
+++ b/src/bvar/gflag.cpp
@@ -65,11 +65,11 @@ void GFlag::get_value(boost::any* value) const {
         *value = static_cast<int64_t>(atoll(info.current_value.c_str()));
     } else if (info.type == "uint64") {
         *value = static_cast<uint64_t>(
-            strtoull(info.current_value.c_str(), NULL, 10));
+            strtoull(info.current_value.c_str(), nullptr, 10));
     } else if (info.type == "bool") {
         *value = (info.current_value == "true");
     } else if (info.type == "double") {
-        *value = strtod(info.current_value.c_str(), NULL);
+        *value = strtod(info.current_value.c_str(), nullptr);
     } else {
         *value = "Unknown type=" + info.type + " of gflag=" + gflag_name();
     }

--- a/src/bvar/latency_recorder.cpp
+++ b/src/bvar/latency_recorder.cpp
@@ -55,7 +55,7 @@ void CDF::describe(std::ostream& os, bool) const {
 
 int CDF::describe_series(
     std::ostream& os, const SeriesOptions& options) const {
-    if (_w == NULL) {
+    if (_w == nullptr) {
         return 1;
     }
     if (options.test_only) {

--- a/src/bvar/multi_dimension.h
+++ b/src/bvar/multi_dimension.h
@@ -104,7 +104,7 @@ public:
     }
 
     // Get real bvar pointer object
-    // Return real bvar pointer on success, NULL otherwise.
+    // Return real bvar pointer on success, nullptr otherwise.
     // K requirements:
     // 1. K must be a container type with iterator,
     //    e.g. std::vector, std::list, std::set, std::array.
@@ -143,7 +143,7 @@ public:
     
 #ifdef UNIT_TEST
     // Get real bvar pointer object 
-    // Return real bvar pointer if labels_name exist, NULL otherwise.
+    // Return real bvar pointer if labels_name exist, nullptr otherwise.
     // CAUTION!!! Just For Debug!!!
     template <typename K = key_type>
     value_ptr_type get_stats_read_only(const K& labels_value) {
@@ -154,7 +154,7 @@ public:
     // Return real bvar pointer if labels_name exist, otherwise(not exist) create bvar pointer.
     // CAUTION!!! Just For Debug!!!
     template <typename K = key_type>
-    value_ptr_type get_stats_read_or_insert(const K& labels_value, bool* do_write = NULL) {
+    value_ptr_type get_stats_read_or_insert(const K& labels_value, bool* do_write = nullptr) {
         return get_stats_impl(labels_value, READ_OR_INSERT, do_write);
     }
 #endif
@@ -165,7 +165,7 @@ private:
 
     template <typename K>
     value_ptr_type get_stats_impl(
-        const K& labels_value, STATS_OP stats_op, bool* do_write = NULL);
+        const K& labels_value, STATS_OP stats_op, bool* do_write = nullptr);
 
     template <typename K>
     static typename std::enable_if<butil::is_same<K, key_type>::value>::type

--- a/src/bvar/multi_dimension_inl.h
+++ b/src/bvar/multi_dimension_inl.h
@@ -88,7 +88,7 @@ void MultiDimension<T, KeyType, Shared>::delete_stats(const K& labels_value) {
         // we need to use an empty tmp_metric, get the deleted value of
         // second copy into tmp_metric, which can prevent the bvar object
         // from being deleted twice.
-        op_value_type tmp_metric = NULL;
+        op_value_type tmp_metric = nullptr;
         auto erase_fn = [&labels_value, &tmp_metric](MetricMap& bg) {
             return bg.erase(labels_value, &tmp_metric);
         };
@@ -123,7 +123,7 @@ void MultiDimension<T, KeyType, Shared>::delete_stats() {
 
 template <typename T, typename KeyType, bool Shared>
 void MultiDimension<T, KeyType, Shared>::list_stats(std::vector<key_type>* names) {
-    if (names == NULL) {
+    if (names == nullptr) {
         return;
     }
     names->clear();
@@ -143,17 +143,17 @@ template <typename K>
 typename MultiDimension<T, KeyType, Shared>::value_ptr_type
 MultiDimension<T, KeyType, Shared>::get_stats_impl(const K& labels_value) {
     if (!is_valid_lables_value(labels_value)) {
-        return NULL;
+        return nullptr;
     }
     MetricMapScopedPtr metric_map_ptr;
     if (_metric_map.Read(&metric_map_ptr) != 0) {
         LOG(ERROR) << "Fail to read dbd";
-        return NULL;
+        return nullptr;
     }
 
     auto it = metric_map_ptr->seek(labels_value);
-    if (NULL == it) {
-        return NULL;
+    if (nullptr == it) {
+        return nullptr;
     }
     return (*it);
 }
@@ -164,36 +164,36 @@ typename MultiDimension<T, KeyType, Shared>::value_ptr_type
 MultiDimension<T, KeyType, Shared>::get_stats_impl(
     const K& labels_value, STATS_OP stats_op, bool* do_write) {
     if (!is_valid_lables_value(labels_value)) {
-        return NULL;
+        return nullptr;
     }
     {
         MetricMapScopedPtr metric_map_ptr;
         if (0 != _metric_map.Read(&metric_map_ptr)) {
             LOG(ERROR) << "Fail to read dbd";
-            return NULL;
+            return nullptr;
         }
 
         auto it = metric_map_ptr->seek(labels_value);
-        if (NULL != it) {
+        if (nullptr != it) {
             return (*it);
         } else if (READ_ONLY == stats_op) {
-            return NULL;
+            return nullptr;
         }
 
         if (metric_map_ptr->size() > _max_stats_count) {
             LOG(ERROR) << "Too many stats seen, overflow detected, max stats count="
                        << _max_stats_count;
-            return NULL;
+            return nullptr;
         }
     }
 
     // Because DBD has two copies(foreground and background) MetricMap, both copies need to be modified,
     // In order to avoid new duplicate bvar object, need use cache_metric to cache the new bvar object,
     // In this way, when modifying the second copy, can directly use the cache_metric bvar object.
-    op_value_type cache_metric = NULL;
+    op_value_type cache_metric = nullptr;
     auto insert_fn = [this, &labels_value, &cache_metric, &do_write](MetricMap& bg) {
         auto bg_metric = bg.seek(labels_value);
-        if (NULL != bg_metric) {
+        if (nullptr != bg_metric) {
             cache_metric = *bg_metric;
             return 0;
         }
@@ -201,7 +201,7 @@ MultiDimension<T, KeyType, Shared>::get_stats_impl(
             *do_write = true;
         }
 
-        if (NULL == cache_metric) {
+        if (nullptr == cache_metric) {
             cache_metric = new_value();
         }
         insert_metrics_map(bg, labels_value, cache_metric);
@@ -219,7 +219,7 @@ void MultiDimension<T, KeyType, Shared>::clear_stats() {
 template <typename T, typename KeyType, bool Shared>
 template <typename K>
 bool MultiDimension<T, KeyType, Shared>::has_stats(const K& labels_value) {
-    return get_stats_impl(labels_value) != NULL;
+    return get_stats_impl(labels_value) != nullptr;
 }
 
 template <typename T, typename KeyType, bool Shared>
@@ -234,7 +234,7 @@ MultiDimension<T, KeyType, Shared>::dump_impl(Dumper* dumper, const DumpOptions*
     size_t n = 0;
     for (auto &label_name : label_names) {
         value_ptr_type bvar = get_stats_impl(label_name);
-        if (NULL == bvar) {
+        if (nullptr == bvar) {
             continue;
         }
         std::ostringstream oss;
@@ -303,7 +303,7 @@ MultiDimension<T, KeyType, Shared>::dump_impl(Dumper* dumper, const DumpOptions*
     dumper->dump_comment(this->name() + "_max_latency", METRIC_TYPE_GAUGE);
     for (auto &label_name : label_names) {
         LatencyRecorder* bvar = get_stats_impl(label_name);
-        if (NULL == bvar) {
+        if (nullptr == bvar) {
             continue;
         }
         std::ostringstream oss_max_latency_key;
@@ -317,7 +317,7 @@ MultiDimension<T, KeyType, Shared>::dump_impl(Dumper* dumper, const DumpOptions*
     dumper->dump_comment(this->name() + "_qps", METRIC_TYPE_GAUGE);
     for (auto &label_name : label_names) {
         LatencyRecorder* bvar = get_stats_impl(label_name);
-        if (NULL == bvar) {
+        if (nullptr == bvar) {
             continue;
         }
         std::ostringstream oss_qps_key;
@@ -331,7 +331,7 @@ MultiDimension<T, KeyType, Shared>::dump_impl(Dumper* dumper, const DumpOptions*
     dumper->dump_comment(this->name() + "_count", METRIC_TYPE_COUNTER);
     for (auto &label_name : label_names) {
         LatencyRecorder* bvar = get_stats_impl(label_name);
-        if (NULL == bvar) {
+        if (nullptr == bvar) {
             continue;
         }
         std::ostringstream oss_count_key;

--- a/src/bvar/mvariable.cpp
+++ b/src/bvar/mvariable.cpp
@@ -71,7 +71,7 @@ BUTIL_VALIDATE_GFLAG(max_multi_dimension_stats_count,
 
 class MVarEntry {
 public:
-    MVarEntry() : var(NULL) {}
+    MVarEntry() : var(nullptr) {}
 
     MVariableBase* var;
 };
@@ -85,14 +85,14 @@ struct MVarMapWithLock : public MVarMap {
         if (init(256) != 0) {
             LOG(WARNING) << "Fail to init";
         }
-        pthread_mutex_init(&mutex, NULL);
+        pthread_mutex_init(&mutex, nullptr);
     }
 };
 
 // We have to initialize global map on need because bvar is possibly used
 // before main().
 static pthread_once_t s_mvar_map_once = PTHREAD_ONCE_INIT;
-static MVarMapWithLock* s_mvar_map = NULL;
+static MVarMapWithLock* s_mvar_map = nullptr;
 
 static void init_mvar_map() {
     // It's probably slow to initialize all sub maps, but rpc often expose 
@@ -121,7 +121,7 @@ int MVariableBase::describe_exposed(const std::string& name,
     MVarMapWithLock& m = get_mvar_map();
     BAIDU_SCOPED_LOCK(m.mutex);
     MVarEntry* entry = m.seek(name);
-    if (entry == NULL) {
+    if (entry == nullptr) {
         return -1;
     }
     entry->var->describe(os);
@@ -172,7 +172,7 @@ int MVariableBase::expose_impl(const butil::StringPiece& prefix,
     {
         BAIDU_SCOPED_LOCK(m.mutex);
         MVarEntry* entry = m.seek(_name);
-        if (entry == NULL) {
+        if (entry == nullptr) {
             entry = &m[_name];
             entry->var = this;
             return 0;
@@ -226,7 +226,7 @@ size_t MVariableBase::count_exposed() {
 }
 
 void MVariableBase::list_exposed(std::vector<std::string>* names) {
-    if (names == NULL) {
+    if (names == nullptr) {
         return;
     }
 
@@ -241,8 +241,8 @@ void MVariableBase::list_exposed(std::vector<std::string>* names) {
 }
 
 size_t MVariableBase::dump_exposed(Dumper* dumper, const DumpOptions* options) {
-    if (NULL == dumper) {
-        LOG(ERROR) << "Parameter[dumper] is NULL";
+    if (nullptr == dumper) {
+        LOG(ERROR) << "Parameter[dumper] is nullptr";
         return -1;
     }
     DumpOptions opt;

--- a/src/bvar/mvariable.h
+++ b/src/bvar/mvariable.h
@@ -80,7 +80,7 @@ public:
 
     // Find all exposed mvariables matching `white_wildcards' but
     // `black_wildcards' and send them to `dumper'.
-    // Use default options when `options' is NULL.
+    // Use default options when `options' is nullptr.
     // Return number of dumped mvariables, -1 on error.
     static size_t dump_exposed(Dumper* dumper, const DumpOptions* options);
 

--- a/src/bvar/passive_status.h
+++ b/src/bvar/passive_status.h
@@ -55,14 +55,14 @@ public:
         typedef typename butil::conditional<
         ADDITIVE, detail::AddTo<Tp>, PlaceHolderOp>::type Op;
         explicit SeriesSampler(PassiveStatus* owner)
-            : _owner(owner), _vector_names(NULL), _series(Op()) {}
+            : _owner(owner), _vector_names(nullptr), _series(Op()) {}
         ~SeriesSampler() {
             delete _vector_names;
         }
         void take_sample() override { _series.append(_owner->get_value()); }
         void describe(std::ostream& os) { _series.describe(os, _vector_names); }
         void set_vector_names(const std::string& names) {
-            if (_vector_names == NULL) {
+            if (_vector_names == nullptr) {
                 _vector_names = new std::string;
             }
             *_vector_names = names;
@@ -80,8 +80,8 @@ public:
                   Tp (*getfn)(void*), void* arg)
         : _getfn(getfn)
         , _arg(arg)
-        , _sampler(NULL)
-        , _series_sampler(NULL) {
+        , _sampler(nullptr)
+        , _series_sampler(nullptr) {
         expose(name);
     }
     
@@ -90,27 +90,27 @@ public:
                   Tp (*getfn)(void*), void* arg)
         : _getfn(getfn)
         , _arg(arg)
-        , _sampler(NULL)
-        , _series_sampler(NULL) {
+        , _sampler(nullptr)
+        , _series_sampler(nullptr) {
         expose_as(prefix, name);
     }
     
     PassiveStatus(Tp (*getfn)(void*), void* arg) 
         : _getfn(getfn)
         , _arg(arg)
-        , _sampler(NULL)
-        , _series_sampler(NULL) {
+        , _sampler(nullptr)
+        , _series_sampler(nullptr) {
     }
 
     ~PassiveStatus() {
         hide();
         if (_sampler) {
             _sampler->destroy();
-            _sampler = NULL;
+            _sampler = nullptr;
         }
         if (_series_sampler) {
             _series_sampler->destroy();
-            _series_sampler = NULL;
+            _series_sampler = nullptr;
         }
     }
     
@@ -141,7 +141,7 @@ public:
     }
     
     sampler_type* get_sampler() {
-        if (NULL == _sampler) {
+        if (nullptr == _sampler) {
             _sampler = new sampler_type(this);
             _sampler->schedule();
         }
@@ -152,7 +152,7 @@ public:
     detail::MinusFrom<Tp> inv_op() const { return detail::MinusFrom<Tp>(); }
 
     int describe_series(std::ostream& os, const SeriesOptions& options) const override {
-        if (_series_sampler == NULL) {
+        if (_series_sampler == nullptr) {
             return 1;
         }
         if (!options.test_only) {
@@ -173,7 +173,7 @@ protected:
         const int rc = Variable::expose_impl(prefix, name, display_filter);
         if (ADDITIVE &&
             rc == 0 &&
-            _series_sampler == NULL &&
+            _series_sampler == nullptr &&
             FLAGS_save_series) {
             _series_sampler = new SeriesSampler(this);
             _series_sampler->schedule();

--- a/src/bvar/recorder.h
+++ b/src/bvar/recorder.h
@@ -124,7 +124,7 @@ public:
     typedef typename combiner_type::self_shared_type shared_combiner_type;
     typedef combiner_type::Agent agent_type;
 
-    IntRecorder() : _combiner(std::make_shared<combiner_type>()), _sampler(NULL) {}
+    IntRecorder() : _combiner(std::make_shared<combiner_type>()), _sampler(nullptr) {}
 
     IntRecorder(const butil::StringPiece& name) : IntRecorder() {
         expose(name);
@@ -139,7 +139,7 @@ public:
         hide();
         if (_sampler) {
             _sampler->destroy();
-            _sampler = NULL;
+            _sampler = nullptr;
         }
     }
 
@@ -172,7 +172,7 @@ public:
     bool valid() const { return _combiner->valid(); }
     
     sampler_type* get_sampler() {
-        if (NULL == _sampler) {
+        if (nullptr == _sampler) {
             _sampler = new sampler_type(this);
             _sampler->schedule();
         }
@@ -246,7 +246,7 @@ private:
 
 inline IntRecorder& IntRecorder::operator<<(int64_t sample) {
     if (BAIDU_UNLIKELY((int64_t)(int)sample != sample)) {
-        const char* reason = NULL;
+        const char* reason = nullptr;
         if (sample > std::numeric_limits<int>::max()) {
             reason = "overflows";
             sample = std::numeric_limits<int>::max();
@@ -308,7 +308,7 @@ public:
 
     ~IntRecorder() override {
         hide();
-        if (NULL != _sampler) {
+        if (nullptr != _sampler) {
             _sampler->destroy();
         }
     }
@@ -316,7 +316,7 @@ public:
     // Note: The input type is acutally int. Use int64_t to check overflow.
     IntRecorder& operator<<(int64_t value) {
         if (BAIDU_UNLIKELY((int64_t)(int)value != value)) {
-            const char* reason = NULL;
+            const char* reason = nullptr;
             if (value > std::numeric_limits<int>::max()) {
                 reason = "overflows";
                 value = std::numeric_limits<int>::max();
@@ -370,7 +370,7 @@ public:
     bool valid() const { return true; }
 
     sampler_type* get_sampler() {
-        if (NULL == _sampler) {
+        if (nullptr == _sampler) {
             _sampler = new sampler_type(this);
             _sampler->schedule();
         }
@@ -384,7 +384,7 @@ public:
     }
 private:
     babylon::ConcurrentSummer _summer;
-    sampler_type* _sampler{NULL};
+    sampler_type* _sampler{nullptr};
     std::string _debug_name;
 };
 #endif // WITH_BABYLON_COUNTER

--- a/src/bvar/reducer.h
+++ b/src/bvar/reducer.h
@@ -42,7 +42,7 @@ public:
     SeriesSamplerImpl(O* owner, const Op& op)
         : _owner(owner), _series(op) {}
     void take_sample() override { _series.append(_owner->get_value()); }
-    void describe(std::ostream& os) { _series.describe(os, NULL); }
+    void describe(std::ostream& os) { _series.describe(os, nullptr); }
 
 private:
     O* _owner;
@@ -70,10 +70,10 @@ public:
 
     ~BabylonVariable() override {
         hide();
-        if (NULL != _sampler) {
+        if (nullptr != _sampler) {
             _sampler->destroy();
         }
-        if (NULL != _series_sampler) {
+        if (nullptr != _series_sampler) {
             _series_sampler->destroy();
         }
     }
@@ -84,7 +84,7 @@ public:
     }
 
     sampler_type* get_sampler() {
-        if (NULL == _sampler) {
+        if (nullptr == _sampler) {
             _sampler = new sampler_type(this);
             _sampler->schedule();
         }
@@ -122,7 +122,7 @@ public:
     }
 
     int describe_series(std::ostream& os, const SeriesOptions& options) const override {
-        if (NULL == _series_sampler) {
+        if (nullptr == _series_sampler) {
             return 1;
         }
         if (!options.test_only) {
@@ -136,7 +136,7 @@ protected:
                     const butil::StringPiece& name,
                     DisplayFilter display_filter) override {
         const int rc = Variable::expose_impl(prefix, name, display_filter);
-        if (rc == 0 && NULL == _series_sampler &&
+        if (rc == 0 && nullptr == _series_sampler &&
             !butil::is_same<InvOp, VoidOp>::value &&
             !butil::is_same<T, std::string>::value &&
             FLAGS_save_series) {
@@ -148,8 +148,8 @@ protected:
 
 private:
     Counter _counter;
-    sampler_type* _sampler{NULL};
-    series_sampler_type* _series_sampler{NULL};
+    sampler_type* _sampler{nullptr};
+    series_sampler_type* _series_sampler{nullptr};
     Op _op;
     InvOp _inv_op;
 };
@@ -202,18 +202,18 @@ public:
     explicit Reducer(typename butil::add_cr_non_integral<T>::type identity = T(),
                      const Op& op = Op(), const InvOp& inv_op = InvOp())
         : _combiner(std::make_shared<combiner_type>(identity, identity, op))
-        , _sampler(NULL) , _series_sampler(NULL) , _inv_op(inv_op) {}
+        , _sampler(nullptr) , _series_sampler(nullptr) , _inv_op(inv_op) {}
 
     ~Reducer() override {
         // Calling hide() manually is a MUST required by Variable.
         hide();
         if (_sampler) {
             _sampler->destroy();
-            _sampler = NULL;
+            _sampler = nullptr;
         }
         if (_series_sampler) {
             _series_sampler->destroy();
-            _series_sampler = NULL;
+            _series_sampler = nullptr;
         }
     }
 
@@ -225,7 +225,7 @@ public:
     // Notice that this function walks through threads that ever add values
     // into this reducer. You should avoid calling it frequently.
     T get_value() const {
-        CHECK(!(butil::is_same<InvOp, detail::VoidOp>::value) || _sampler == NULL)
+        CHECK(!(butil::is_same<InvOp, detail::VoidOp>::value) || _sampler == nullptr)
             << "You should not call Reducer<" << butil::class_name_str<T>()
             << ", " << butil::class_name_str<Op>() << ">::get_value() when a"
             << " Window<> is used because the operator does not have inverse.";
@@ -257,7 +257,7 @@ public:
     const InvOp& inv_op() const { return _inv_op; }
     
     sampler_type* get_sampler() {
-        if (NULL == _sampler) {
+        if (nullptr == _sampler) {
             _sampler = new sampler_type(this);
             _sampler->schedule();
         }
@@ -265,7 +265,7 @@ public:
     }
 
     int describe_series(std::ostream& os, const SeriesOptions& options) const override {
-        if (_series_sampler == NULL) {
+        if (_series_sampler == nullptr) {
             return 1;
         }
         if (!options.test_only) {
@@ -280,7 +280,7 @@ protected:
                     DisplayFilter display_filter) override {
         const int rc = Variable::expose_impl(prefix, name, display_filter);
         if (rc == 0 &&
-            _series_sampler == NULL &&
+            _series_sampler == nullptr &&
             !butil::is_same<InvOp, detail::VoidOp>::value &&
             !butil::is_same<T, std::string>::value &&
             FLAGS_save_series) {

--- a/src/bvar/status.h
+++ b/src/bvar/status.h
@@ -98,29 +98,29 @@ public:
         explicit SeriesSampler(Status* owner)
             : _owner(owner), _series(Op()) {}
         void take_sample() { _series.append(_owner->get_value()); }
-        void describe(std::ostream& os) { _series.describe(os, NULL); }
+        void describe(std::ostream& os) { _series.describe(os, nullptr); }
     private:
         Status* _owner;
         detail::Series<T, Op> _series;
     };
 
 public:
-    Status() : _series_sampler(NULL) {}
-    Status(const T& value) : _value(value), _series_sampler(NULL) { }
+    Status() : _series_sampler(nullptr) {}
+    Status(const T& value) : _value(value), _series_sampler(nullptr) { }
     Status(const butil::StringPiece& name, const T& value)
-        : _value(value), _series_sampler(NULL) {
+        : _value(value), _series_sampler(nullptr) {
         this->expose(name);
     }
     Status(const butil::StringPiece& prefix,
            const butil::StringPiece& name, const T& value)
-        : _value(value), _series_sampler(NULL) {
+        : _value(value), _series_sampler(nullptr) {
         this->expose_as(prefix, name);
     }
     ~Status() {
         hide();
         if (_series_sampler) {
             _series_sampler->destroy();
-            _series_sampler = NULL;
+            _series_sampler = nullptr;
         }
     }
 
@@ -143,7 +143,7 @@ public:
     }
 
     int describe_series(std::ostream& os, const SeriesOptions& options) const override {
-        if (_series_sampler == NULL) {
+        if (_series_sampler == nullptr) {
             return 1;
         }
         if (!options.test_only) {
@@ -158,7 +158,7 @@ protected:
                     DisplayFilter display_filter) override {
         const int rc = Variable::expose_impl(prefix, name, display_filter);
         if (rc == 0 &&
-            _series_sampler == NULL &&
+            _series_sampler == nullptr &&
             FLAGS_save_series) {
             _series_sampler = new SeriesSampler(this);
             _series_sampler->schedule();

--- a/src/bvar/utils/lock_timer.h
+++ b/src/bvar/utils/lock_timer.h
@@ -119,11 +119,11 @@ template <>
 struct MutexConstructor<pthread_mutex_t> {
     bool operator()(pthread_mutex_t* mutex) const { 
 #ifndef NDEBUG
-        const int rc = pthread_mutex_init(mutex, NULL);
+        const int rc = pthread_mutex_init(mutex, nullptr);
         CHECK_EQ(0, rc) << "Fail to init pthread_mutex, " << berror(rc);
         return rc == 0;
 #else
-        return pthread_mutex_init(mutex, NULL) == 0;
+        return pthread_mutex_init(mutex, nullptr) == 0;
 #endif
     }
 };
@@ -158,7 +158,7 @@ public:
         MCtor()(&_mutex);
     }
 
-    MutexWithRecorderBase() : _recorder(NULL) {
+    MutexWithRecorderBase() : _recorder(nullptr) {
         MCtor()(&_mutex);
     }
 
@@ -275,7 +275,7 @@ public:
             *_mutex << _timer.u_elapsed();
         }
         mutex_type* saved_mutex = _mutex;
-        _mutex = NULL;
+        _mutex = nullptr;
         _lock.release();
         return saved_mutex;
     }

--- a/src/bvar/variable.cpp
+++ b/src/bvar/variable.cpp
@@ -64,7 +64,7 @@ BAIDU_CASSERT(!(SUB_MAP_COUNT & (SUB_MAP_COUNT - 1)), must_be_power_of_2);
 
 class VarEntry {
 public:
-    VarEntry() : var(NULL), display_filter(DISPLAY_ON_ALL) {}
+    VarEntry() : var(nullptr), display_filter(DISPLAY_ON_ALL) {}
 
     Variable* var;
     DisplayFilter display_filter;
@@ -91,7 +91,7 @@ struct VarMapWithLock : public VarMap {
 // We have to initialize global map on need because bvar is possibly used
 // before main().
 static pthread_once_t s_var_maps_once = PTHREAD_ONCE_INIT;
-static VarMapWithLock* s_var_maps = NULL;
+static VarMapWithLock* s_var_maps = nullptr;
 
 static void init_var_maps() {
     // It's probably slow to initialize all sub maps, but rpc often expose 
@@ -158,7 +158,7 @@ int Variable::expose_impl(const butil::StringPiece& prefix,
     {
         BAIDU_SCOPED_LOCK(m.mutex);
         VarEntry* entry = m.seek(_name);
-        if (entry == NULL) {
+        if (entry == nullptr) {
             entry = &m[_name];
             entry->var = this;
             entry->display_filter = display_filter;
@@ -202,7 +202,7 @@ bool Variable::hide() {
 
 void Variable::list_exposed(std::vector<std::string>* names,
                             DisplayFilter display_filter) {
-    if (names == NULL) {
+    if (names == nullptr) {
         return;
     }
     names->clear();
@@ -251,7 +251,7 @@ int Variable::describe_exposed(const std::string& name, std::ostream& os,
     VarMapWithLock& m = get_var_map(name);
     BAIDU_SCOPED_LOCK(m.mutex);
     VarEntry* p = m.seek(name);
-    if (p == NULL) {
+    if (p == nullptr) {
         return -1;
     }
     if (!(display_filter & p->display_filter)) {
@@ -291,7 +291,7 @@ int Variable::describe_series_exposed(const std::string& name,
     VarMapWithLock& m = get_var_map(name);
     BAIDU_SCOPED_LOCK(m.mutex);
     VarEntry* p = m.seek(name);
-    if (p == NULL) {
+    if (p == nullptr) {
         return -1;
     }
     return p->var->describe_series(os, options);
@@ -302,7 +302,7 @@ int Variable::get_exposed(const std::string& name, boost::any* value) {
     VarMapWithLock& m = get_var_map(name);
     BAIDU_SCOPED_LOCK(m.mutex);
     VarEntry* p = m.seek(name);
-    if (p == NULL) {
+    if (p == nullptr) {
         return -1;
     }
     p->var->get_value(value);
@@ -317,7 +317,7 @@ int Variable::get_exposed(const std::string& name, boost::any* value) {
 // creation of std::string which allocates memory internally.
 class CharArrayStreamBuf : public std::streambuf {
 public:
-    explicit CharArrayStreamBuf() : _data(NULL), _size(0) {}
+    explicit CharArrayStreamBuf() : _data(nullptr), _size(0) {}
     ~CharArrayStreamBuf();
 
     int overflow(int ch) override;
@@ -342,8 +342,8 @@ int CharArrayStreamBuf::overflow(int ch) {
     }
     size_t new_size = std::max(_size * 3 / 2, (size_t)64);
     char* new_data = (char*)malloc(new_size);
-    if (BAIDU_UNLIKELY(new_data == NULL)) {
-        setp(NULL, NULL);
+    if (BAIDU_UNLIKELY(new_data == nullptr)) {
+        setp(nullptr, nullptr);
         return std::streambuf::traits_type::eof();
     }
     memcpy(new_data, _data, _size);
@@ -370,8 +370,8 @@ void CharArrayStreamBuf::reset() {
 // Written by Jack Handy
 // <A href="mailto:jakkhandy@hotmail.com">jakkhandy@hotmail.com</A>
 inline bool wildcmp(const char* wild, const char* str, char question_mark) {
-    const char* cp = NULL;
-    const char* mp = NULL;
+    const char* cp = nullptr;
+    const char* mp = nullptr;
 
     while (*str && *wild != '*') {
         if (*wild != *str && *wild != question_mark) {
@@ -416,7 +416,7 @@ public:
         std::string name;
         const char wc_pattern[3] = { '*', question_mark, '\0' };
         for (butil::StringMultiSplitter sp(wildcards.c_str(), ",;");
-             sp != NULL; ++sp) {
+             sp != nullptr; ++sp) {
             name.assign(sp.field(), sp.length());
             if (name.find_first_of(wc_pattern) != std::string::npos) {
                 if (_wcs.empty()) {
@@ -462,8 +462,8 @@ DumpOptions::DumpOptions()
 {}
 
 int Variable::dump_exposed(Dumper* dumper, const DumpOptions* poptions) {
-    if (NULL == dumper) {
-        LOG(ERROR) << "Parameter[dumper] is NULL";
+    if (nullptr == dumper) {
+        LOG(ERROR) << "Parameter[dumper] is nullptr";
         return -1;
     }
     DumpOptions opt;
@@ -567,7 +567,7 @@ std::string read_command_name() {
 class FileDumper : public Dumper {
 public:
     FileDumper(const std::string& filename, butil::StringPiece s/*prefix*/)
-        : _filename(filename), _fp(NULL) {
+        : _filename(filename), _fp(nullptr) {
         // setting prefix.
         // remove trailing spaces.
         const char* p = s.data() + s.size();
@@ -588,13 +588,13 @@ public:
     void close() {
         if (_fp) {
             fclose(_fp);
-            _fp = NULL;
+            _fp = nullptr;
         }
     }
 
 protected:
     bool dump_impl(const std::string& name, const butil::StringPiece& desc, const std::string& separator) {
-        if (_fp == NULL) {
+        if (_fp == nullptr) {
             butil::File::Error error;
             butil::FilePath dir = butil::FilePath(_filename).DirName();
             if (!butil::CreateDirectoryAndGetError(dir, &error)) {
@@ -603,7 +603,7 @@ protected:
                 return false;
             }
             _fp = fopen(_filename.c_str(), "w");
-            if (NULL == _fp) {
+            if (nullptr == _fp) {
                 LOG(ERROR) << "Fail to open " << _filename;
                 return false;
             }
@@ -668,7 +668,7 @@ public:
         }
         dumpers.emplace_back(
                     new CommonFileDumper(path.AddExtension("data").value(), s), 
-                    (WildcardMatcher *)NULL);
+                    (WildcardMatcher *)nullptr);
     }
     ~FileDumperGroup() {
         for (size_t i = 0; i < dumpers.size(); ++i) {
@@ -745,39 +745,39 @@ static void* dumping_thread(void*) {
         std::string mbvar_format;
         if (!GFLAGS_NAMESPACE::GetCommandLineOption("bvar_dump_file", &filename)) {
             LOG(ERROR) << "Fail to get gflag bvar_dump_file";
-            return NULL;
+            return nullptr;
         }
         if (!GFLAGS_NAMESPACE::GetCommandLineOption("bvar_dump_include",
                                           &options.white_wildcards)) {
             LOG(ERROR) << "Fail to get gflag bvar_dump_include";
-            return NULL;
+            return nullptr;
         }
         if (!GFLAGS_NAMESPACE::GetCommandLineOption("bvar_dump_exclude",
                                           &options.black_wildcards)) {
             LOG(ERROR) << "Fail to get gflag bvar_dump_exclude";
-            return NULL;
+            return nullptr;
         }
         if (!GFLAGS_NAMESPACE::GetCommandLineOption("bvar_dump_prefix", &prefix)) {
             LOG(ERROR) << "Fail to get gflag bvar_dump_prefix";
-            return NULL;
+            return nullptr;
         }
         if (!GFLAGS_NAMESPACE::GetCommandLineOption("bvar_dump_tabs", &tabs)) {
             LOG(ERROR) << "Fail to get gflags bvar_dump_tabs";
-            return NULL;
+            return nullptr;
         }
 
         // We can't access string flags directly because it's thread-unsafe.
         if (!GFLAGS_NAMESPACE::GetCommandLineOption("mbvar_dump_file", &mbvar_filename)) {
             LOG(ERROR) << "Fail to get gflag mbvar_dump_file";
-            return NULL;
+            return nullptr;
         }
         if (!GFLAGS_NAMESPACE::GetCommandLineOption("mbvar_dump_prefix", &mbvar_prefix)) {
             LOG(ERROR) << "Fail to get gflag mbvar_dump_prefix";
-            return NULL;
+            return nullptr;
         }
         if (!GFLAGS_NAMESPACE::GetCommandLineOption("mbvar_dump_format", &mbvar_format)) {
             LOG(ERROR) << "Fail to get gflag mbvar_dump_format";
-            return NULL;
+            return nullptr;
         }
 
         if (FLAGS_bvar_dump && !filename.empty()) {
@@ -827,7 +827,7 @@ static void* dumping_thread(void*) {
                 mbvar_prefix.replace(pos2, 5/*<app>*/, command_name);
             }
 
-            Dumper* dumper = NULL;
+            Dumper* dumper = nullptr;
             if ("common" == mbvar_format) {
                 dumper = new CommonFileDumper(mbvar_filename, mbvar_prefix);
             } else if ("prometheus" == mbvar_format) {
@@ -838,7 +838,7 @@ static void* dumping_thread(void*) {
                 LOG(ERROR) << "Fail to dump mvars into " << filename;
             }
             delete dumper;
-            dumper = NULL;
+            dumper = nullptr;
         }
 
         // We need to separate the sleeping into a long interruptible sleep
@@ -861,7 +861,7 @@ static void* dumping_thread(void*) {
 
 static void launch_dumping_thread() {
     pthread_t thread_id;
-    int rc = pthread_create(&thread_id, NULL, dumping_thread, NULL);
+    int rc = pthread_create(&thread_id, nullptr, dumping_thread, nullptr);
     if (rc != 0) {
         LOG(FATAL) << "Fail to launch dumping thread: " << berror(rc);
         return;

--- a/src/bvar/variable.h
+++ b/src/bvar/variable.h
@@ -223,7 +223,7 @@ public:
 
     // Find all exposed variables matching `white_wildcards' but
     // `black_wildcards' and send them to `dumper'.
-    // Use default options when `options' is NULL.
+    // Use default options when `options' is nullptr.
     // Return number of dumped variables, -1 on error.
     static int dump_exposed(Dumper* dumper, const DumpOptions* options);
 

--- a/src/bvar/window.h
+++ b/src/bvar/window.h
@@ -70,7 +70,7 @@ public:
                 _series.append(_owner->get_value());
             }
         }
-        void describe(std::ostream& os) { _series.describe(os, NULL); }
+        void describe(std::ostream& os) { _series.describe(os, nullptr); }
     private:
         WindowBase* _owner;
         detail::Series<value_type, Op> _series;
@@ -80,7 +80,7 @@ public:
         : _var(var)
         , _window_size(window_size > 0 ? window_size : FLAGS_bvar_dump_interval)
         , _sampler(var->get_sampler())
-        , _series_sampler(NULL) {
+        , _series_sampler(nullptr) {
         CHECK_EQ(0, _sampler->set_window_size(_window_size));
     }
     
@@ -88,7 +88,7 @@ public:
         hide();
         if (_series_sampler) {
             _series_sampler->destroy();
-            _series_sampler = NULL;
+            _series_sampler = nullptr;
         }
     }
 
@@ -125,7 +125,7 @@ public:
     time_t window_size() const { return _window_size; }
 
     int describe_series(std::ostream& os, const SeriesOptions& options) const override {
-        if (_series_sampler == NULL) {
+        if (_series_sampler == nullptr) {
             return 1;
         }
         if (!options.test_only) {
@@ -146,7 +146,7 @@ protected:
                     DisplayFilter display_filter) override {
         const int rc = Variable::expose_impl(prefix, name, display_filter);
         if (rc == 0 &&
-            _series_sampler == NULL &&
+            _series_sampler == nullptr &&
             FLAGS_save_series) {
             _series_sampler = new SeriesSampler(this, _var);
             _series_sampler->schedule();


### PR DESCRIPTION
  ### What problem does this PR solve?

  Issue Number: resolve N/A

  Problem Summary:

  `src/bvar` still used the legacy `NULL` macro for pointer null values. Since bRPC already builds with at least C++11, using `nullptr` is clearer and type-safe,  especially in overloaded calls and pointer comparisons.

  ### What is changed and the side effects?

  Changed:

  - Replaced `NULL` with `nullptr` across `src/bvar` headers and implementation files.
  - Updated related comments that referred to returning `NULL`.
  - Kept the cleanup scoped to bvar sources only.

  Side effects:

  - Performance effects: None expected. This is a source-level modernization with no intended runtime behavior change.

  - Breaking backward compatibility: No. `nullptr` is available under the project’s C++11 baseline.

  ---
  ### Check List:
  - Please make sure your changes are compilable.
    - Verified with `cmake --build build --target brpc-static -j6`.
    - Verified with `git diff --check`.
    - Verified no `NULL` tokens remain in `src/bvar` via `rg '\bNULL\b' src/bvar -g '*.{h,cpp}'`.
  - When providing us with a new feature, it is best to add related tests.
    - Not applicable; this PR does not add a feature or change behavior.
  - Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
