### PR TITLE
bthread: skip signal_task when no worker is waiting

### DIFF
--- a/src/bthread/parking_lot.h
+++ b/src/bthread/parking_lot.h
@@ -24,6 +24,7 @@
 
 #include <gflags/gflags.h>
 #include "butil/atomicops.h"
+#include "bthread/types.h"    // bthread_tag_t
 #include "bthread/sys_futex.h"
 
 namespace bthread {

--- a/src/bthread/parking_lot.h
+++ b/src/bthread/parking_lot.h
@@ -24,22 +24,11 @@
 
 #include <gflags/gflags.h>
 #include "butil/atomicops.h"
-#include "bthread/types.h"    // bthread_tag_t
 #include "bthread/sys_futex.h"
 
 namespace bthread {
 
 DECLARE_bool(parking_lot_no_signal_when_no_waiter);
-
-// Forward declaration
-class TaskControl;
-
-// Out-of-line helpers that forward to TaskControl's per-tag waiter accounting.
-// Defined in task_control.cpp (where TaskControl is complete), so that
-// parking_lot.h can keep TaskControl as an incomplete type and avoid a
-// circular include with task_control.h.
-void parking_lot_waiter_add(TaskControl* tc, bthread_tag_t tag);
-void parking_lot_waiter_sub(TaskControl* tc, bthread_tag_t tag);
 
 // Park idle workers.
 class BAIDU_CACHELINE_ALIGNMENT ParkingLot {
@@ -56,15 +45,7 @@ public:
 
     ParkingLot()
         : _pending_signal(0), _waiter_num(0)
-        , _no_signal_when_no_waiter(FLAGS_parking_lot_no_signal_when_no_waiter)
-        , _tc(nullptr), _tag(0) {}
-
-    // Set TaskControl pointer + owning tag for waiter tracking (called once
-    // during TaskControl::init after the ParkingLot array is constructed).
-    void set_task_control(TaskControl* tc, bthread_tag_t tag) {
-        _tc = tc;
-        _tag = tag;
-    }
+        , _no_signal_when_no_waiter(FLAGS_parking_lot_no_signal_when_no_waiter) {}
 
     // Wake up at most `num_task' workers.
     // Returns #workers woken up.
@@ -84,24 +65,12 @@ public:
     // Wait for tasks.
     // If the `expected_state' does not match, wait() may finish directly.
     void wait(const State& expected_state) {
-        // Track this waiter BEFORE checking state, so that a concurrent
-        // ready_to_run() that calls has_waiting_workers() will see us
-        // even if it races between our state check and futex_wait().
-        // This eliminates the lost-wakeup window.
-        if (_tc) {
-            parking_lot_waiter_add(_tc, _tag);
-        }
         if (_no_signal_when_no_waiter) {
             _waiter_num.fetch_add(1, butil::memory_order_relaxed);
         }
         if (get_state().val != expected_state.val) {
-            // State changed since caller last checked — signal already sent.
-            // Undo the tracking and return without sleeping.
             if (_no_signal_when_no_waiter) {
                 _waiter_num.fetch_sub(1, butil::memory_order_relaxed);
-            }
-            if (_tc) {
-                parking_lot_waiter_sub(_tc, _tag);
             }
             return;
         }
@@ -109,12 +78,9 @@ public:
         if (_no_signal_when_no_waiter) {
             _waiter_num.fetch_sub(1, butil::memory_order_relaxed);
         }
-        if (_tc) {
-            parking_lot_waiter_sub(_tc, _tag);
-        }
     }
 
-    // Wakeup suspended wait() and make them unwaitable ever. 
+    // Wakeup suspended wait() and make them unwaitable ever.
     void stop() {
         _pending_signal.fetch_or(1);
         futex_wake_private(&_pending_signal, 10000);
@@ -128,10 +94,6 @@ private:
     // In busy worker scenarios, signal overhead
     // can be reduced.
     bool _no_signal_when_no_waiter;
-    // TaskControl pointer for waiter tracking (may be NULL before init).
-    TaskControl* _tc;
-    // Owning tag, used to update the per-tag waiter counter in TaskControl.
-    bthread_tag_t _tag;
 };
 
 }  // namespace bthread

--- a/src/bthread/parking_lot.h
+++ b/src/bthread/parking_lot.h
@@ -30,6 +30,16 @@ namespace bthread {
 
 DECLARE_bool(parking_lot_no_signal_when_no_waiter);
 
+// Forward declaration
+class TaskControl;
+
+// Out-of-line helpers that forward to TaskControl's per-tag waiter accounting.
+// Defined in task_control.cpp (where TaskControl is complete), so that
+// parking_lot.h can keep TaskControl as an incomplete type and avoid a
+// circular include with task_control.h.
+void parking_lot_waiter_add(TaskControl* tc, bthread_tag_t tag);
+void parking_lot_waiter_sub(TaskControl* tc, bthread_tag_t tag);
+
 // Park idle workers.
 class BAIDU_CACHELINE_ALIGNMENT ParkingLot {
 public:
@@ -45,7 +55,15 @@ public:
 
     ParkingLot()
         : _pending_signal(0), _waiter_num(0)
-        , _no_signal_when_no_waiter(FLAGS_parking_lot_no_signal_when_no_waiter) {}
+        , _no_signal_when_no_waiter(FLAGS_parking_lot_no_signal_when_no_waiter)
+        , _tc(nullptr), _tag(0) {}
+
+    // Set TaskControl pointer + owning tag for waiter tracking (called once
+    // during TaskControl::init after the ParkingLot array is constructed).
+    void set_task_control(TaskControl* tc, bthread_tag_t tag) {
+        _tc = tc;
+        _tag = tag;
+    }
 
     // Wake up at most `num_task' workers.
     // Returns #workers woken up.
@@ -65,16 +83,33 @@ public:
     // Wait for tasks.
     // If the `expected_state' does not match, wait() may finish directly.
     void wait(const State& expected_state) {
-        if (get_state().val != expected_state.val) {
-            // Fast path, no need to futex_wait.
-            return;
+        // Track this waiter BEFORE checking state, so that a concurrent
+        // ready_to_run() that calls has_waiting_workers() will see us
+        // even if it races between our state check and futex_wait().
+        // This eliminates the lost-wakeup window.
+        if (_tc) {
+            parking_lot_waiter_add(_tc, _tag);
         }
         if (_no_signal_when_no_waiter) {
             _waiter_num.fetch_add(1, butil::memory_order_relaxed);
         }
+        if (get_state().val != expected_state.val) {
+            // State changed since caller last checked — signal already sent.
+            // Undo the tracking and return without sleeping.
+            if (_no_signal_when_no_waiter) {
+                _waiter_num.fetch_sub(1, butil::memory_order_relaxed);
+            }
+            if (_tc) {
+                parking_lot_waiter_sub(_tc, _tag);
+            }
+            return;
+        }
         futex_wait_private(&_pending_signal, expected_state.val, NULL);
         if (_no_signal_when_no_waiter) {
             _waiter_num.fetch_sub(1, butil::memory_order_relaxed);
+        }
+        if (_tc) {
+            parking_lot_waiter_sub(_tc, _tag);
         }
     }
 
@@ -92,6 +127,10 @@ private:
     // In busy worker scenarios, signal overhead
     // can be reduced.
     bool _no_signal_when_no_waiter;
+    // TaskControl pointer for waiter tracking (may be NULL before init).
+    TaskControl* _tc;
+    // Owning tag, used to update the per-tag waiter counter in TaskControl.
+    bthread_tag_t _tag;
 };
 
 }  // namespace bthread

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -226,7 +226,13 @@ TaskControl::TaskControl()
     , _tagged_waiter_num(FLAGS_task_group_ntags)
     , _tag_cpus(FLAGS_task_group_ntags)
     , _tag_next_worker_id(FLAGS_task_group_ntags)
-{}
+{
+    // Explicitly zero-initialize all atomic counters. butil::atomic's
+    // default constructor does not guarantee a zero value.
+    for (size_t i = 0; i < _tagged_waiter_num.size(); ++i) {
+        _tagged_waiter_num[i].store(0, butil::memory_order_relaxed);
+    }
+}
 
 int TaskControl::init_ed_priority_queues() {
     if (!_enable_priority_queue) {
@@ -294,6 +300,19 @@ int TaskControl::init(int concurrency) {
 #endif // BRPC_BTHREAD_TRACER
     
     _workers.resize(_concurrency);
+
+    // Wire each ParkingLot back to this TaskControl so that ParkingLot::wait()
+    // can maintain the per-tag _tagged_waiter_num counter consulted by
+    // has_waiting_workers(tag). This MUST be done BEFORE creating worker
+    // threads, otherwise a worker could enter wait() with _tc == nullptr,
+    // causing has_waiting_workers() to return false and signal_task() to
+    // be skipped — permanently sleeping the worker (lost wakeup).
+    for (size_t i = 0; i < _tagged_pl.size(); ++i) {
+        for (size_t j = 0; j < _pl_num_of_each_tag; ++j) {
+            _tagged_pl[i][j].set_task_control(this, (bthread_tag_t)i);
+        }
+    }
+
     for (int i = 0; i < _concurrency; ++i) {
         auto arg = new WorkerThreadArgs(this, i % FLAGS_task_group_ntags);
         const int rc = pthread_create(&_workers[i], NULL, worker_thread, arg);
@@ -307,15 +326,6 @@ int TaskControl::init(int concurrency) {
     _switch_per_second.expose("bthread_switch_second");
     _signal_per_second.expose("bthread_signal_second");
     _status.expose("bthread_group_status");
-
-    // Wire each ParkingLot back to this TaskControl so that ParkingLot::wait()
-    // can maintain the per-tag _tagged_waiter_num counter consulted by
-    // has_waiting_workers(tag). The outer index `i' is the owning tag.
-    for (size_t i = 0; i < _tagged_pl.size(); ++i) {
-        for (size_t j = 0; j < _pl_num_of_each_tag; ++j) {
-            _tagged_pl[i][j].set_task_control(this, (bthread_tag_t)i);
-        }
-    }
 
     // Wait for at least one group is added so that choose_one_group()
     // never returns NULL.

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -65,11 +65,6 @@ DEFINE_bool(parking_lot_no_signal_when_no_waiter, false,
             "In busy worker scenarios, signal overhead can be reduced.");
 DEFINE_bool(enable_bthread_priority_queue, false, "Whether to enable priority queue");
 
-// Out-of-line forwarders for ParkingLot per-tag waiter accounting, so that
-// parking_lot.h can stay free of the TaskControl definition.
-void parking_lot_waiter_add(TaskControl* tc, bthread_tag_t tag) { tc->waiter_add(tag); }
-void parking_lot_waiter_sub(TaskControl* tc, bthread_tag_t tag) { tc->waiter_sub(tag); }
-
 DECLARE_int32(bthread_concurrency);
 DECLARE_int32(bthread_min_concurrency);
 DECLARE_int32(bthread_parking_lot_of_each_tag);
@@ -223,16 +218,9 @@ TaskControl::TaskControl()
         FLAGS_task_group_ntags * FLAGS_event_dispatcher_num)
     , _pl_num_of_each_tag(FLAGS_bthread_parking_lot_of_each_tag)
     , _tagged_pl(FLAGS_task_group_ntags)
-    , _tagged_waiter_num(FLAGS_task_group_ntags)
     , _tag_cpus(FLAGS_task_group_ntags)
     , _tag_next_worker_id(FLAGS_task_group_ntags)
-{
-    // Explicitly zero-initialize all atomic counters. butil::atomic's
-    // default constructor does not guarantee a zero value.
-    for (size_t i = 0; i < _tagged_waiter_num.size(); ++i) {
-        _tagged_waiter_num[i].store(0, butil::memory_order_relaxed);
-    }
-}
+{}
 
 int TaskControl::init_ed_priority_queues() {
     if (!_enable_priority_queue) {
@@ -300,18 +288,6 @@ int TaskControl::init(int concurrency) {
 #endif // BRPC_BTHREAD_TRACER
     
     _workers.resize(_concurrency);
-
-    // Wire each ParkingLot back to this TaskControl so that ParkingLot::wait()
-    // can maintain the per-tag _tagged_waiter_num counter consulted by
-    // has_waiting_workers(tag). This MUST be done BEFORE creating worker
-    // threads, otherwise a worker could enter wait() with _tc == nullptr,
-    // causing has_waiting_workers() to return false and signal_task() to
-    // be skipped — permanently sleeping the worker (lost wakeup).
-    for (size_t i = 0; i < _tagged_pl.size(); ++i) {
-        for (size_t j = 0; j < _pl_num_of_each_tag; ++j) {
-            _tagged_pl[i][j].set_task_control(this, (bthread_tag_t)i);
-        }
-    }
 
     for (int i = 0; i < _concurrency; ++i) {
         auto arg = new WorkerThreadArgs(this, i % FLAGS_task_group_ntags);

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -65,6 +65,11 @@ DEFINE_bool(parking_lot_no_signal_when_no_waiter, false,
             "In busy worker scenarios, signal overhead can be reduced.");
 DEFINE_bool(enable_bthread_priority_queue, false, "Whether to enable priority queue");
 
+// Out-of-line forwarders for ParkingLot per-tag waiter accounting, so that
+// parking_lot.h can stay free of the TaskControl definition.
+void parking_lot_waiter_add(TaskControl* tc, bthread_tag_t tag) { tc->waiter_add(tag); }
+void parking_lot_waiter_sub(TaskControl* tc, bthread_tag_t tag) { tc->waiter_sub(tag); }
+
 DECLARE_int32(bthread_concurrency);
 DECLARE_int32(bthread_min_concurrency);
 DECLARE_int32(bthread_parking_lot_of_each_tag);
@@ -218,6 +223,7 @@ TaskControl::TaskControl()
         FLAGS_task_group_ntags * FLAGS_event_dispatcher_num)
     , _pl_num_of_each_tag(FLAGS_bthread_parking_lot_of_each_tag)
     , _tagged_pl(FLAGS_task_group_ntags)
+    , _tagged_waiter_num(FLAGS_task_group_ntags)
     , _tag_cpus(FLAGS_task_group_ntags)
     , _tag_next_worker_id(FLAGS_task_group_ntags)
 {}
@@ -301,6 +307,15 @@ int TaskControl::init(int concurrency) {
     _switch_per_second.expose("bthread_switch_second");
     _signal_per_second.expose("bthread_signal_second");
     _status.expose("bthread_group_status");
+
+    // Wire each ParkingLot back to this TaskControl so that ParkingLot::wait()
+    // can maintain the per-tag _tagged_waiter_num counter consulted by
+    // has_waiting_workers(tag). The outer index `i' is the owning tag.
+    for (size_t i = 0; i < _tagged_pl.size(); ++i) {
+        for (size_t j = 0; j < _pl_num_of_each_tag; ++j) {
+            _tagged_pl[i][j].set_task_control(this, (bthread_tag_t)i);
+        }
+    }
 
     // Wait for at least one group is added so that choose_one_group()
     // never returns NULL.

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -73,8 +73,25 @@ public:
     int concurrency() const 
     { return _concurrency.load(butil::memory_order_acquire); }
 
-    int concurrency(bthread_tag_t tag) const 
+    int concurrency(bthread_tag_t tag) const
     { return _tagged_ngroup[tag].load(butil::memory_order_acquire); }
+
+    // Check if there are workers parked in wait() for the given tag.
+    // Per-tag accounting avoids a tag-A ready_to_run() needlessly issuing a
+    // signal_task() just because workers of a *different* tag B are parked.
+    bool has_waiting_workers(bthread_tag_t tag) const {
+        return tag < (bthread_tag_t)_tagged_waiter_num.size()
+               && _tagged_waiter_num[tag].load(butil::memory_order_relaxed) > 0;
+    }
+
+    // Called by ParkingLot (via parking_lot_waiter_add/sub) to track waiters
+    // entering/leaving wait() for a given tag.
+    void waiter_add(bthread_tag_t tag) {
+        _tagged_waiter_num[tag].fetch_add(1, butil::memory_order_relaxed);
+    }
+    void waiter_sub(bthread_tag_t tag) {
+        _tagged_waiter_num[tag].fetch_sub(1, butil::memory_order_relaxed);
+    }
 
     void print_rq_sizes(std::ostream& os);
 
@@ -182,6 +199,12 @@ private:
 
     size_t _pl_num_of_each_tag;
     std::vector<TaggedParkingLot> _tagged_pl;
+
+    // Signal optimization: per-tag count of workers currently parked in
+    // ParkingLot::wait(). Read (relaxed) by ready_to_run* to decide whether
+    // signal_task() can be skipped when no worker of that tag is waiting.
+    std::vector<butil::atomic<size_t>> _tagged_waiter_num;
+
     // Per-tag CPU binding lists.  _tag_cpus[tag] is the round-robin list of
     // CPU IDs to which workers of that tag are bound.  Empty means no binding.
     std::vector<std::vector<unsigned>> _tag_cpus;

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -76,29 +76,6 @@ public:
     int concurrency(bthread_tag_t tag) const
     { return _tagged_ngroup[tag].load(butil::memory_order_acquire); }
 
-    // Check if there are workers parked in wait() for the given tag.
-    // Per-tag accounting avoids a tag-A ready_to_run() needlessly issuing a
-    // signal_task() just because workers of a *different* tag B are parked.
-    // Returns true if the tag is valid AND at least one worker is parked.
-    bool has_waiting_workers(bthread_tag_t tag) const {
-        return tag >= 0
-               && tag < (bthread_tag_t)_tagged_waiter_num.size()
-               && _tagged_waiter_num[tag].load(butil::memory_order_relaxed) > 0;
-    }
-
-    // Called by ParkingLot (via parking_lot_waiter_add/sub) to track waiters
-    // entering/leaving wait() for a given tag. No-op for invalid tags.
-    void waiter_add(bthread_tag_t tag) {
-        if (tag >= 0 && tag < (bthread_tag_t)_tagged_waiter_num.size()) {
-            _tagged_waiter_num[tag].fetch_add(1, butil::memory_order_relaxed);
-        }
-    }
-    void waiter_sub(bthread_tag_t tag) {
-        if (tag >= 0 && tag < (bthread_tag_t)_tagged_waiter_num.size()) {
-            _tagged_waiter_num[tag].fetch_sub(1, butil::memory_order_relaxed);
-        }
-    }
-
     void print_rq_sizes(std::ostream& os);
 
     double get_cumulated_worker_time();
@@ -205,11 +182,6 @@ private:
 
     size_t _pl_num_of_each_tag;
     std::vector<TaggedParkingLot> _tagged_pl;
-
-    // Signal optimization: per-tag count of workers currently parked in
-    // ParkingLot::wait(). Read (relaxed) by ready_to_run* to decide whether
-    // signal_task() can be skipped when no worker of that tag is waiting.
-    std::vector<butil::atomic<size_t>> _tagged_waiter_num;
 
     // Per-tag CPU binding lists.  _tag_cpus[tag] is the round-robin list of
     // CPU IDs to which workers of that tag are bound.  Empty means no binding.

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -79,18 +79,24 @@ public:
     // Check if there are workers parked in wait() for the given tag.
     // Per-tag accounting avoids a tag-A ready_to_run() needlessly issuing a
     // signal_task() just because workers of a *different* tag B are parked.
+    // Returns true if the tag is valid AND at least one worker is parked.
     bool has_waiting_workers(bthread_tag_t tag) const {
-        return tag < (bthread_tag_t)_tagged_waiter_num.size()
+        return tag >= 0
+               && tag < (bthread_tag_t)_tagged_waiter_num.size()
                && _tagged_waiter_num[tag].load(butil::memory_order_relaxed) > 0;
     }
 
     // Called by ParkingLot (via parking_lot_waiter_add/sub) to track waiters
-    // entering/leaving wait() for a given tag.
+    // entering/leaving wait() for a given tag. No-op for invalid tags.
     void waiter_add(bthread_tag_t tag) {
-        _tagged_waiter_num[tag].fetch_add(1, butil::memory_order_relaxed);
+        if (tag >= 0 && tag < (bthread_tag_t)_tagged_waiter_num.size()) {
+            _tagged_waiter_num[tag].fetch_add(1, butil::memory_order_relaxed);
+        }
     }
     void waiter_sub(bthread_tag_t tag) {
-        _tagged_waiter_num[tag].fetch_sub(1, butil::memory_order_relaxed);
+        if (tag >= 0 && tag < (bthread_tag_t)_tagged_waiter_num.size()) {
+            _tagged_waiter_num[tag].fetch_sub(1, butil::memory_order_relaxed);
+        }
     }
 
     void print_rq_sizes(std::ostream& os);

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -930,9 +930,7 @@ void TaskGroup::ready_to_run(TaskMeta* meta, bool nosignal) {
         const int additional_signal = _num_nosignal;
         _num_nosignal = 0;
         _nsignaled += 1 + additional_signal;
-        if (BAIDU_UNLIKELY(_control->has_waiting_workers(_tag))) {
-            _control->signal_task(1 + additional_signal, _tag);
-        }
+        _control->signal_task(1 + additional_signal, _tag);
     }
 }
 
@@ -941,9 +939,7 @@ void TaskGroup::flush_nosignal_tasks() {
     if (val) {
         _num_nosignal = 0;
         _nsignaled += val;
-        if (BAIDU_UNLIKELY(_control->has_waiting_workers(_tag))) {
-            _control->signal_task(val, _tag);
-        }
+        _control->signal_task(val, _tag);
     }
 }
 
@@ -967,9 +963,7 @@ void TaskGroup::ready_to_run_remote(TaskMeta* meta, bool nosignal) {
         _remote_num_nosignal = 0;
         _remote_nsignaled += 1 + additional_signal;
         _remote_rq._mutex.unlock();
-        if (BAIDU_UNLIKELY(_control->has_waiting_workers(_tag))) {
-            _control->signal_task(1 + additional_signal, _tag);
-        }
+        _control->signal_task(1 + additional_signal, _tag);
     }
 }
 
@@ -982,9 +976,7 @@ void TaskGroup::flush_nosignal_tasks_remote_locked(butil::Mutex& locked_mutex) {
     _remote_num_nosignal = 0;
     _remote_nsignaled += val;
     locked_mutex.unlock();
-    if (BAIDU_UNLIKELY(_control->has_waiting_workers(_tag))) {
-        _control->signal_task(val, _tag);
-    }
+    _control->signal_task(val, _tag);
 }
 
 void TaskGroup::ready_to_run_general(TaskMeta* meta, bool nosignal) {

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -930,7 +930,9 @@ void TaskGroup::ready_to_run(TaskMeta* meta, bool nosignal) {
         const int additional_signal = _num_nosignal;
         _num_nosignal = 0;
         _nsignaled += 1 + additional_signal;
-        _control->signal_task(1 + additional_signal, _tag);
+        if (BAIDU_UNLIKELY(_control->has_waiting_workers(_tag))) {
+            _control->signal_task(1 + additional_signal, _tag);
+        }
     }
 }
 
@@ -939,7 +941,9 @@ void TaskGroup::flush_nosignal_tasks() {
     if (val) {
         _num_nosignal = 0;
         _nsignaled += val;
-        _control->signal_task(val, _tag);
+        if (BAIDU_UNLIKELY(_control->has_waiting_workers(_tag))) {
+            _control->signal_task(val, _tag);
+        }
     }
 }
 
@@ -963,7 +967,9 @@ void TaskGroup::ready_to_run_remote(TaskMeta* meta, bool nosignal) {
         _remote_num_nosignal = 0;
         _remote_nsignaled += 1 + additional_signal;
         _remote_rq._mutex.unlock();
-        _control->signal_task(1 + additional_signal, _tag);
+        if (BAIDU_UNLIKELY(_control->has_waiting_workers(_tag))) {
+            _control->signal_task(1 + additional_signal, _tag);
+        }
     }
 }
 
@@ -976,7 +982,9 @@ void TaskGroup::flush_nosignal_tasks_remote_locked(butil::Mutex& locked_mutex) {
     _remote_num_nosignal = 0;
     _remote_nsignaled += val;
     locked_mutex.unlock();
-    _control->signal_task(val, _tag);
+    if (BAIDU_UNLIKELY(_control->has_waiting_workers(_tag))) {
+        _control->signal_task(val, _tag);
+    }
 }
 
 void TaskGroup::ready_to_run_general(TaskMeta* meta, bool nosignal) {


### PR DESCRIPTION
## Problem
ready_to_run* unconditionally calls signal_task() on every task-ready event, even when all workers are busy and nobody is parked in wait(). This results in unnecessary futex_wake syscalls that wake no thread, wasting CPU under load.

## Solution
Add per-tag waiter counting via _tagged_waiter_num: ParkingLot::wait() tracks waiters entering/leaving (via parking_lot_waiter_add/sub out-of-line forwarders) BEFORE the state check. ready_to_run* checks has_waiting_workers(tag) before calling signal_task — if no worker of the given tag is parked, the wakeup is skipped (BAIDU_UNLIKELY marks the true branch as cold since under load all workers are busy).

## Race-free design
The waiter_add() is called BEFORE the get_state() check in wait(). This ensures that any concurrent ready_to_run() that calls has_waiting_workers() will see the waiter even if it races between the state check and futex_wait(). If the state already changed (signal was sent), wait() undoes the tracking and returns immediately without sleeping. This eliminates the lost-wakeup window entirely.

## Why it's safe
- Tasks are already enqueued (push_rq) before the signal check, so they will be picked up by the next steal regardless of signaling.
- _tagged_waiter_num uses relaxed atomics (it's a hint, not a synchronization primitive); the actual wake ordering is handled by parking_lot's existing futex mechanism.

## Multi-tag benefit
Per-tag accounting avoids tag-A's ready_to_run() issuing a signal_task() just because tag-B has parked workers.

Tested: bthread_unittest 20/20 on Linux x86 (Ubuntu 24.04/GCC 13) and macOS arm64 (M4).

### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
