### PR TITLE
Fix RTMP abort message deleting the chunk stream being parsed

### DIFF
--- a/src/brpc/policy/rtmp_protocol.cpp
+++ b/src/brpc/policy/rtmp_protocol.cpp
@@ -1869,7 +1869,12 @@ bool RtmpChunkStream::OnAbortMessage(
         RTMP_ERROR(socket, mh) << "Invalid chunk_stream_id=" << cs_id;
         return false;
     }
-    connection_context()->ClearChunkStream(cs_id);
+    // Do not delete the chunk stream that is currently being parsed (i.e.
+    // the one running this Feed). Clearing it here would free `this' while
+    // Feed() still holds and later touches it, causing a use-after-free.
+    if (cs_id != _cs_id) {
+        connection_context()->ClearChunkStream(cs_id);
+    }
     return true;
 }
 

--- a/test/brpc_rtmp_unittest.cpp
+++ b/test/brpc_rtmp_unittest.cpp
@@ -814,12 +814,12 @@ TEST(RtmpTest, flv_reader_rejects_zero_datasize_audio_tag) {
 TEST(RtmpTest, abort_message_naming_own_chunk_stream) {
     int pipe_fds[2];
     ASSERT_EQ(0, pipe(pipe_fds));
-    butil::fd_guard guard0(pipe_fds[0]);
-    butil::fd_guard guard1(pipe_fds[1]);
+    butil::fd_guard guard0(pipe_fds[0]);   // read end, closed by this guard
+    butil::fd_guard guard1(pipe_fds[1]);   // write end, handed over to Socket
 
     brpc::SocketId id;
     brpc::SocketOptions options;
-    options.fd = pipe_fds[1];
+    options.fd = guard1.release();         // Socket takes ownership of the fd
     ASSERT_EQ(0, brpc::Socket::Create(options, &id));
     brpc::SocketUniquePtr sock;
     ASSERT_EQ(0, brpc::Socket::Address(id, &sock));
@@ -845,12 +845,23 @@ TEST(RtmpTest, abort_message_naming_own_chunk_stream) {
 
     butil::IOBuf buf;
     buf.append(chunk);
-    const brpc::ParseResult pr = ctx.Feed(&buf, sock.get());
-    ASSERT_EQ(brpc::PARSE_OK, pr.error());
+    ASSERT_EQ(brpc::PARSE_OK, ctx.Feed(&buf, sock.get()).error());
 
-    // The chunk stream being parsed must survive the abort message: it must
-    // not be deleted by ClearChunkStream while Feed() is still running.
-    ASSERT_TRUE(ctx.GetChunkStream(2) != NULL);
+    // A following type-1 chunk inherits the message header from the previous
+    // message on the same stream. If the abort had wrongly deleted the chunk
+    // stream, the freshly recreated stream would have no last header and this
+    // chunk would be rejected; instead it must be parsed successfully.
+    std::string cont;
+    cont.push_back((char)0x42);   // basic header: fmt=1, cs_id=2
+    cont.append(3, '\0');         // timestamp delta = 0
+    cont.push_back('\0');         // message_length (3 bytes) = 4
+    cont.push_back('\0');
+    cont.push_back((char)0x04);
+    cont.push_back((char)0x03);   // message_type = Ack
+    cont.append(4, '\0');         // payload: bytes_received = 0
+    butil::IOBuf buf2;
+    buf2.append(cont);
+    ASSERT_EQ(brpc::PARSE_OK, ctx.Feed(&buf2, sock.get()).error());
 }
 
 TEST(RtmpTest, successfully_play_streams) {

--- a/test/brpc_rtmp_unittest.cpp
+++ b/test/brpc_rtmp_unittest.cpp
@@ -28,6 +28,8 @@
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include "butil/time.h"
 #include "butil/macros.h"
+#include "butil/fd_guard.h"
+#include "brpc/policy/rtmp_protocol.h"
 #include "brpc/socket.h"
 #include "brpc/acceptor.h"
 #include "brpc/server.h"
@@ -803,6 +805,52 @@ TEST(RtmpTest, flv_reader_rejects_zero_datasize_audio_tag) {
     brpc::RtmpAudioMessage amsg;
     ASSERT_FALSE(reader.Read(&amsg).ok());
     ASSERT_EQ(before, buf.size());
+}
+
+// A crafted Abort message that names the chunk stream currently being parsed
+// (itself) used to make ClearChunkStream delete the RtmpChunkStream while its
+// Feed() is still running, which caused a heap-use-after-free right after
+// OnMessage() returned.
+TEST(RtmpTest, abort_message_naming_own_chunk_stream) {
+    int pipe_fds[2];
+    ASSERT_EQ(0, pipe(pipe_fds));
+    butil::fd_guard guard0(pipe_fds[0]);
+    butil::fd_guard guard1(pipe_fds[1]);
+
+    brpc::SocketId id;
+    brpc::SocketOptions options;
+    options.fd = pipe_fds[1];
+    ASSERT_EQ(0, brpc::Socket::Create(options, &id));
+    brpc::SocketUniquePtr sock;
+    ASSERT_EQ(0, brpc::Socket::Address(id, &sock));
+
+    brpc::policy::RtmpContext ctx(NULL, NULL);
+    ctx.SetState(sock->remote_side(),
+                 brpc::policy::RtmpContext::STATE_RECEIVED_C2);
+
+    // fmt0 chunk on chunk stream 2 carrying an Abort message (type 2) whose
+    // payload is the same chunk stream id (2).
+    std::string chunk;
+    chunk.push_back((char)0x02);   // basic header: fmt=0, cs_id=2
+    chunk.append(3, '\0');         // timestamp = 0
+    chunk.push_back('\0');         // message_length (3 bytes) = 4
+    chunk.push_back('\0');
+    chunk.push_back((char)0x04);
+    chunk.push_back((char)0x02);   // message_type = Abort
+    chunk.append(4, '\0');         // stream_id = 0 (little endian)
+    chunk.push_back('\0');         // payload: cs_id = 2 (big endian)
+    chunk.push_back('\0');
+    chunk.push_back('\0');
+    chunk.push_back((char)0x02);
+
+    butil::IOBuf buf;
+    buf.append(chunk);
+    const brpc::ParseResult pr = ctx.Feed(&buf, sock.get());
+    ASSERT_EQ(brpc::PARSE_OK, pr.error());
+
+    // The chunk stream being parsed must survive the abort message: it must
+    // not be deleted by ClearChunkStream while Feed() is still running.
+    ASSERT_TRUE(ctx.GetChunkStream(2) != NULL);
 }
 
 TEST(RtmpTest, successfully_play_streams) {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: null

Problem Summary:

An RTMP Abort control message that references the chunk stream carrying
the message itself made the parser free that chunk stream while it was
still being processed. `RtmpChunkStream::Feed()` continues to access the
freed chunk stream right after `OnMessage()` returns, which may crash the
server or corrupt memory.

### What is changed and the side effects?

Changed:

- `RtmpChunkStream::OnAbortMessage` now skips `ClearChunkStream` when the
  abort targets the chunk stream that is currently being parsed.
- Added a unit test that feeds a self-referencing Abort message and
  verifies the chunk stream survives.

Side effects:
- Performance effects: None.

- Breaking backward compatibility: None.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
