### PR TITLE
build: complete UBRING Bazel and CI support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -87,3 +87,5 @@ build:macos-asan --copt -D_FORTIFY_SOURCE=0
 build:macos-asan --dynamic_mode=off
 
 test:asan --test_env=ASAN_OPTIONS=detect_leaks=0:detect_stack_use_after_return=1
+
+build:ubring --define BRPC_WITH_UBRING=true

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         export CC=gcc && export CXX=g++
         mkdir gcc_build_all && cd gcc_build_all
-        cmake -DWITH_MESALINK=OFF -DWITH_GLOG=ON -DWITH_THRIFT=ON -DWITH_RDMA=ON \
+        cmake -DWITH_MESALINK=OFF -DWITH_GLOG=ON -DWITH_THRIFT=ON -DWITH_RDMA=ON -DWITH_UBRING=ON \
               -DWITH_DEBUG_BTHREAD_SCHE_SAFETY=ON -DWITH_DEBUG_LOCK=ON -DWITH_BTHREAD_TRACER=ON \
               -DWITH_ASAN=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
         make -j ${{env.proc_num}} && make clean
@@ -123,7 +123,7 @@ jobs:
     # real server (e.g. brpc_redis_unittest) actually run under bazel instead
     # of skipping. Same shared action the make-based unittest jobs use.
     - uses: ./.github/actions/install-essential-dependencies
-    - run: bazel test //test/...
+    - run: bazel test --config=rdma --config=ubring //test/...
 
   gcc-compile-with-bazel-all-options:
     runs-on: ubuntu-22.04
@@ -135,6 +135,8 @@ jobs:
         bazel build --define with_mesalink=false \
                     --define with_glog=true \
                     --define with_thrift=true \
+                    --define BRPC_WITH_RDMA=true \
+                    --define BRPC_WITH_UBRING=true \
                     --define BRPC_WITH_BORINGSSL=true \
                     --define with_debug_bthread_sche_safety=true \
                     --define with_debug_lock=true \
@@ -149,6 +151,8 @@ jobs:
         bazel build --define with_mesalink=false \
                     --define with_glog=true \
                     --define with_thrift=true \
+                    --define BRPC_WITH_RDMA=true \
+                    --define BRPC_WITH_UBRING=true \
                     --define BRPC_WITH_BORINGSSL=true \
                     --define with_debug_bthread_sche_safety=true \
                     --define with_debug_lock=true \
@@ -198,6 +202,8 @@ jobs:
     - run: |
         bazel test --test_output=streamed \
                    --action_env=CC=clang \
+                   --config=rdma \
+                   --config=ubring \
                    //test/...
 
   clang-compile-with-bazel-all-options:
@@ -211,6 +217,8 @@ jobs:
                     --define with_mesalink=false \
                     --define with_glog=true \
                     --define with_thrift=true \
+                    --define BRPC_WITH_RDMA=true \
+                    --define BRPC_WITH_UBRING=true \
                     --define BRPC_WITH_BORINGSSL=true \
                     --define with_debug_bthread_sche_safety=true \
                     --define with_debug_lock=true \
@@ -226,6 +234,8 @@ jobs:
                     --define with_mesalink=false \
                     --define with_glog=true \
                     --define with_thrift=true \
+                    --define BRPC_WITH_RDMA=true \
+                    --define BRPC_WITH_UBRING=true \
                     --define BRPC_WITH_BORINGSSL=true \
                     --define with_debug_bthread_sche_safety=true \
                     --define with_debug_lock=true \
@@ -242,7 +252,7 @@ jobs:
     - uses: ./.github/actions/install-essential-dependencies
     - uses: ./.github/actions/init-ut-make-config
       with:
-        options: --with-bthread-tracer
+        options: --with-bthread-tracer --with-rdma
     - name: compile tests
       run: |
         cat config.mk
@@ -296,7 +306,7 @@ jobs:
         grep -qE "bazel_dep\(name = ['\"]protobuf['\"], version = ['\"]${TEST_PROTOBUF_VERSION}['\"]" MODULE.bazel \
           || { echo "ERROR: failed to override protobuf version in MODULE.bazel to ${TEST_PROTOBUF_VERSION}"; exit 1; }
     - run: | 
