### PR TITLE
fix(test): avoid overriding the configured C++ standard

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ NEED_GPERFTOOLS=1
 NEED_GTEST=1
 include ../config.mk
 CPPFLAGS+=-DBTHREAD_USE_FAST_PTHREAD_MUTEX -D_GNU_SOURCE -DUSE_SYMBOLIZE -DNO_TCMALLOC -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DUNIT_TEST -DBVAR_NOT_LINK_DEFAULT_VARIABLES
-CXXFLAGS+=$(CPPFLAGS) -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -fno-access-control -std=c++14
+CXXFLAGS+=$(CPPFLAGS) -pipe -Wall -W -fPIC -fstrict-aliasing -Wno-invalid-offsetof -Wno-unused-parameter -fno-omit-frame-pointer -fno-access-control
 
 # On Darwin, only gtest library is needed, other libraries have been linked in `brpc.dbg.dylib`
 ifeq ($(SYSTEM),Darwin)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #3236

Problem Summary:

When bRPC is configured with Protobuf 22 or newer, `config_brpc.sh` selects C++17 for the accompanying Abseil dependency.

However, after including the generated `config.mk`, `test/Makefile` unconditionally appends `-std=c++14`. The resulting compiler options contain:

```text
-std=c++17 ... -std=c++14
```

Because the last `-std` option takes precedence, the unit tests are compiled as C++14. With Protobuf 25.1 and Abseil 20230802, this causes compilation failures in Abseil headers, including:

```text
absl/strings/cord.h:1020:18:
error: cannot convert ... lambda ... to int
```

The failure was reproduced for the following targets:

- `brpc_load_balancer_unittest.o`
- `brpc_builtin_service_unittest.o`

Keeping all other compiler options unchanged and making C++17 the effective standard allowed both targets to compile successfully.

### What is changed and the side effects?

Changed:

Remove the test-specific `-std=c++14` option from `test/Makefile`, allowing the test build to inherit the C++ standard selected by `config_brpc.sh` through `config.mk`.

The resulting behavior is:

- Protobuf 22 or newer: tests inherit C++17.
- Older Protobuf versions: tests inherit the configured C++14 baseline.

This prevents `test/Makefile` from overriding the C++ standard selected according to the dependency version.

This change preserves the C++14 baseline: configurations that do not require C++17 continue to inherit `-std=c++14` from `config.mk`.

Validation environment:

```text
openEuler 24.03 LTS-SP4, x86_64
GCC 12.3.1
Protobuf 25.1
Abseil 20230802.1
GoogleTest/GoogleMock 1.14.0
```

Validation performed:

- Reproduced the Abseil compilation error with C++14 as the effective standard.
- Confirmed both affected targets compile when C++17 is the effective standard.
- Successfully rebuilt both targets through the modified `test/Makefile`.
- Successfully linked both corresponding test binaries.
- Successfully built and linked the complete `test` directory with `make -j2`.
- `brpc_builtin_service_unittest`: 21 tests passed.
- GitHub Actions passed on Linux and macOS, covering:
  - Protobuf 21 and Protobuf 29
  - GCC and Clang
  - Make, CMake, and Bazel
  - Unit tests and ASan
- License Check passed.

Side effects:

- Performance effects: None. This only changes how the test build obtains its C++ standard.
- Breaking backward compatibility: No. Configurations using older Protobuf versions continue to inherit the C++14 baseline.

---

### Check List

- The change is compilable.
- The complete test directory builds and links successfully.
- Relevant unit tests and GitHub Actions checks passed.
- The change follows the Contributor Covenant Code of Conduct.