### PR TITLE
fix(cmake): prioritize discovered zlib headers for brpc sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 find_package(Protobuf REQUIRED)
+find_package(ZLIB REQUIRED)
 if(Protobuf_VERSION VERSION_GREATER 4.21)
     # required by absl
     set(BRPC_CXX_STANDARD 17)
@@ -351,7 +352,7 @@ set(DYNAMIC_LIB
     ${CMAKE_THREAD_LIBS_INIT}
     ${THRIFT_LIB}
     dl
-    z)
+    ZLIB::ZLIB)
 
 if(WITH_BORINGSSL)
     list(APPEND DYNAMIC_LIB ${BORINGSSL_SSL_LIBRARY})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,10 @@ add_dependencies(SOURCES_LIB PROTO_LIB)
 target_link_libraries(BUTIL_LIB PRIVATE brpc_common_config)
 target_link_libraries(SOURCES_LIB PRIVATE brpc_common_config)
 
+# protobuf/io/gzip_stream.h includes <zlib.h>. Prioritize the discovered
+# zlib headers over include directories inherited from parent projects.
+target_include_directories(SOURCES_LIB BEFORE PRIVATE ${ZLIB_INCLUDE_DIRS})
+
 # shared library needs POSITION_INDEPENDENT_CODE
 set_property(TARGET ${SOURCES_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
 set_property(TARGET ${BUTIL_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,10 +21,6 @@ add_dependencies(SOURCES_LIB PROTO_LIB)
 target_link_libraries(BUTIL_LIB PRIVATE brpc_common_config)
 target_link_libraries(SOURCES_LIB PRIVATE brpc_common_config)
 
-# protobuf/io/gzip_stream.h includes <zlib.h>. Prioritize the discovered
-# zlib headers over include directories inherited from parent projects.
-target_include_directories(SOURCES_LIB BEFORE PRIVATE ${ZLIB_INCLUDE_DIRS})
-
 # shared library needs POSITION_INDEPENDENT_CODE
 set_property(TARGET ${SOURCES_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)
 set_property(TARGET ${BUTIL_LIB} PROPERTY POSITION_INDEPENDENT_CODE 1)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #2593

Problem Summary:

zlib is a direct dependency of bRPC, but the CMake build currently links it using the bare library name `z` without explicitly discovering the dependency.

This makes the CMake dependency declaration less portable and prevents CMake from carrying the configuration provided by `FindZLIB`, such as a toolchain-specific library selection.

The problem was observed while investigating #2593, where bRPC was integrated into a parent project with `add_subdirectory`. However, include directories leaked by a parent project should be scoped at the parent-project level and are not worked around by this change.

### What is changed and the side effects?

Changed:

- Add `find_package(ZLIB REQUIRED)` to discover zlib explicitly.
- Replace the bare `z` link dependency with the standard CMake imported target `ZLIB::ZLIB`.

This makes bRPC's direct zlib dependency explicit and allows CMake to use the zlib library selected by the active toolchain or package configuration.

This PR does not modify global or target include ordering. Parent projects remain responsible for scoping unrelated include directories with target-level CMake commands such as `target_include_directories`.

Side effects:

- Performance effects: 
- Breaking backward compatibility: 
- Dependency changes: 

### Verification

Standard builds:

- Standalone bRPC CMake build: passed.
- GitHub Actions `Build and Test on Linux`: passed.
- CMake builds with GCC and Clang, using both default and all-options configurations: passed.
- GitHub Actions `Build on Macos`: passed.
- GitHub Actions `License Check`: passed.

Scope validation:

After removing the `SOURCES_LIB` include-order workaround, the original parent-project collision was tested again with:

- `/workspace/cryptopp` added as a directory-level include path by the parent project;
- bRPC integrated through `add_subdirectory`;
- `REPRO_CRYPTOPP_ZLIB_COLLISION=ON`;
- a fresh build directory.

CMake configuration succeeded, but compilation failed at step 213/378. The compile command placed the parent include directory before the bRPC source directory:

```text
-I/workspace/cryptopp -I/workspace/brpc/src
```
Protobuf's gzip_stream.h then selected Crypto++'s unrelated zlib.h and failed with:
error: 'z_stream' does not name a type
This confirms that linking through ZLIB::ZLIB improves dependency modeling but does not correct include directories leaked by a parent project. Following the review feedback, that collision is considered a parent-project dependency-scoping issue and is intentionally not worked around by this PR.

### Check List:

- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [[Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md)](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).