-        bazel test --action_env=CC=clang --config=rdma \
+        bazel test --action_env=CC=clang --config=rdma --config=ubring \
                    --define with_bthread_tracer=true \
                    --define with_babylon_counter=true \
                    //test/...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,6 +52,9 @@ DEFINES = [
      "//bazel/config:brpc_with_rdma": ["BRPC_WITH_RDMA=1"],
      "//conditions:default": [],
  }) + select({
+     "//bazel/config:brpc_with_ubring": ["BRPC_WITH_UBRING=1"],
+     "//conditions:default": [],
+ }) + select({
      "//bazel/config:brpc_with_debug_bthread_sche_safety": ["BRPC_DEBUG_BTHREAD_SCHE_SAFETY=1"],
      "//conditions:default": ["BRPC_DEBUG_BTHREAD_SCHE_SAFETY=0"],
  }) + select({

--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -156,3 +156,9 @@ config_setting(
     define_values = {"with_babylon_counter": "true"},
     visibility = ["//visibility:public"],
 )
+
+config_setting(
+    name = "brpc_with_ubring",
+    define_values = {"BRPC_WITH_UBRING": "true"},
+    visibility = ["//visibility:public"],
+)

--- a/docs/cn/ubring.md
+++ b/docs/cn/ubring.md
@@ -71,10 +71,13 @@ cmake --build build -j 8
 ```bash
 # 构建 brpc 并启用 UBRing 支持
 cd /path/to/brpc
-bazel build //... --define=with_ubring=true
+bazel build //:brpc --define=BRPC_WITH_UBRING=true
 
 # 构建 ubring_performance 示例
-bazel build //example/ubring_performance/...
+bazel build \
+  //example:ubring_performance_server \
+  //example:ubring_performance_client \
+  --define=BRPC_WITH_UBRING=true
 ```
 
 ### 选择共享内存后端

--- a/docs/en/ubring.md
+++ b/docs/en/ubring.md
@@ -70,10 +70,13 @@ To build brpc with UBRing support using Bazel:
 ```bash
 # Build brpc with UBRing support
 cd /path/to/brpc
-bazel build //... --define=with_ubring=true
+bazel build //:brpc --define=BRPC_WITH_UBRING=true
 
 # Build the ubring_performance example
-bazel build //example/ubring_performance/...
+bazel build \
+  //example:ubring_performance_server \
+  //example:ubring_performance_client \
+  --define=BRPC_WITH_UBRING=true
 ```
 
 ### Select Shared Memory Backend

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -37,6 +37,9 @@ COPTS = [
 }) + select({
     "//bazel/config:brpc_with_rdma": ["-DBRPC_WITH_RDMA=1"],
     "//conditions:default": [""],
+}) + select({
+    "//bazel/config:brpc_with_ubring": ["-DBRPC_WITH_UBRING=1"],
+    "//conditions:default": [""],
 })
 
 brpc_proto_library(
@@ -50,6 +53,13 @@ brpc_proto_library(
     name = "cc_rdma_performance_proto",
     srcs = ["rdma_performance/test.proto"],
     include = "rdma_performance",
+    proto_deps = [],
+)
+
+brpc_proto_library(
+    name = "cc_ubring_performance_proto",
+    srcs = ["ubring_performance/test.proto"],
+    include = "ubring_performance",
     proto_deps = [],
 )
 
@@ -109,6 +119,36 @@ cc_binary(
     copts = COPTS + ["-DBRPC_WITH_RDMA=1"],
     deps = [
         ":cc_rdma_performance_proto",
+        "//:brpc",
+    ],
+)
+
+cc_binary(
+    name = "ubring_performance_server",
+    srcs = [
+        "ubring_performance/server.cpp",
+    ],
+    copts = COPTS,
+    includes = [
+        "ubring_performance",
+    ],
+    deps = [
+        ":cc_ubring_performance_proto",
+        "//:brpc",
+    ],
+)
+
+cc_binary(
+    name = "ubring_performance_client",
+    srcs = [
+        "ubring_performance/client.cpp",
+    ],
+    copts = COPTS,
+    includes = [
+        "ubring_performance",
+    ],
+    deps = [
+        ":cc_ubring_performance_proto",
         "//:brpc",
     ],
 )

--- a/example/ubring_performance/client.cpp
+++ b/example/ubring_performance/client.cpp
@@ -165,16 +165,19 @@ public:
         std::unique_ptr<brpc::Controller> cntl_guard(closure->cntl);
         std::unique_ptr<test::PerfTestResponse> response_guard(closure->resp);
         if (closure->cntl->Failed()) {
-            LOG(DEBUG) << "RPC call failed: " << closure->cntl->ErrorText();
-            // Don't stop the test immediately, just log the error and continue
-        } else {
-            g_latency_recorder << closure->cntl->latency_us();
-            if (closure->resp->cpu_usage().size() > 0) {
-                g_server_cpu_recorder << atof(closure->resp->cpu_usage().c_str()) * 100;
-            }
-            g_total_bytes.fetch_add(closure->cntl->request_attachment().size(), butil::memory_order_relaxed);
-            g_total_cnt.fetch_add(1, butil::memory_order_relaxed);
+            LOG(ERROR) << "RPC call failed: " << closure->cntl->ErrorText();
+            // RPCs in this example are expected to succeed. Silently ignoring
+            // failures would hide problems and invalidate the performance result.
+            closure->test->_stop = true;
+            return;
         }
+
+        g_latency_recorder << closure->cntl->latency_us();
+        if (closure->resp->cpu_usage().size() > 0) {
+            g_server_cpu_recorder << atof(closure->resp->cpu_usage().c_str()) * 100;
+        }
+        g_total_bytes.fetch_add(closure->cntl->request_attachment().size(), butil::memory_order_relaxed);
+        g_total_cnt.fetch_add(1, butil::memory_order_relaxed);
 
         cntl_guard.reset(NULL);
         response_guard.reset(NULL);

--- a/src/brpc/ubshm/timer/timer_mgr.cpp
+++ b/src/brpc/ubshm/timer/timer_mgr.cpp
@@ -77,7 +77,7 @@ static RETURN_CODE DeleteTimerInner(uint32_t fd) {
     read((int)fd, &exp, sizeof(exp));
 
     close((int)fd);
-    std::atomic_fetch_sub(&g_total_timer_num, 1);
+    std::atomic_fetch_sub(&g_total_timer_num, 1U);
     return UBRING_OK;
 }
 
@@ -305,7 +305,7 @@ void DeleteTimerSafe(uint32_t fd) {
     read((int)fd, &exp, sizeof(exp));
 
     close((int)fd);
-    std::atomic_fetch_sub(&g_total_timer_num, 1);
+    std::atomic_fetch_sub(&g_total_timer_num, 1U);
 }
 
 void DeleteTimer(uint32_t fd) {
@@ -365,7 +365,7 @@ int32_t TimerStart(const itimerspec *time, void *(*cb)(void *), void *args) {
         return -1;
     }
 
-    std::atomic_fetch_add(&g_total_timer_num, 1);
+    std::atomic_fetch_add(&g_total_timer_num, 1U);
 
 #if defined(OS_LINUX)
     ret = timerfd_settime(timer_fd, 0, time, NULL);
@@ -384,7 +384,7 @@ int32_t TimerStart(const itimerspec *time, void *(*cb)(void *), void *args) {
             LOG(ERROR) << "Failed to delete the timer fd=" << timer_fd << " with errno=" << errno;
         }
         CloseTimerFd(timer_fd);
-        std::atomic_fetch_sub(&g_total_timer_num, 1);
+        std::atomic_fetch_sub(&g_total_timer_num, 1U);
         LOG(ERROR) << "Failed to set timer";
         return -1;
     }


### PR DESCRIPTION
Add the missing BRPC_WITH_UBRING Bazel configuration, wire it through the library and example targets, and document the supported build commands.

Enable RDMA and UBRING in CI jobs whose all-options configurations did not exercise those features. Run both feature suites in the existing Bazel unit-test jobs and enable RDMA in the Make unit-test job.

Use unsigned literals for UBRING atomic counter operations to match the counter type and avoid template deduction failures on stricter compilers.


