### PR TITLE
Run Bazel tests in parallel in CI

### DIFF
--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -61,7 +61,6 @@ runs:
         key: ${{ runner.os }}-bazel-disk-${{ github.job }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-bazel-disk-${{ github.job }}-
-          ${{ runner.os }}-bazel-disk-
 
     - name: Configure Bazel caches
       if: inputs.kind == 'bazel'

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -203,7 +203,12 @@ jobs:
     # real server (e.g. brpc_redis_unittest) actually run under bazel instead
     # of skipping. Same shared action the make-based unittest jobs use.
     - uses: ./.github/actions/install-essential-dependencies
-    - run: bazel test --config=rdma --config=ubring //test/...
+    - run: |
+        bazel test --test_output=errors \
+                   --local_test_jobs=3 \
+                   --config=rdma \
+                   --config=ubring \
+                   //test/...
 
   gcc-compile-with-bazel-all-options:
     runs-on: ubuntu-22.04
@@ -256,7 +261,9 @@ jobs:
     # actually run under bazel (see gcc-unittest-with-bazel).
     - uses: ./.github/actions/install-essential-dependencies
     - run: |
-        bazel test --test_output=streamed \
+        # Keep test targets parallel; streamed output forces local serial execution.
+        bazel test --test_output=errors \
+                   --local_test_jobs=3 \
                    --action_env=CC=clang \
                    --config=rdma \
                    --config=ubring \
@@ -384,7 +391,9 @@ jobs:
         grep -qE "bazel_dep\(name = ['\"]protobuf['\"], version = ['\"]${TEST_PROTOBUF_VERSION}['\"]" MODULE.bazel \
           || { echo "ERROR: failed to override protobuf version in MODULE.bazel to ${TEST_PROTOBUF_VERSION}"; exit 1; }
     - run: | 
-        bazel test --action_env=CC=clang --config=rdma --config=ubring \
+        bazel test --test_output=errors \
+                   --local_test_jobs=3 \
+                   --action_env=CC=clang --config=rdma --config=ubring \
                    --define with_bthread_tracer=true \
                    --define with_babylon_counter=true \
                    //test/...

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -207,6 +207,11 @@ generate_unittests(
         "@com_google_googletest//:gtest_main",
     ] + TCMALLOC_DEP_UNLESS_ASAN,
     copts = COPTS,
+    per_test_tags = {
+        "bthread_cond_unittest.cpp": ["exclusive"],
+        "bthread_fd_unittest.cpp": ["exclusive"],
+        "bthread_unittest.cpp": ["exclusive"],
+    },
 )
 
 # Expose unit-test data files (cert*, jsonout) at the runfiles workspace root
