### PR TITLE
Suppress false-positive LSan leaks in Span pool factory functions

### DIFF
--- a/src/brpc/span.cpp
+++ b/src/brpc/span.cpp
@@ -31,6 +31,7 @@
 #include "butil/fast_rand.h"
 #include "butil/file_util.h"
 #include "butil/files/file_enumerator.h"
+#include "butil/debug/leak_annotations.h"
 #include "brpc/shared_object.h"
 #include "brpc/reloadable_flags.h"
 #include "brpc/span.h"
@@ -201,6 +202,11 @@ Span::~Span() {
 
 std::shared_ptr<Span> Span::CreateClientSpan(const std::string& full_method_name,
                                              int64_t base_real_us) {
+    // Span objects are recycled via butil::object_pool and are never truly
+    // freed; the shared_ptr control block and other allocations made here are
+    // kept alive by that pool by design. Instruct LeakSanitizer to ignore
+    // these intentional "leaks".
+    ANNOTATE_SCOPED_MEMORY_LEAK;
     Span* span_raw = butil::get_object<Span>(Forbidden());
     if (__builtin_expect(span_raw == NULL, 0)) {
         return nullptr;
@@ -243,6 +249,11 @@ std::shared_ptr<Span> Span::CreateClientSpan(const std::string& full_method_name
 
 std::shared_ptr<Span> Span::CreateBthreadSpan(const std::string& full_method_name,
                                               int64_t base_real_us) {
+    // Span objects are recycled via butil::object_pool and are never truly
+    // freed; the shared_ptr control block and other allocations made here are
+    // kept alive by that pool by design. Instruct LeakSanitizer to ignore
+    // these intentional "leaks".
+    ANNOTATE_SCOPED_MEMORY_LEAK;
     std::shared_ptr<Span> parent = Span::tls_parent();
     Span* span_raw = butil::get_object<Span>(Forbidden());
     if (__builtin_expect(span_raw == NULL, 0)) {
@@ -291,10 +302,14 @@ inline const std::string& unknown_span_name() {
     return s_unknown_method_name;
 }
 
-std::shared_ptr<Span> Span::CreateServerSpan(
-    const std::string& full_method_name,
-    uint64_t trace_id, uint64_t span_id, uint64_t parent_span_id,
-    int64_t base_real_us) {
+std::shared_ptr<Span> Span::CreateServerSpan(const std::string& full_method_name,
+                                             uint64_t trace_id, uint64_t span_id,
+                                             uint64_t parent_span_id, int64_t base_real_us) {
+    // Span objects are recycled via butil::object_pool and are never truly
+    // freed; the shared_ptr control block and other allocations made here are
+    // kept alive by that pool by design. Instruct LeakSanitizer to ignore
+    // these intentional "leaks".
+    ANNOTATE_SCOPED_MEMORY_LEAK;
     Span* span_raw = butil::get_object<Span>(Forbidden());
     if (__builtin_expect(span_raw == NULL, 0)) {
         return nullptr;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

`brpc_controller_unittest` fails under LeakSanitizer/ASan with reports like:

```
==ERROR: LeakSanitizer: detected memory leaks
Direct leak ... in brpc::Span::CreateClientSpan(...) src/brpc/span.cpp:208
SUMMARY: AddressSanitizer: 110 byte(s) leaked in 4 allocation(s).
```

`Span` objects are recycled through `butil::object_pool` and are never truly
freed; `SpanDeleter` returns them to the pool instead of releasing them. As a
result, the `shared_ptr` control block, the `_full_method_name` string, and the
pooled `Span` itself are kept alive by the pool by design. LeakSanitizer cannot
follow the pointers held inside the pool and therefore reports these intentional
retentions as leaks.

### What is changed and the side effects?

Changed:

Add `ANNOTATE_SCOPED_MEMORY_LEAK` at the entry of the span factory functions
that allocate through the object pool, so LeakSanitizer ignores these intentional retentions:
  - `Span::CreateClientSpan`
  - `Span::CreateBthreadSpan`
  - `Span::CreateServerSpan` (the overload that performs the allocation)

This reuses the existing suppression mechanism already used in `Server::InitializeOnce` 
for `_keytable_pool`.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
