### PR TITLE
fix WeightedRandomizedLoadBalancer skipping the last server

### DIFF
--- a/src/brpc/policy/weighted_randomized_load_balancer.cpp
+++ b/src/brpc/policy/weighted_randomized_load_balancer.cpp
@@ -131,13 +131,11 @@ int WeightedRandomizedLoadBalancer::SelectServer(const SelectIn& in, SelectOut* 
     uint64_t weight_sum = s->weight_sum;
     for (size_t i = 0; i < n; ++i) {
         uint64_t random_weight = butil::fast_rand_less_than(weight_sum);
-        // current_weight_sum is an inclusive prefix sum, so server i owns the
-        // half-open range [prefix(i-1), prefix(i)). random_weight belongs to the
-        // first server whose prefix sum is strictly greater than it, which is
-        // lower_bound() of random_weight + 1 rather than of random_weight itself.
-        const Server random_server(0, 0, random_weight + 1);
+        // current_weight_sum is an inclusive prefix sum, so random_weight belongs
+        // to the first server whose prefix sum is strictly greater than it.
+        const Server random_server(0, 0, random_weight);
         const auto& server =
-            std::lower_bound(s->server_list.begin(), s->server_list.end(),
+            std::upper_bound(s->server_list.begin(), s->server_list.end(),
                              random_server, server_compare);
         const SocketId id = server->id;
         if (ExcludedServers::IsExcluded(in.excluded, id)) {

--- a/src/brpc/policy/weighted_randomized_load_balancer.cpp
+++ b/src/brpc/policy/weighted_randomized_load_balancer.cpp
@@ -131,7 +131,11 @@ int WeightedRandomizedLoadBalancer::SelectServer(const SelectIn& in, SelectOut* 
     uint64_t weight_sum = s->weight_sum;
     for (size_t i = 0; i < n; ++i) {
         uint64_t random_weight = butil::fast_rand_less_than(weight_sum);
-        const Server random_server(0, 0, random_weight);
+        // current_weight_sum is an inclusive prefix sum, so server i owns the
+        // half-open range [prefix(i-1), prefix(i)). random_weight belongs to the
+        // first server whose prefix sum is strictly greater than it, which is
+        // lower_bound() of random_weight + 1 rather than of random_weight itself.
+        const Server random_server(0, 0, random_weight + 1);
         const auto& server =
             std::lower_bound(s->server_list.begin(), s->server_list.end(),
                              random_server, server_compare);

--- a/test/brpc_load_balancer_unittest.cpp
+++ b/test/brpc_load_balancer_unittest.cpp
@@ -1026,6 +1026,55 @@ TEST_F(LoadBalancerTest, weighted_randomized) {
     }
 }
 
+TEST_F(LoadBalancerTest, weighted_randomized_equal_weight) {
+    // With equal weights every server must get the same share of the traffic.
+    // The tolerance of `weighted_randomized` above is +/-2x, which is too loose
+    // to catch a single misplaced slot, so check the distribution tightly here.
+    const char* servers[] = {
+        "10.92.115.19:8831",
+        "10.42.108.25:8832",
+        "10.36.150.31:8833",
+        "10.36.150.32:8899"
+    };
+    brpc::policy::WeightedRandomizedLoadBalancer wrlb;
+    for (size_t i = 0; i < ARRAY_SIZE(servers); ++i) {
+        butil::EndPoint dummy;
+        ASSERT_EQ(0, str2endpoint(servers[i], &dummy));
+        brpc::ServerId id(8888);
+        brpc::SocketOptions options;
+        options.remote_side = dummy;
+        options.user = new SaveRecycle;
+        ASSERT_EQ(0, brpc::Socket::Create(options, &id.id));
+        id.tag = "1";
+        ASSERT_TRUE(wrlb.AddServer(id));
+    }
+
+    std::map<butil::EndPoint, size_t> select_result;
+    brpc::SocketUniquePtr ptr;
+    brpc::LoadBalancer::SelectIn in = { 0, false, false, 0u, NULL };
+    brpc::LoadBalancer::SelectOut out(&ptr);
+    const int run_times = 40000;
+    for (int i = 0; i < run_times; ++i) {
+        ASSERT_EQ(0, wrlb.SelectServer(in, &out));
+        ++select_result[ptr->remote_side()];
+    }
+
+    // Every server must be selected at least once, in particular the one added
+    // last, which owns the largest prefix sum.
+    ASSERT_EQ(ARRAY_SIZE(servers), select_result.size());
+    const double expect_rate = 1.0 / ARRAY_SIZE(servers);
+    for (const auto& result : select_result) {
+        const double actual_rate = result.second * 1.0 / run_times;
+        std::cout << result.first << " select_times=" << result.second
+            << " actual_rate=" << actual_rate
+            << " expect_rate=" << expect_rate << std::endl;
+        // 0.9x ~ 1.1x of the expected rate, which is more than 20 standard
+        // deviations away from the mean at this number of runs.
+        ASSERT_GE(actual_rate, expect_rate * 0.9);
+        ASSERT_LE(actual_rate, expect_rate * 1.1);
+    }
+}
+
 TEST_F(LoadBalancerTest, health_check_no_valid_server) {
     const char* servers[] = { 
             "10.92.115.19:8832", 

--- a/test/brpc_load_balancer_unittest.cpp
+++ b/test/brpc_load_balancer_unittest.cpp
@@ -1068,8 +1068,9 @@ TEST_F(LoadBalancerTest, weighted_randomized_equal_weight) {
         std::cout << result.first << " select_times=" << result.second
             << " actual_rate=" << actual_rate
             << " expect_rate=" << expect_rate << std::endl;
-        // 0.9x ~ 1.1x of the expected rate, which is more than 20 standard
-        // deviations away from the mean at this number of runs.
+        // 0.9x ~ 1.1x of the expected rate. With n=40000 and p=0.25 the count has
+        // sigma = sqrt(n*p*(1-p)) ~= 86.6, so the +-10% band is about 11 sigma
+        // wide and a passing run is not luck.
         ASSERT_GE(actual_rate, expect_rate * 0.9);
         ASSERT_LE(actual_rate, expect_rate * 1.1);
     }


### PR DESCRIPTION
### What problem does this PR solve?

`WeightedRandomizedLoadBalancer::SelectServer()` never selects the server that was added last, and over-selects the first one.

`Add()` fills `Server::current_weight_sum` with an *inclusive* prefix sum. `SelectServer()` draws `random_weight` from `butil::fast_rand_less_than(weight_sum)`, i.e. from `[0, weight_sum - 1]`, and then `lower_bound()`s that value against those prefix sums. `lower_bound()` returns the first server whose prefix sum is `>= random_weight`, but a server owns the half-open range `[prefix(i-1), prefix(i))`, so the predicate has to be `> random_weight`.

Two consequences: the first server also serves `random_weight == prefix(0)`, so it gets one slot too many; and the last server is never selected at all, because `random_weight` can never reach `weight_sum`.

With four servers of equal weight the measured distribution is 49.8 / 25.1 / 25.1 / 0.0 percent instead of 25 percent each. The last server only receives traffic through the fallback loop, when every server picked at random happens to be unavailable.

### What is changed and the side effects?

Changed: search for `random_weight + 1`, so `lower_bound()` lands on the first prefix sum strictly greater than `random_weight`. `random_weight + 1` is at most `weight_sum`, which is exactly the last prefix sum, so the iterator is still always valid.

Side effects:
- Performance effects: none, the comparison is unchanged.
- Breaking backward compatibility: no. Traffic shifts towards the configured weights.

The existing `weighted_randomized` test does not catch this. Its servers have weights 3/2/5/10 and it only asserts that every rate is within 0.5x~2x of the expected one. The weight-10 server measures 0.453 before this change and 0.5055 after it, and both are inside that band. The off-by-one predicts that number exactly: the server should own 10 of 20 slots but owns 9, i.e. 0.45.

This PR adds `weighted_randomized_equal_weight`, which uses equal weights so a single misplaced slot is visible, and checks the rates within 0.9x~1.1x. On master the last server is selected 0 times out of 40000 and the test fails; with this change all four land within 0.2476~0.25435.

### Check List:

- `brpc_load_balancer_unittest` passes in full: `[  PASSED  ] 17 tests.`
- The new test was run with `--gtest_repeat=40` without a failure.
- Verified the new test fails without the one-line change and passes with it.

Tested on macOS/arm64 with clang. I was not able to build on Linux/gcc locally; CI will cover that.