@@ -252,8 +257,14 @@ generate_unittests(
     # PATH, apt-installed by install-essential-dependencies); tag them the same
     # so bazel never serves a cached pass that actually skipped and runs them
     # outside the sandbox where mysqld and loopback are visible.
+    # Run timing-sensitive event-loop and socket tests without competing test
+    # processes. Their assertions intentionally depend on prompt scheduling.
     per_test_tags = {
+        "brpc_event_dispatcher_unittest.cpp": ["exclusive"],
+        "brpc_http_rpc_protocol_unittest.cpp": ["exclusive"],
         "brpc_redis_unittest.cpp": ["external", "local"],
+        "brpc_server_unittest.cpp": ["exclusive"],
+        "brpc_socket_unittest.cpp": ["exclusive"],
         "brpc_mysql_auth_handshake_unittest.cpp": ["external", "local"],
         "brpc_mysql_connection_type_unittest.cpp": ["external", "local"],
         "brpc_mysql_prepared_integration_unittest.cpp": ["external", "local"],

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -285,6 +285,7 @@ generate_unittests(
     per_test_size = {
         "brpc_channel_unittest.cpp": "large",
         "brpc_load_balancer_unittest.cpp": "large",
+        "brpc_protobuf_json_unittest.cpp": "large",
     },
 )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -257,14 +257,18 @@ generate_unittests(
     # PATH, apt-installed by install-essential-dependencies); tag them the same
     # so bazel never serves a cached pass that actually skipped and runs them
     # outside the sandbox where mysqld and loopback are visible.
-    # Run timing-sensitive event-loop and socket tests without competing test
-    # processes. Their assertions intentionally depend on prompt scheduling.
+    # Run timing-sensitive tests and tests that manipulate process-wide
+    # networking state without competing test processes.
     per_test_tags = {
+        "brpc_channel_unittest.cpp": ["exclusive"],
         "brpc_event_dispatcher_unittest.cpp": ["exclusive"],
         "brpc_http_rpc_protocol_unittest.cpp": ["exclusive"],
         "brpc_redis_unittest.cpp": ["external", "local"],
+        "brpc_rdma_unittest.cpp": ["exclusive"],
         "brpc_server_unittest.cpp": ["exclusive"],
         "brpc_socket_unittest.cpp": ["exclusive"],
+        "brpc_ssl_unittest.cpp": ["exclusive"],
+        "brpc_streaming_rpc_unittest.cpp": ["exclusive"],
         "brpc_mysql_auth_handshake_unittest.cpp": ["external", "local"],
         "brpc_mysql_connection_type_unittest.cpp": ["external", "local"],
         "brpc_mysql_prepared_integration_unittest.cpp": ["external", "local"],

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -2767,14 +2767,12 @@ void ReadOneResponse(brpc::SocketUniquePtr& sock,
 }
 
 TEST_F(HttpTest, http_expect) {
-    const int port = 8923;
     brpc::Server server;
     HttpServiceImpl svc;
     EXPECT_EQ(0, server.AddService(&svc, brpc::SERVER_DOESNT_OWN_SERVICE));
-    EXPECT_EQ(0, server.Start(port, nullptr));
+    EXPECT_EQ(0, server.Start(0, nullptr));
 
-    butil::EndPoint ep;
-    ASSERT_EQ(0, butil::str2endpoint("127.0.0.1:8923", &ep));
+    const butil::EndPoint ep = server.listen_address();
     brpc::SocketOptions options;
     options.remote_side = ep;
     brpc::SocketId id;

--- a/test/brpc_interceptor_unittest.cpp
+++ b/test/brpc_interceptor_unittest.cpp
@@ -38,7 +38,6 @@ int main(int argc, char* argv[]) {
 
 const int EREJECT = 4000;
 int g_index = 0;
-const int port = 8613;
 const std::string EXP_REQUEST = "hello";
 const std::string EXP_RESPONSE = "world";
 const std::string NSHEAD_EXP_RESPONSE = "error";
@@ -108,7 +107,7 @@ public:
         options.interceptor = new MyInterceptor;
         options.nshead_service = new MyNsheadProtocol;
         options.server_owns_interceptor = true;
-        EXPECT_EQ(0, _server.Start(port, &options));
+        EXPECT_EQ(0, _server.Start(0, &options));
     }
 
     ~InterceptorTest() override = default;
@@ -143,7 +142,7 @@ TEST_F(InterceptorTest, sanity) {
     {
         brpc::Channel channel;
         brpc::ChannelOptions options;
-        ASSERT_EQ(0, channel.Init("localhost", port, &options));
+        ASSERT_EQ(0, channel.Init(_server.listen_address(), &options));
         test::EchoService_Stub stub(&channel);
         CallMethod(stub, req, res);
     }
@@ -153,7 +152,7 @@ TEST_F(InterceptorTest, sanity) {
         brpc::Channel channel;
         brpc::ChannelOptions options;
         options.protocol = brpc::PROTOCOL_HTTP;
-        ASSERT_EQ(0, channel.Init("localhost", port, &options));
+        ASSERT_EQ(0, channel.Init(_server.listen_address(), &options));
         test::EchoService_Stub stub(&channel);
         // Set the x-bd-error-code header of http response to brpc error code.
         brpc::policy::FLAGS_use_http_error_code = true;
@@ -165,7 +164,7 @@ TEST_F(InterceptorTest, sanity) {
         brpc::Channel channel;
         brpc::ChannelOptions options;
         options.protocol = brpc::PROTOCOL_HULU_PBRPC;
-        ASSERT_EQ(0, channel.Init("localhost", port, &options));
+        ASSERT_EQ(0, channel.Init(_server.listen_address(), &options));
         test::EchoService_Stub stub(&channel);
         CallMethod(stub, req, res);
     }
@@ -175,7 +174,7 @@ TEST_F(InterceptorTest, sanity) {
         brpc::Channel channel;
         brpc::ChannelOptions options;
         options.protocol = brpc::PROTOCOL_SOFA_PBRPC;
-        ASSERT_EQ(0, channel.Init("localhost", port, &options));
+        ASSERT_EQ(0, channel.Init(_server.listen_address(), &options));
         test::EchoService_Stub stub(&channel);
         CallMethod(stub, req, res);
     }
@@ -185,7 +184,7 @@ TEST_F(InterceptorTest, sanity) {
         brpc::Channel channel;
         brpc::ChannelOptions options;
         options.protocol = brpc::PROTOCOL_NSHEAD;
-        ASSERT_EQ(0, channel.Init("localhost", port, &options));
+        ASSERT_EQ(0, channel.Init(_server.listen_address(), &options));
         brpc::NsheadMessage request;
         for (g_index = 0; g_index < 1000; ++g_index) {
             brpc::Controller cntl;

--- a/test/brpc_server_unittest.cpp
+++ b/test/brpc_server_unittest.cpp
@@ -1918,11 +1918,13 @@ TEST_F(ServerTest, single_repeated_to_array) {
 }
 
 TEST_F(ServerTest, too_big_message) {
+    GFLAGS_NAMESPACE::FlagSaver flag_saver;
+    brpc::FLAGS_max_body_size = 1024;
     EchoServiceImpl echo_svc;
     brpc::Server server;
     ASSERT_EQ(0, server.AddService(&echo_svc,
                                    brpc::SERVER_DOESNT_OWN_SERVICE));
-    ASSERT_EQ(0, server.Start(8613, nullptr));
+    ASSERT_EQ(0, server.Start(0, nullptr));
 
 #if !BRPC_WITH_GLOG
     logging::StringSink log_str;
@@ -1930,7 +1932,7 @@ TEST_F(ServerTest, too_big_message) {
 #endif
 
     brpc::Channel chan;
-    ASSERT_EQ(0, chan.Init("localhost:8613", nullptr));
+    ASSERT_EQ(0, chan.Init(server.listen_address(), nullptr));
     brpc::Controller cntl;
     test::EchoRequest req;
     test::EchoResponse res;

--- a/test/endpoint_unittest.cpp
+++ b/test/endpoint_unittest.cpp
@@ -190,6 +190,10 @@ static void test_listen_connect(const std::string& server_addr, const std::strin
 
     int listen_fd = butil::tcp_listen(point);
     ASSERT_GT(listen_fd, 0);
+    if (point.port == 0) {
+        ASSERT_EQ(0, butil::get_local_side(listen_fd, &point));
+    }
+    const std::string actual_server_addr = butil::endpoint2str(point).c_str();
     pthread_t pid;
     pthread_create(&pid, nullptr, server_proc, (void*)(int64_t)listen_fd);
 
@@ -206,7 +210,7 @@ static void test_listen_connect(const std::string& server_addr, const std::strin
         ASSERT_EQ(exp_client_addr, s.substr(0, exp_client_addr.size()));
     }
     ASSERT_EQ(0, butil::get_remote_side(fd, &point2));
-    ASSERT_EQ(server_addr, butil::endpoint2str(point2).c_str());
+    ASSERT_EQ(actual_server_addr, butil::endpoint2str(point2).c_str());
     close(fd);
 
     void* ret = nullptr;
@@ -225,7 +229,7 @@ static void test_parse_and_serialize(const std::string& instr, const std::string
 }
 
 TEST(EndPointTest, ipv4) {
-    test_listen_connect("127.0.0.1:8787", "127.0.0.1:");
+    test_listen_connect("127.0.0.1:0", "127.0.0.1:");
 }
 
 TEST(EndPointTest, ipv6) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve

Problem Summary:

The Bazel unit-test jobs run independent test binaries serially or without an
explicit concurrency limit. This makes the jobs unnecessarily slow, while
unrestricted concurrency exposes tests that rely on timing, fixed ports, or
process-wide networking state to resource contention.

The Bazel disk-cache fallback can also restore an archive produced by a
different compiler or protobuf configuration. Such an archive consumes cache
transfer time and capacity without producing cache hits.

### What is changed and the side effects?

Changed:

- Run the GCC, Clang, and Clang with new protobuf Bazel unit-test jobs with
  `--test_output=errors` and `--local_test_jobs=3`.
- Run timing-sensitive tests and tests that manipulate process-wide networking
  state exclusively, while keeping independent test binaries parallel.
- Use ephemeral ports in the interceptor, HTTP expect, endpoint, and oversized
  message tests to avoid conflicts with other processes.
- Set and restore the oversized-message test's maximum body size explicitly.
- Declare the protobuf JSON test as a large Bazel test so its timeout matches
  its existing runtime under CI contention.
- Restrict Bazel disk-cache fallback restoration to caches produced by the
  same CI job.

Side effects:

- Performance effects: reduces Bazel unit-test wall time while limiting local
  test concurrency to avoid overloading GitHub-hosted runners.
- Breaking backward compatibility: No. Production library behavior is
  unchanged; this updates CI scheduling and test robustness.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
