### PR TITLE
test: wait for asynchronous span collection

### DIFF
--- a/test/brpc_controller_unittest.cpp
+++ b/test/brpc_controller_unittest.cpp
@@ -42,6 +42,14 @@ void MyCancelCallback(bool* cancel_flag) {
     *cancel_flag = true;
 }
 
+bool WaitForSpanToExpire(const std::weak_ptr<brpc::Span>& span) {
+    const int64_t deadline_us = butil::gettimeofday_us() + 5000000L;
+    while (!span.expired() && butil::gettimeofday_us() < deadline_us) {
+        usleep(1000);
+    }
+    return span.expired();
+}
+
 TEST_F(ControllerTest, notify_on_failed) {
     brpc::SocketId id = 0;
     ASSERT_EQ(0, brpc::Socket::Create(brpc::SocketOptions(), &id));
@@ -94,6 +102,7 @@ TEST_F(ControllerTest, root_client_span_kept_alive_until_reset) {
 
     cntl.Reset();
     ASSERT_FALSE(cntl._span);
+    ASSERT_TRUE(WaitForSpanToExpire(weak_span));
 }
 
 TEST_F(ControllerTest, root_client_span_released_by_submit_span) {
@@ -115,6 +124,7 @@ TEST_F(ControllerTest, root_client_span_released_by_submit_span) {
 
     cntl.SubmitSpan();
     ASSERT_FALSE(cntl._span);
+    ASSERT_TRUE(WaitForSpanToExpire(weak_span));
 }
 
 #if ! BRPC_WITH_GLOG


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`brpc_controller_unittest` may fail under LeakSanitizer with a 110-byte leak report after the root client span tests. The spans have already been submitted to the asynchronous bvar collector, but the short-lived test process can exit before the collector releases its references.

### What is changed and the side effects?

Changed:

- Add a bounded `WaitForSpanToExpire` helper that polls the test's `weak_ptr` for at most 5 seconds.
- Wait for asynchronous span collection after both `Controller::Reset` and `Controller::SubmitSpan`.
- Assert the observable lifetime contract instead of suppressing LeakSanitizer reports for all span factory allocations.

Side effects:
- Performance effects: Test-only. The two affected tests normally wait for approximately one collector interval and fail after a 5-second deadline if collection does not complete.
- Breaking backward compatibility: None.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
