### PR TITLE
Fix SOFA PBRPC parser not limiting metadata size

### DIFF
--- a/src/brpc/policy/sofa_pbrpc_protocol.cpp
+++ b/src/brpc/policy/sofa_pbrpc_protocol.cpp
@@ -189,11 +189,12 @@ ParseResult ParseSofaMessage(butil::IOBuf* source, Socket* socket,
                    << " + body_size=" << body_size;
         return MakeParseError(PARSE_ERROR_TRY_OTHERS);
     }
-    if (body_size > FLAGS_max_body_size) {
-        // We need this log to report the body_size to give users some clues
+    if (body_size > FLAGS_max_body_size ||
+        meta_size > FLAGS_max_body_size) {
+        // We need this log to report the size to give users some clues
         // which is not printed in InputMessenger.
-        LOG(ERROR) << "body_size=" << body_size << " from "
-                   << socket->remote_side() << " is too large";
+        LOG(ERROR) << "body_size=" << body_size << " meta_size=" << meta_size
+                   << " from " << socket->remote_side() << " is too large";
         return MakeParseError(PARSE_ERROR_TOO_BIG_DATA);
     } else if (source->length() < sizeof(header_buf) + msg_size) {
         return MakeParseError(PARSE_ERROR_NOT_ENOUGH_DATA);

--- a/test/brpc_sofa_pbrpc_protocol_unittest.cpp
+++ b/test/brpc_sofa_pbrpc_protocol_unittest.cpp
@@ -214,6 +214,26 @@ protected:
     MyAuthenticator _auth;
 };
 
+// Build a SOFA header without a real SocketMessage. Fields are stored in host
+// byte order (see PackSofaHeader), each 64-bit field is stored as low 32-bit
+// word followed by high 32-bit word.
+static void AppendSofaTestHeader(butil::IOBuf* buf, uint32_t meta_size,
+                                 uint64_t body_size, uint64_t msg_size) {
+    char header[24];
+    memcpy(header, "SOFA", 4);
+    const uint32_t meta = meta_size;
+    const uint32_t body_words[2] = {
+        static_cast<uint32_t>(body_size & 0xFFFFFFFFULL),
+        static_cast<uint32_t>(body_size >> 32)};
+    const uint32_t msg_words[2] = {
+        static_cast<uint32_t>(msg_size & 0xFFFFFFFFULL),
+        static_cast<uint32_t>(msg_size >> 32)};
+    memcpy(header + 4, &meta, sizeof(meta));
+    memcpy(header + 8, body_words, sizeof(body_words));
+    memcpy(header + 16, msg_words, sizeof(msg_words));
+    buf->append(header, sizeof(header));
+}
+
 TEST_F(SofaTest, process_request_failed_socket) {
     brpc::policy::SofaRpcMeta meta;
     meta.set_type(brpc::policy::SofaRpcMeta::REQUEST);
@@ -343,5 +363,27 @@ TEST_F(SofaTest, sofa_compress) {
     TestSofaCompress(brpc::COMPRESS_TYPE_SNAPPY);
     TestSofaCompress(brpc::COMPRESS_TYPE_GZIP);
     TestSofaCompress(brpc::COMPRESS_TYPE_ZLIB);
+}
+
+TEST_F(SofaTest, reject_oversized_body) {
+    GFLAGS_NAMESPACE::FlagSaver flag_saver;
+    brpc::FLAGS_max_body_size = 1024;
+    const uint64_t body_size = 8 * 1024 * 1024;
+    butil::IOBuf buf;
+    AppendSofaTestHeader(&buf, 0, body_size, body_size);
+    brpc::ParseResult pr =
+        brpc::policy::ParseSofaMessage(&buf, _socket.get(), false, NULL);
+    ASSERT_EQ(brpc::PARSE_ERROR_TOO_BIG_DATA, pr.error());
+}
+
+TEST_F(SofaTest, reject_oversized_meta) {
+    GFLAGS_NAMESPACE::FlagSaver flag_saver;
+    brpc::FLAGS_max_body_size = 1024;
+    const uint32_t meta_size = 8 * 1024 * 1024;
+    butil::IOBuf buf;
+    AppendSofaTestHeader(&buf, meta_size, 0, meta_size);
+    brpc::ParseResult pr =
+        brpc::policy::ParseSofaMessage(&buf, _socket.get(), false, NULL);
+    ASSERT_EQ(brpc::PARSE_ERROR_TOO_BIG_DATA, pr.error());
 }
 } //namespace


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: null

Problem Summary:

The SOFA PBRPC parser (`ParseSofaMessage`) enforces `FLAGS_max_body_size`
only on the frame's `body_size` field. The `meta_size` field, and
therefore the whole frame size, is not bounded. A peer can send a frame
with a large `meta_size` and `body_size = 0`, which passes the current
check, so the connection keeps reading and buffering the declared frame
until the metadata is finally parsed (and rejected). This makes the
configured per-message limit ineffective and can consume much more memory
than expected.

### What is changed and the side effects?

Changed:

- In `ParseSofaMessage`, reject frames whose `meta_size` exceeds
  `FLAGS_max_body_size`, in addition to the existing `body_size` check.
- Add unit tests in `test/brpc_sofa_pbrpc_protocol_unittest.cpp` covering
  an oversized body and an oversized metadata block.

Side effects:

- Performance effects: none.
- Breaking backward compatibility: SOFA frames whose metadata exceeds
  `max_body_size` (previously buffered and then rejected at protobuf
  parsing time) are now rejected earlier with a "too big data" error and
  the connection is closed.

---

### Check List:

- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).

Tests run:

- `test/brpc_sofa_pbrpc_protocol_unittest` (all cases passed)