### PR TITLE
Feat: Add adaptive input message batching

### DIFF
--- a/src/brpc/input_messenger.cpp
+++ b/src/brpc/input_messenger.cpp
@@ -98,7 +98,11 @@ void* ProcessInputMessage(void* void_arg) {
 void* ProcessInputMessageBatch(void* void_arg) {
     std::unique_ptr<InputMessageBatch> batch(
         static_cast<InputMessageBatch*>(void_arg));
-    batch->Run();
+    try {
+        batch->Run();
+    } catch (...) {
+        LOG(ERROR) << "An input message handler threw while processing a batch";
+    }
     return nullptr;
 }
 
@@ -108,8 +112,13 @@ InputMessageBatch::InputMessageBatch(size_t capacity) {
         capacity, static_cast<size_t>(MAX_ADAPTIVE_INPUT_BATCH_SIZE)));
 }
 
-InputMessageBatch::~InputMessageBatch() noexcept(false) {
-    Run();
+InputMessageBatch::~InputMessageBatch() noexcept {
+    try {
+        Run();
+    } catch (...) {
+        LOG(ERROR) << "An input message handler threw during batch cleanup";
+        DestroyRemainingMessages();
+    }
 }
 
 void InputMessageBatch::add(InputMessageBase* msg) {
@@ -120,7 +129,27 @@ void InputMessageBatch::add(InputMessageBase* msg) {
 
 void InputMessageBatch::Run() {
     for (size_t i = 0; i < _msgs.size(); ++i) {
-        ProcessInputMessage(_msgs[i]);
+        InputMessageBase* msg = _msgs[i];
+        _msgs[i] = nullptr;
+        if (msg == nullptr) {
+            continue;
+        }
+        ProcessInputMessage(msg);
+    }
+    _msgs.clear();
+}
+
+void InputMessageBatch::DestroyRemainingMessages() noexcept {
+    for (size_t i = 0; i < _msgs.size(); ++i) {
+        if (_msgs[i] == nullptr) {
+            continue;
+        }
+        try {
+            _msgs[i]->Destroy();
+        } catch (...) {
+            LOG(ERROR) << "Failed to destroy an unprocessed input message";
+        }
+        _msgs[i] = nullptr;
     }
     _msgs.clear();
 }

--- a/src/brpc/input_messenger.cpp
+++ b/src/brpc/input_messenger.cpp
@@ -102,6 +102,12 @@ void* ProcessInputMessageBatch(void* void_arg) {
     return nullptr;
 }
 
+InputMessageBatch::InputMessageBatch(size_t capacity) {
+    // Avoid a large upfront allocation from a user-controlled fixed batch size.
+    _msgs.reserve(std::min(
+        capacity, static_cast<size_t>(MAX_ADAPTIVE_INPUT_BATCH_SIZE)));
+}
+
 InputMessageBatch::~InputMessageBatch() noexcept(false) {
     Run();
 }

--- a/src/brpc/input_messenger.cpp
+++ b/src/brpc/input_messenger.cpp
@@ -17,6 +17,8 @@
 
 
 #include <gflags/gflags.h>
+#include <algorithm>
+#include <memory>
 #include "butil/fd_guard.h"                      // fd_guard
 #include "butil/logging.h"                       // CHECK
 #include "butil/time.h"                          // cpuwide_time_us
@@ -72,13 +74,49 @@ DEFINE_int32(socket_tcp_user_timeout_ms, -1,
              "connection and return ETIMEDOUT to the application. Only linux supports "
              "TCP_USER_TIMEOUT.");
 
+DEFINE_int32(input_message_batch_process_size, 0,
+             "Experimental. -1 adaptively processes up to 16 parsed input "
+             "messages in one bthread based on the recent per-socket burst. "
+             "Values greater than 1 use a fixed batch size. 0 or 1 preserves "
+             "the original one-message-per-bthread behavior.");
+static bool ValidateInputMessageBatchProcessSize(const char*, int32_t value) {
+    return value >= -1;
+}
+BRPC_VALIDATE_GFLAG(input_message_batch_process_size,
+                    ValidateInputMessageBatchProcessSize);
+
 DECLARE_bool(usercode_in_pthread);
 DECLARE_bool(usercode_in_coroutine);
+const uint32_t MAX_ADAPTIVE_INPUT_BATCH_SIZE = 16;
 
 void* ProcessInputMessage(void* void_arg) {
     InputMessageBase* msg = static_cast<InputMessageBase*>(void_arg);
     msg->_process(msg);
     return nullptr;
+}
+
+void* ProcessInputMessageBatch(void* void_arg) {
+    std::unique_ptr<InputMessageBatch> batch(
+        static_cast<InputMessageBatch*>(void_arg));
+    batch->Run();
+    return nullptr;
+}
+
+InputMessageBatch::~InputMessageBatch() noexcept(false) {
+    Run();
+}
+
+void InputMessageBatch::add(InputMessageBase* msg) {
+    if (msg) {
+        _msgs.push_back(msg);
+    }
+}
+
+void InputMessageBatch::Run() {
+    for (size_t i = 0; i < _msgs.size(); ++i) {
+        ProcessInputMessage(_msgs[i]);
+    }
+    _msgs.clear();
 }
 
 struct RunLastMessage {
@@ -107,8 +145,10 @@ void InputMessenger::OnNewMessages(Socket* m) {
     // - If the socket has several messages, all messages will be parsed (
     //   meaning cutting from butil::IOBuf. serializing from protobuf is part of
     //   "process") in this bthread. All messages except the last one will be
-    //   processed in separate bthreads. To minimize the overhead, scheduling
-    //   is batched(notice the BTHREAD_NOSIGNAL and bthread_flush).
+    //   processed in separate bthreads, or in batches when
+    //   -input_message_batch_process_size is -1 or greater than 1. To minimize
+    //   the overhead, scheduling is batched(notice the BTHREAD_NOSIGNAL and
+    //   bthread_flush).
     // - Verify will always be called in this bthread at most once and before
     //   any process.
     InputMessengerProcessor& processor = m->fd_input_processor();

--- a/src/brpc/input_messenger.h
+++ b/src/brpc/input_messenger.h
@@ -98,9 +98,7 @@ private:
 class InputMessageBatch {
 public:
     InputMessageBatch() {}
-    explicit InputMessageBatch(size_t capacity) {
-        _msgs.reserve(capacity);
-    }
+    explicit InputMessageBatch(size_t capacity);
     ~InputMessageBatch() noexcept(false);
 
     void add(InputMessageBase* msg);

--- a/src/brpc/input_messenger.h
+++ b/src/brpc/input_messenger.h
@@ -19,6 +19,9 @@
 #ifndef BRPC_INPUT_MESSENGER_H
 #define BRPC_INPUT_MESSENGER_H
 
+#include <memory>
+#include <vector>
+
 #include "butil/iobuf.h"                    // butil::IOBuf
 #include "brpc/socket.h"              // SocketId, SocketUser
 #include "brpc/parse_result.h"        // ParseResult
@@ -92,6 +95,26 @@ private:
     InputMessageBase* _msg;
 };
 
+class InputMessageBatch {
+public:
+    InputMessageBatch() {}
+    explicit InputMessageBatch(size_t capacity) {
+        _msgs.reserve(capacity);
+    }
+    ~InputMessageBatch() noexcept(false);
+
+    void add(InputMessageBase* msg);
+    void Run();
+    bool empty() const { return _msgs.empty(); }
+    size_t size() const { return _msgs.size(); }
+
+private:
+    std::vector<InputMessageBase*> _msgs;
+};
+
+void* ProcessInputMessage(void* void_arg);
+void* ProcessInputMessageBatch(void* void_arg);
+
 // Process messages from connections.
 // `Message' corresponds to a client's request or a server's response.
 class InputMessenger : public SocketUser {
@@ -137,7 +160,6 @@ protected:
     static void OnNewMessages(Socket* m);
     
 private:
-
     // User-supplied scissors and handlers.
     // the index of handler is exactly the same as the protocol
     InputMessageHandler* _handlers;

--- a/src/brpc/input_messenger.h
+++ b/src/brpc/input_messenger.h
@@ -99,7 +99,7 @@ class InputMessageBatch {
 public:
     InputMessageBatch() {}
     explicit InputMessageBatch(size_t capacity);
-    ~InputMessageBatch() noexcept(false);
+    ~InputMessageBatch() noexcept;
 
     void add(InputMessageBase* msg);
     void Run();
@@ -107,6 +107,8 @@ public:
     size_t size() const { return _msgs.size(); }
 
 private:
+    void DestroyRemainingMessages() noexcept;
+
     std::vector<InputMessageBase*> _msgs;
 };
 

--- a/src/brpc/input_messenger_processor.cpp
+++ b/src/brpc/input_messenger_processor.cpp
@@ -181,12 +181,11 @@ void InputMessengerProcessor::Reset() {
 
 void InputMessengerProcessor::QueueInputMessageBatch(
         std::unique_ptr<InputMessageBatch>* batch,
-        int* num_bthread_created, bool last_msg) {
+        int* num_bthread_created) {
     if (!batch->get() || (*batch)->empty()) {
         return;
     }
-    _socket->_transport->QueueMessages(
-        batch->release(), num_bthread_created, last_msg);
+    _socket->_transport->QueueMessages(batch->release(), num_bthread_created);
 }
 
 void InputMessengerProcessor::QueueLastMessageOrBatch(
@@ -208,7 +207,7 @@ void InputMessengerProcessor::QueueLastMessageOrBatch(
     }
     (*batch)->add(msg);
     if ((*batch)->size() >= batch_size) {
-        QueueInputMessageBatch(batch, num_bthread_created, false);
+        QueueInputMessageBatch(batch, num_bthread_created);
     }
 }
 
@@ -383,7 +382,7 @@ int InputMessengerProcessor::ProcessNewMessage(ssize_t bytes, bool read_eof,
             last_msg.reset(msg.release());
             if (batch_process) {
                 QueueInputMessageBatch(
-                    &input_batch, &num_bthread_created, false);
+                    &input_batch, &num_bthread_created);
             }
             _socket->_transport->QueueMessage(last_msg, &num_bthread_created, false);
             bthread_flush();
@@ -395,8 +394,7 @@ int InputMessengerProcessor::ProcessNewMessage(ssize_t bytes, bool read_eof,
     // method for processing messages may call synchronization primitives,
     // causing the polling bthread to be scheduled out.
     if (batch_process) {
-        QueueInputMessageBatch(
-            &input_batch, &num_bthread_created, false);
+        QueueInputMessageBatch(&input_batch, &num_bthread_created);
     }
     if (_socket->_socket_mode == SOCKET_MODE_RDMA ||
         _socket->_socket_mode == SOCKET_MODE_UBRING) {

--- a/src/brpc/input_messenger_processor.cpp
+++ b/src/brpc/input_messenger_processor.cpp
@@ -394,10 +394,11 @@ int InputMessengerProcessor::ProcessNewMessage(ssize_t bytes, bool read_eof,
     // method for processing messages may call synchronization primitives,
     // causing the polling bthread to be scheduled out.
     if (batch_process) {
+        QueueLastMessageOrBatch(
+            last_msg, &input_batch, &num_bthread_created, batch_size);
         QueueInputMessageBatch(&input_batch, &num_bthread_created);
-    }
-    if (_socket->_socket_mode == SOCKET_MODE_RDMA ||
-        _socket->_socket_mode == SOCKET_MODE_UBRING) {
+    } else if (_socket->_socket_mode == SOCKET_MODE_RDMA ||
+               _socket->_socket_mode == SOCKET_MODE_UBRING) {
         _socket->_transport->QueueMessage(last_msg, &num_bthread_created, true);
     }
     if (adaptive_batch_process && batchable_message_count != 0) {

--- a/src/brpc/input_messenger_processor.cpp
+++ b/src/brpc/input_messenger_processor.cpp
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <algorithm>
+#include <new>
+
 #include "butil/logging.h"
 #include "butil/binary_printer.h"
 #include "bthread/unstable.h"
@@ -26,10 +29,16 @@
 namespace brpc {
 
 DECLARE_uint64(max_body_size);
+DECLARE_bool(usercode_in_coroutine);
+DECLARE_int32(input_message_batch_process_size);
 
 const size_t MSG_SIZE_WINDOW = 10;  // Take last so many message into stat.
 const size_t MIN_ONCE_READ = 4096;
 const size_t MAX_ONCE_READ = 524288;
+const uint32_t INPUT_BATCH_EMA_SCALE = 256;
+const uint32_t MAX_ADAPTIVE_INPUT_BATCH_SIZE = 16;
+const uint32_t MAX_ADAPTIVE_INPUT_BATCH_SAMPLE =
+    MAX_ADAPTIVE_INPUT_BATCH_SIZE * 2;
 
 static const char* StreamTypeName(InputMessengerProcessor::StreamType type) {
     switch (type) {
@@ -167,8 +176,79 @@ size_t InputMessengerProcessor::OnceReadSize() const {
 
 void InputMessengerProcessor::Reset() {
     _read_buf.clear();
-    _last_msg_size = 0;
-    _avg_msg_size = 0;
+    ResetMsgSizeStats();
+}
+
+void InputMessengerProcessor::QueueInputMessageBatch(
+        std::unique_ptr<InputMessageBatch>* batch,
+        int* num_bthread_created, bool last_msg) {
+    if (!batch->get() || (*batch)->empty()) {
+        return;
+    }
+    _socket->_transport->QueueMessages(
+        batch->release(), num_bthread_created, last_msg);
+}
+
+void InputMessengerProcessor::QueueLastMessageOrBatch(
+        InputMessageClosure& last_msg,
+        std::unique_ptr<InputMessageBatch>* batch,
+        int* num_bthread_created, size_t batch_size) {
+    InputMessageBase* msg = last_msg.release();
+    if (msg == nullptr) {
+        return;
+    }
+    if (!batch->get()) {
+        batch->reset(new (std::nothrow) InputMessageBatch(batch_size));
+    }
+    if (!batch->get()) {
+        last_msg.reset(msg);
+        _socket->_transport->QueueMessage(
+            last_msg, num_bthread_created, false);
+        return;
+    }
+    (*batch)->add(msg);
+    if ((*batch)->size() >= batch_size) {
+        QueueInputMessageBatch(batch, num_bthread_created, false);
+    }
+}
+
+uint32_t InputMessengerProcessor::UpdateAdaptiveBatchSize(
+        uint32_t* messages_per_read_ema_q8,
+        uint32_t current_batch_size,
+        size_t parsed_message_count) {
+    if (parsed_message_count == 0) {
+        return current_batch_size;
+    }
+    if (*messages_per_read_ema_q8 == 0 || current_batch_size == 0) {
+        *messages_per_read_ema_q8 = INPUT_BATCH_EMA_SCALE;
+        current_batch_size = 1;
+    }
+
+    const uint32_t sample = static_cast<uint32_t>(
+        std::min(parsed_message_count,
+                 static_cast<size_t>(MAX_ADAPTIVE_INPUT_BATCH_SAMPLE)));
+    const uint32_t sample_q8 = sample * INPUT_BATCH_EMA_SCALE;
+    uint32_t ema_q8 = *messages_per_read_ema_q8;
+    if (sample_q8 > ema_q8) {
+        // Increase slowly to avoid turning a short burst into persistent
+        // head-of-line blocking.
+        ema_q8 += (sample_q8 - ema_q8) / 8;
+    } else {
+        // Reduce quickly when the connection becomes sparse.
+        ema_q8 -= (ema_q8 - sample_q8 + 1) / 2;
+    }
+    *messages_per_read_ema_q8 = ema_q8;
+
+    uint32_t desired_batch_size = 1;
+    while (desired_batch_size < MAX_ADAPTIVE_INPUT_BATCH_SIZE &&
+           ema_q8 > desired_batch_size * INPUT_BATCH_EMA_SCALE) {
+        desired_batch_size *= 2;
+    }
+    if (desired_batch_size > current_batch_size) {
+        // Increase at most one level for each observation.
+        return std::min(current_batch_size * 2, desired_batch_size);
+    }
+    return desired_batch_size;
 }
 
 int InputMessengerProcessor::ProcessNewMessage(ssize_t bytes, bool read_eof,
@@ -184,6 +264,27 @@ int InputMessengerProcessor::ProcessNewMessage(ssize_t bytes, bool read_eof,
 
     size_t last_size = _read_buf.length();
     int num_bthread_created = 0;
+    const int configured_batch_size =
+        FLAGS_input_message_batch_process_size;
+    const bool adaptive_batch_process =
+        configured_batch_size == -1 && !FLAGS_usercode_in_coroutine;
+    size_t batch_size = configured_batch_size > 0
+                        ? static_cast<size_t>(configured_batch_size) : 1;
+    if (adaptive_batch_process) {
+        if (_adaptive_input_message_batch_size == 0) {
+            _input_messages_per_read_ema_q8 = INPUT_BATCH_EMA_SCALE;
+            _adaptive_input_message_batch_size = 1;
+        }
+        batch_size = _adaptive_input_message_batch_size;
+    } else if (_adaptive_input_message_batch_size != 0) {
+        // Do not reuse history after switching away from adaptive mode.
+        _input_messages_per_read_ema_q8 = 0;
+        _adaptive_input_message_batch_size = 0;
+    }
+    const bool batch_process =
+        batch_size > 1 && !FLAGS_usercode_in_coroutine;
+    size_t batchable_message_count = 0;
+    std::unique_ptr<InputMessageBatch> input_batch;
     while (true) {
         size_t index = 8888;
         ParseResult pr = CutInputMessage(messenger, &index, read_eof);
@@ -237,7 +338,13 @@ int InputMessengerProcessor::ProcessNewMessage(ssize_t bytes, bool read_eof,
         // This unique_ptr prevents msg to be lost before transfering
         // ownership to last_msg
         DestroyingPtr<InputMessageBase> msg(pr.message());
-        _socket->_transport->QueueMessage(last_msg, &num_bthread_created, false);
+        if (batch_process) {
+            QueueLastMessageOrBatch(
+                last_msg, &input_batch, &num_bthread_created, batch_size);
+        } else {
+            _socket->_transport->QueueMessage(
+                last_msg, &num_bthread_created, false);
+        }
         if (handlers[index].process == nullptr) {
             LOG(ERROR) << "process of index=" << index << " is NULL";
             continue;
@@ -269,8 +376,15 @@ int InputMessengerProcessor::ProcessNewMessage(ssize_t bytes, bool read_eof,
         if (!_socket->is_read_progressive()) {
             // Transfer ownership to last_msg
             last_msg.reset(msg.release());
+            if (adaptive_batch_process) {
+                ++batchable_message_count;
+            }
         } else {
             last_msg.reset(msg.release());
+            if (batch_process) {
+                QueueInputMessageBatch(
+                    &input_batch, &num_bthread_created, false);
+            }
             _socket->_transport->QueueMessage(last_msg, &num_bthread_created, false);
             bthread_flush();
             num_bthread_created = 0;
@@ -280,9 +394,20 @@ int InputMessengerProcessor::ProcessNewMessage(ssize_t bytes, bool read_eof,
     // not in the bthread where the polling bthread is located, because the
     // method for processing messages may call synchronization primitives,
     // causing the polling bthread to be scheduled out.
+    if (batch_process) {
+        QueueInputMessageBatch(
+            &input_batch, &num_bthread_created, false);
+    }
     if (_socket->_socket_mode == SOCKET_MODE_RDMA ||
         _socket->_socket_mode == SOCKET_MODE_UBRING) {
         _socket->_transport->QueueMessage(last_msg, &num_bthread_created, true);
+    }
+    if (adaptive_batch_process && batchable_message_count != 0) {
+        _adaptive_input_message_batch_size =
+            UpdateAdaptiveBatchSize(
+                &_input_messages_per_read_ema_q8,
+                _adaptive_input_message_batch_size,
+                batchable_message_count);
     }
     if (num_bthread_created) {
         bthread_flush();

--- a/src/brpc/input_messenger_processor.h
+++ b/src/brpc/input_messenger_processor.h
@@ -19,6 +19,8 @@
 #ifndef BRPC_INPUT_MESSENGER_PROCESSOR_H_
 #define BRPC_INPUT_MESSENGER_PROCESSOR_H_
 
+#include <memory>
+
 #include "butil/iobuf.h"                    // butil::IOPortal
 #include "butil/logging.h"                   // DCHECK
 #include "butil/macros.h"                   // DISALLOW_COPY_AND_ASSIGN
@@ -29,6 +31,7 @@ namespace brpc {
 class Socket;
 class InputMessenger;
 class InputMessageClosure;
+class InputMessageBatch;
 
 // The state of one input stream: the data read but not cut off yet, and the
 // message-size statistics used to size the next read.
@@ -43,7 +46,9 @@ public:
 
     InputMessengerProcessor()
         : _socket(nullptr), _stream_type(STREAM_NONE)
-        , _last_msg_size(0), _avg_msg_size(0) {}
+        , _last_msg_size(0), _avg_msg_size(0)
+        , _input_messages_per_read_ema_q8(0)
+        , _adaptive_input_message_batch_size(0) {}
 
     DISALLOW_COPY_AND_ASSIGN(InputMessengerProcessor);
 
@@ -72,12 +77,23 @@ public:
     size_t OnceReadSize() const;
 
     uint32_t avg_msg_size() const { return _avg_msg_size; }
+    uint32_t input_messages_per_read_ema_q8() const {
+        return _input_messages_per_read_ema_q8;
+    }
+    uint32_t adaptive_input_message_batch_size() const {
+        return _adaptive_input_message_batch_size;
+    }
 
     // Drop buffered data and reset the statistics.
     void Reset();
 
     // Reset the message-size statistics only, keeping buffered data.
-    void ResetMsgSizeStats() { _last_msg_size = 0; _avg_msg_size = 0; }
+    void ResetMsgSizeStats() {
+        _last_msg_size = 0;
+        _avg_msg_size = 0;
+        _input_messages_per_read_ema_q8 = 0;
+        _adaptive_input_message_batch_size = 0;
+    }
 
 private:
 
@@ -104,6 +120,18 @@ private:
     // from `_read_buf`, save the index of the scissor into `index`.
     ParseResult CutInputMessage(InputMessenger* messenger, size_t* index, bool read_eof);
 
+    void QueueInputMessageBatch(std::unique_ptr<InputMessageBatch>* batch,
+                                int* num_bthread_created,
+                                bool last_msg);
+    void QueueLastMessageOrBatch(InputMessageClosure& last_msg,
+                                 std::unique_ptr<InputMessageBatch>* batch,
+                                 int* num_bthread_created,
+                                 size_t batch_size);
+    static uint32_t UpdateAdaptiveBatchSize(
+        uint32_t* messages_per_read_ema_q8,
+        uint32_t current_batch_size,
+        size_t parsed_message_count);
+
     // The Socket this stream belongs to. Not owned.
     Socket* _socket;
 
@@ -116,6 +144,10 @@ private:
     uint32_t _last_msg_size;
     // Average message size of last #MSG_SIZE_WINDOW messages (roughly)
     uint32_t _avg_msg_size;
+    // Q8 EMA of processable messages parsed in one read.
+    uint32_t _input_messages_per_read_ema_q8;
+    // 0 when adaptive batching is inactive, otherwise one of 1/2/4/8/16.
+    uint32_t _adaptive_input_message_batch_size;
 };
 
 } // namespace brpc

--- a/src/brpc/input_messenger_processor.h
+++ b/src/brpc/input_messenger_processor.h
@@ -121,8 +121,7 @@ private:
     ParseResult CutInputMessage(InputMessenger* messenger, size_t* index, bool read_eof);
 
     void QueueInputMessageBatch(std::unique_ptr<InputMessageBatch>* batch,
-                                int* num_bthread_created,
-                                bool last_msg);
+                                int* num_bthread_created);
     void QueueLastMessageOrBatch(InputMessageClosure& last_msg,
                                  std::unique_ptr<InputMessageBatch>* batch,
                                  int* num_bthread_created,

--- a/src/brpc/rdma_transport.cpp
+++ b/src/brpc/rdma_transport.cpp
@@ -180,29 +180,8 @@ void RdmaTransport::QueueMessage(InputMessageClosure& input_msg,
 
 void RdmaTransport::QueueMessages(InputMessageBatch* input_msgs,
                                   int* num_bthread_created) {
-    if (!input_msgs || input_msgs->empty()) {
-        delete input_msgs;
-        return;
-    }
-    if (rdma::FLAGS_rdma_disable_bthread) {
-        input_msgs->Run();
-        delete input_msgs;
-        return;
-    }
-
-    bthread_t th;
-    bthread_attr_t tmp =
-        (FLAGS_usercode_in_pthread ? BTHREAD_ATTR_PTHREAD : BTHREAD_ATTR_NORMAL) |
-        BTHREAD_NOSIGNAL;
-    tmp.keytable_pool = _socket->keytable_pool();
-    tmp.tag = bthread_self_tag();
-    if (!FLAGS_usercode_in_coroutine && bthread_start_background(
-            &th, &tmp, ProcessInputMessageBatch, input_msgs) == 0) {
-        ++*num_bthread_created;
-    } else {
-        input_msgs->Run();
-        delete input_msgs;
-    }
+    QueueInputMessageBatch(
+        input_msgs, num_bthread_created, rdma::FLAGS_rdma_disable_bthread);
 }
 
 void RdmaTransport::Debug(std::ostream &os) {

--- a/src/brpc/rdma_transport.cpp
+++ b/src/brpc/rdma_transport.cpp
@@ -179,8 +179,7 @@ void RdmaTransport::QueueMessage(InputMessageClosure& input_msg,
 }
 
 void RdmaTransport::QueueMessages(InputMessageBatch* input_msgs,
-                                  int* num_bthread_created, bool last_msg) {
-    CHECK(!last_msg || rdma::FLAGS_rdma_use_polling);
+                                  int* num_bthread_created) {
     if (!input_msgs || input_msgs->empty()) {
         delete input_msgs;
         return;

--- a/src/brpc/rdma_transport.cpp
+++ b/src/brpc/rdma_transport.cpp
@@ -178,6 +178,34 @@ void RdmaTransport::QueueMessage(InputMessageClosure& input_msg,
     }
 }
 
+void RdmaTransport::QueueMessages(InputMessageBatch* input_msgs,
+                                  int* num_bthread_created, bool last_msg) {
+    CHECK(!last_msg || rdma::FLAGS_rdma_use_polling);
+    if (!input_msgs || input_msgs->empty()) {
+        delete input_msgs;
+        return;
+    }
+    if (rdma::FLAGS_rdma_disable_bthread) {
+        input_msgs->Run();
+        delete input_msgs;
+        return;
+    }
+
+    bthread_t th;
+    bthread_attr_t tmp =
+        (FLAGS_usercode_in_pthread ? BTHREAD_ATTR_PTHREAD : BTHREAD_ATTR_NORMAL) |
+        BTHREAD_NOSIGNAL;
+    tmp.keytable_pool = _socket->keytable_pool();
+    tmp.tag = bthread_self_tag();
+    if (!FLAGS_usercode_in_coroutine && bthread_start_background(
+            &th, &tmp, ProcessInputMessageBatch, input_msgs) == 0) {
+        ++*num_bthread_created;
+    } else {
+        input_msgs->Run();
+        delete input_msgs;
+    }
+}
+
 void RdmaTransport::Debug(std::ostream &os) {
     if (_rdma_state == RDMA_ON && _rdma_ep) {
         _rdma_ep->DebugInfo(os);

--- a/src/brpc/rdma_transport.h
+++ b/src/brpc/rdma_transport.h
@@ -40,6 +40,9 @@ public:
     int WaitEpollOut(butil::atomic<int>* _epollout_butex, bool pollin, const timespec duetime) override;
     void ProcessEvent(bthread_attr_t attr) override;
     void QueueMessage(InputMessageClosure& inputMsg, int* num_bthread_created, bool last_msg) override;
+    void QueueMessages(InputMessageBatch* inputMsgs,
+                       int* num_bthread_created,
+                       bool last_msg) override;
     void Debug(std::ostream &os) override;
     rdma::RdmaEndpoint* GetRdmaEp() {
         CHECK(_rdma_ep != nullptr);

--- a/src/brpc/rdma_transport.h
+++ b/src/brpc/rdma_transport.h
@@ -41,8 +41,7 @@ public:
     void ProcessEvent(bthread_attr_t attr) override;
     void QueueMessage(InputMessageClosure& inputMsg, int* num_bthread_created, bool last_msg) override;
     void QueueMessages(InputMessageBatch* inputMsgs,
-                       int* num_bthread_created,
-                       bool last_msg) override;
+                       int* num_bthread_created) override;
     void Debug(std::ostream &os) override;
     rdma::RdmaEndpoint* GetRdmaEp() {
         CHECK(_rdma_ep != nullptr);

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -571,7 +571,7 @@ void Socket::ReleaseAllFailedWriteRequests(Socket::WriteRequest* req) {
 }
 
 int Socket::ResetFileDescriptor(int fd) {
-    // Reset message sizes when fd is changed.
+    // Reset input heuristics when fd is changed.
     _fd_input_processor.ResetMsgSizeStats();
     // MUST store `_fd' before adding itself into epoll device to avoid
     // race conditions with the callback function inside epoll
@@ -2390,6 +2390,10 @@ void Socket::DebugSocket(std::ostream& os, SocketId id) {
     InputMessengerProcessor& input_processor = ptr->fd_input_processor();
     os << "\nhc_count=" << ptr->_hc_count
        << "\navg_input_msg_size=" << input_processor.avg_msg_size()
+       << "\navg_input_messages_per_read="
+       << ((input_processor.input_messages_per_read_ema_q8() + 128) >> 8)
+       << "\nadaptive_input_message_batch_size="
+       << input_processor.adaptive_input_message_batch_size()
         // NOTE: We're assuming that butil::IOBuf.size() is thread-safe, it is now
         // however it's not guaranteed.
        << "\nread_buf=" << input_processor.read_buf().size()

--- a/src/brpc/tcp_transport.cpp
+++ b/src/brpc/tcp_transport.cpp
@@ -103,4 +103,25 @@ void TcpTransport::QueueMessage(InputMessageClosure& input_msg,
     }
 }
 
+void TcpTransport::QueueMessages(InputMessageBatch* input_msgs,
+                                 int* num_bthread_created, bool) {
+    if (!input_msgs || input_msgs->empty()) {
+        delete input_msgs;
+        return;
+    }
+    bthread_t th;
+    bthread_attr_t tmp =
+        (FLAGS_usercode_in_pthread ? BTHREAD_ATTR_PTHREAD : BTHREAD_ATTR_NORMAL) |
+        BTHREAD_NOSIGNAL;
+    tmp.keytable_pool = _socket->keytable_pool();
+    tmp.tag = bthread_self_tag();
+    if (!FLAGS_usercode_in_coroutine && bthread_start_background(
+            &th, &tmp, ProcessInputMessageBatch, input_msgs) == 0) {
+        ++*num_bthread_created;
+    } else {
+        input_msgs->Run();
+        delete input_msgs;
+    }
+}
+
 } // namespace brpc

--- a/src/brpc/tcp_transport.cpp
+++ b/src/brpc/tcp_transport.cpp
@@ -105,23 +105,7 @@ void TcpTransport::QueueMessage(InputMessageClosure& input_msg,
 
 void TcpTransport::QueueMessages(InputMessageBatch* input_msgs,
                                  int* num_bthread_created) {
-    if (!input_msgs || input_msgs->empty()) {
-        delete input_msgs;
-        return;
-    }
-    bthread_t th;
-    bthread_attr_t tmp =
-        (FLAGS_usercode_in_pthread ? BTHREAD_ATTR_PTHREAD : BTHREAD_ATTR_NORMAL) |
-        BTHREAD_NOSIGNAL;
-    tmp.keytable_pool = _socket->keytable_pool();
-    tmp.tag = bthread_self_tag();
-    if (!FLAGS_usercode_in_coroutine && bthread_start_background(
-            &th, &tmp, ProcessInputMessageBatch, input_msgs) == 0) {
-        ++*num_bthread_created;
-    } else {
-        input_msgs->Run();
-        delete input_msgs;
-    }
+    QueueInputMessageBatch(input_msgs, num_bthread_created, false);
 }
 
 } // namespace brpc

--- a/src/brpc/tcp_transport.cpp
+++ b/src/brpc/tcp_transport.cpp
@@ -104,7 +104,7 @@ void TcpTransport::QueueMessage(InputMessageClosure& input_msg,
 }
 
 void TcpTransport::QueueMessages(InputMessageBatch* input_msgs,
-                                 int* num_bthread_created, bool) {
+                                 int* num_bthread_created) {
     if (!input_msgs || input_msgs->empty()) {
         delete input_msgs;
         return;

--- a/src/brpc/tcp_transport.h
+++ b/src/brpc/tcp_transport.h
@@ -35,8 +35,7 @@ public:
     void ProcessEvent(bthread_attr_t attr) override;
     void QueueMessage(InputMessageClosure& input_msg, int* num_bthread_created, bool last_msg) override;
     void QueueMessages(InputMessageBatch* input_msgs,
-                       int* num_bthread_created,
-                       bool last_msg) override;
+                       int* num_bthread_created) override;
     void Debug(std::ostream &os) override {}
 };
 } // namespace brpc

--- a/src/brpc/tcp_transport.h
+++ b/src/brpc/tcp_transport.h
@@ -34,6 +34,9 @@ public:
     int WaitEpollOut(butil::atomic<int>* _epollout_butex, bool pollin, timespec duetime) override;
     void ProcessEvent(bthread_attr_t attr) override;
     void QueueMessage(InputMessageClosure& input_msg, int* num_bthread_created, bool last_msg) override;
+    void QueueMessages(InputMessageBatch* input_msgs,
+                       int* num_bthread_created,
+                       bool last_msg) override;
     void Debug(std::ostream &os) override {}
 };
 } // namespace brpc

--- a/src/brpc/transport.cpp
+++ b/src/brpc/transport.cpp
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "brpc/transport.h"
+
+namespace brpc {
+DECLARE_bool(usercode_in_coroutine);
+DECLARE_bool(usercode_in_pthread);
+
+void Transport::QueueInputMessageBatch(InputMessageBatch* input_msgs,
+                                       int* num_bthread_created,
+                                       bool run_inline) {
+    if (input_msgs == nullptr || input_msgs->empty()) {
+        delete input_msgs;
+        return;
+    }
+    if (run_inline || FLAGS_usercode_in_coroutine) {
+        ProcessInputMessageBatch(input_msgs);
+        return;
+    }
+
+    bthread_t th;
+    bthread_attr_t tmp =
+        (FLAGS_usercode_in_pthread ? BTHREAD_ATTR_PTHREAD : BTHREAD_ATTR_NORMAL) |
+        BTHREAD_NOSIGNAL;
+    tmp.keytable_pool = _socket->keytable_pool();
+    tmp.tag = bthread_self_tag();
+    bthread_attr_set_name(&tmp, "ProcessInputMessageBatch");
+    if (bthread_start_background(
+            &th, &tmp, ProcessInputMessageBatch, input_msgs) == 0) {
+        ++*num_bthread_created;
+    } else {
+        ProcessInputMessageBatch(input_msgs);
+    }
+}
+
+}  // namespace brpc

--- a/src/brpc/transport.h
+++ b/src/brpc/transport.h
@@ -50,8 +50,7 @@ public:
     virtual void ProcessEvent(bthread_attr_t attr) = 0;
     virtual void QueueMessage(InputMessageClosure& input_msg, int* num_bthread_created, bool last_msg) = 0;
     virtual void QueueMessages(InputMessageBatch* input_msgs,
-                               int* num_bthread_created,
-                               bool last_msg) = 0;
+                               int* num_bthread_created) = 0;
     virtual void Debug(std::ostream &os) = 0;
 
     bool HasOnEdgeTrigger() {

--- a/src/brpc/transport.h
+++ b/src/brpc/transport.h
@@ -60,6 +60,10 @@ public:
         return _on_edge_trigger;
     }
 protected:
+    void QueueInputMessageBatch(InputMessageBatch* input_msgs,
+                                int* num_bthread_created,
+                                bool run_inline);
+
     Socket* _socket;
     std::shared_ptr<AppConnect> _default_connect;
     OnEdgeTrigger _on_edge_trigger;

--- a/src/brpc/transport.h
+++ b/src/brpc/transport.h
@@ -49,6 +49,9 @@ public:
     virtual int WaitEpollOut(butil::atomic<int>* _epollout_butex, bool pollin, timespec duetime) = 0;
     virtual void ProcessEvent(bthread_attr_t attr) = 0;
     virtual void QueueMessage(InputMessageClosure& input_msg, int* num_bthread_created, bool last_msg) = 0;
+    virtual void QueueMessages(InputMessageBatch* input_msgs,
+                               int* num_bthread_created,
+                               bool last_msg) = 0;
     virtual void Debug(std::ostream &os) = 0;
 
     bool HasOnEdgeTrigger() {

--- a/src/brpc/ubshm_transport.cpp
+++ b/src/brpc/ubshm_transport.cpp
@@ -173,30 +173,8 @@ void UBShmTransport::QueueMessage(InputMessageClosure& input_msg,
 
 void UBShmTransport::QueueMessages(InputMessageBatch* input_msgs,
                                    int* num_bthread_created) {
-    if (!input_msgs || input_msgs->empty()) {
-        delete input_msgs;
-        return;
-    }
-    if (ubring::FLAGS_ub_disable_bthread) {
-        input_msgs->Run();
-        delete input_msgs;
-        return;
-    }
-
-    bthread_t th;
-    bthread_attr_t tmp =
-        (FLAGS_usercode_in_pthread ? BTHREAD_ATTR_PTHREAD : BTHREAD_ATTR_NORMAL) |
-        BTHREAD_NOSIGNAL;
-    tmp.keytable_pool = _socket->keytable_pool();
-    tmp.tag = bthread_self_tag();
-    bthread_attr_set_name(&tmp, "ProcessInputMessageBatch");
-    if (!FLAGS_usercode_in_coroutine && bthread_start_background(
-            &th, &tmp, ProcessInputMessageBatch, input_msgs) == 0) {
-        ++*num_bthread_created;
-    } else {
-        input_msgs->Run();
-        delete input_msgs;
-    }
+    QueueInputMessageBatch(
+        input_msgs, num_bthread_created, ubring::FLAGS_ub_disable_bthread);
 }
 
 void UBShmTransport::Debug(std::ostream &os) {}

--- a/src/brpc/ubshm_transport.cpp
+++ b/src/brpc/ubshm_transport.cpp
@@ -172,8 +172,7 @@ void UBShmTransport::QueueMessage(InputMessageClosure& input_msg,
 }
 
 void UBShmTransport::QueueMessages(InputMessageBatch* input_msgs,
-                                   int* num_bthread_created, bool last_msg) {
-    CHECK(!last_msg);
+                                   int* num_bthread_created) {
     if (!input_msgs || input_msgs->empty()) {
         delete input_msgs;
         return;

--- a/src/brpc/ubshm_transport.cpp
+++ b/src/brpc/ubshm_transport.cpp
@@ -171,6 +171,35 @@ void UBShmTransport::QueueMessage(InputMessageClosure& input_msg,
     }
 }
 
+void UBShmTransport::QueueMessages(InputMessageBatch* input_msgs,
+                                   int* num_bthread_created, bool last_msg) {
+    CHECK(!last_msg);
+    if (!input_msgs || input_msgs->empty()) {
+        delete input_msgs;
+        return;
+    }
+    if (ubring::FLAGS_ub_disable_bthread) {
+        input_msgs->Run();
+        delete input_msgs;
+        return;
+    }
+
+    bthread_t th;
+    bthread_attr_t tmp =
+        (FLAGS_usercode_in_pthread ? BTHREAD_ATTR_PTHREAD : BTHREAD_ATTR_NORMAL) |
+        BTHREAD_NOSIGNAL;
+    tmp.keytable_pool = _socket->keytable_pool();
+    tmp.tag = bthread_self_tag();
+    bthread_attr_set_name(&tmp, "ProcessInputMessageBatch");
+    if (!FLAGS_usercode_in_coroutine && bthread_start_background(
+            &th, &tmp, ProcessInputMessageBatch, input_msgs) == 0) {
+        ++*num_bthread_created;
+    } else {
+        input_msgs->Run();
+        delete input_msgs;
+    }
+}
+
 void UBShmTransport::Debug(std::ostream &os) {}
 
 int UBShmTransport::ContextInitOrDie(bool serverOrNot, const void* _options) {

--- a/src/brpc/ubshm_transport.h
+++ b/src/brpc/ubshm_transport.h
@@ -38,8 +38,7 @@ public:
     void ProcessEvent(bthread_attr_t attr) override;
     void QueueMessage(InputMessageClosure& inputMsg, int* num_bthread_created, bool last_msg) override;
     void QueueMessages(InputMessageBatch* input_msgs,
-                       int* num_bthread_created,
-                       bool last_msg) override;
+                       int* num_bthread_created) override;
     void Debug(std::ostream &os) override;
     ubring::UBShmEndpoint* GetUBShmEp() {
         CHECK(_ub_ep != nullptr);

--- a/src/brpc/ubshm_transport.h
+++ b/src/brpc/ubshm_transport.h
@@ -37,6 +37,9 @@ public:
     int WaitEpollOut(butil::atomic<int>* _epollout_butex, bool pollin, const timespec duetime) override;
     void ProcessEvent(bthread_attr_t attr) override;
     void QueueMessage(InputMessageClosure& inputMsg, int* num_bthread_created, bool last_msg) override;
+    void QueueMessages(InputMessageBatch* input_msgs,
+                       int* num_bthread_created,
+                       bool last_msg) override;
     void Debug(std::ostream &os) override;
     ubring::UBShmEndpoint* GetUBShmEp() {
         CHECK(_ub_ep != nullptr);

--- a/test/brpc_input_messenger_unittest.cpp
+++ b/test/brpc_input_messenger_unittest.cpp
@@ -22,6 +22,16 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include "gperftools_helper.h"
 #include "butil/time.h"
@@ -29,8 +39,144 @@
 #include "butil/fd_utility.h"
 #include "butil/fd_guard.h"
 #include "butil/unix_socket.h"
+#include "bthread/unstable.h"
 #include "brpc/acceptor.h"
+#include "brpc/input_messenger.h"
 #include "brpc/policy/hulu_pbrpc_protocol.h"
+#include "brpc/transport.h"
+
+namespace brpc {
+DECLARE_bool(usercode_in_coroutine);
+DECLARE_int32(input_message_batch_process_size);
+}
+
+namespace {
+
+struct BatchRecorder {
+    void Record(int value) {
+        std::lock_guard<std::mutex> lock(mutex);
+        values.push_back(value);
+        condition.notify_all();
+    }
+
+    void RecordDestroy() {
+        destroyed.fetch_add(1, std::memory_order_relaxed);
+        condition.notify_all();
+    }
+
+    bool WaitForSize(size_t expected) {
+        std::unique_lock<std::mutex> lock(mutex);
+        return condition.wait_for(
+            lock, std::chrono::seconds(5),
+            [this, expected] { return values.size() >= expected; });
+    }
+
+    bool WaitForDestroyed(int expected) {
+        std::unique_lock<std::mutex> lock(mutex);
+        return condition.wait_for(
+            lock, std::chrono::seconds(5),
+            [this, expected] {
+                return destroyed.load(std::memory_order_relaxed) >= expected;
+            });
+    }
+
+    std::vector<int> Snapshot() {
+        std::lock_guard<std::mutex> lock(mutex);
+        return values;
+    }
+
+    std::mutex mutex;
+    std::condition_variable condition;
+    std::vector<int> values;
+    std::atomic<int> destroyed{0};
+};
+
+class BatchTestMessage : public brpc::InputMessageBase {
+public:
+    BatchTestMessage(int value, BatchRecorder* recorder, bool throw_on_process)
+        : value(value)
+        , recorder(recorder)
+        , throw_on_process(throw_on_process) {}
+
+    int value;
+    BatchRecorder* recorder;
+    bool throw_on_process;
+
+private:
+    void DestroyImpl() override {
+        recorder->RecordDestroy();
+        delete this;
+    }
+};
+
+void ProcessBatchTestMessage(brpc::InputMessageBase* msg_base) {
+    brpc::DestroyingPtr<brpc::InputMessageBase> guard(msg_base);
+    BatchTestMessage* msg = static_cast<BatchTestMessage*>(msg_base);
+    msg->recorder->Record(msg->value);
+    if (msg->throw_on_process) {
+        throw std::runtime_error("injected handler failure");
+    }
+}
+
+BatchTestMessage* NewBatchTestMessage(
+        int value, BatchRecorder* recorder, bool throw_on_process = false) {
+    BatchTestMessage* msg =
+        new BatchTestMessage(value, recorder, throw_on_process);
+    msg->_process = ProcessBatchTestMessage;
+    return msg;
+}
+
+brpc::ParseResult ParseBatchTestMessage(
+        butil::IOBuf* source, brpc::Socket*, bool, const void* arg) {
+    if (source->empty()) {
+        return brpc::MakeParseError(brpc::PARSE_ERROR_NOT_ENOUGH_DATA);
+    }
+    char value = '\0';
+    source->copy_to(&value, 1);
+    source->pop_front(1);
+    return brpc::MakeMessage(new BatchTestMessage(
+        static_cast<unsigned char>(value),
+        static_cast<BatchRecorder*>(const_cast<void*>(arg)), false));
+}
+
+brpc::InputMessageHandler MakeBatchTestHandler(BatchRecorder* recorder) {
+    const brpc::InputMessageHandler handler = {
+        ParseBatchTestMessage,
+        ProcessBatchTestMessage,
+        nullptr,
+        recorder,
+        "batch_test",
+    };
+    return handler;
+}
+
+brpc::SocketUniquePtr CreateBatchTestSocket(
+        brpc::InputMessenger* messenger, brpc::SocketId* id) {
+    brpc::SocketOptions options;
+    options.socket_mode = brpc::SOCKET_MODE_TCP;
+    EXPECT_EQ(0, messenger->Create(options, id));
+    brpc::SocketUniquePtr socket;
+    EXPECT_EQ(0, brpc::Socket::Address(*id, &socket));
+    return socket;
+}
+
+class InputBatchFlagGuard {
+public:
+    InputBatchFlagGuard()
+        : batch_size(brpc::FLAGS_input_message_batch_process_size)
+        , usercode_in_coroutine(brpc::FLAGS_usercode_in_coroutine) {}
+
+    ~InputBatchFlagGuard() {
+        brpc::FLAGS_input_message_batch_process_size = batch_size;
+        brpc::FLAGS_usercode_in_coroutine = usercode_in_coroutine;
+    }
+
+private:
+    int batch_size;
+    bool usercode_in_coroutine;
+};
+
+}  // namespace
 
 void EmptyProcessHuluRequest(brpc::InputMessageBase* msg_base) {
     brpc::DestroyingPtr<brpc::InputMessageBase> a(msg_base);
@@ -59,6 +205,214 @@ protected:
     virtual void TearDown() {
     };
 };
+
+TEST_F(MessengerTest, input_message_batch_runs_in_order_once) {
+    BatchRecorder recorder;
+    brpc::InputMessageBatch batch(8);
+    batch.add(NewBatchTestMessage(1, &recorder));
+    batch.add(nullptr);
+    batch.add(NewBatchTestMessage(2, &recorder));
+    batch.add(NewBatchTestMessage(3, &recorder));
+    ASSERT_EQ(3u, batch.size());
+
+    batch.Run();
+    EXPECT_TRUE(batch.empty());
+    EXPECT_EQ((std::vector<int>{1, 2, 3}), recorder.Snapshot());
+    EXPECT_EQ(3, recorder.destroyed.load());
+
+    batch.Run();
+    EXPECT_EQ((std::vector<int>{1, 2, 3}), recorder.Snapshot());
+    EXPECT_EQ(3, recorder.destroyed.load());
+}
+
+TEST_F(MessengerTest, input_message_batch_destructor_contains_exceptions) {
+    static_assert(
+        std::is_nothrow_destructible<brpc::InputMessageBatch>::value,
+        "InputMessageBatch must be nothrow destructible");
+
+    BatchRecorder recorder;
+    EXPECT_NO_THROW({
+        brpc::InputMessageBatch batch(2);
+        batch.add(NewBatchTestMessage(1, &recorder, true));
+        batch.add(NewBatchTestMessage(2, &recorder));
+    });
+    EXPECT_EQ((std::vector<int>{1}), recorder.Snapshot());
+    EXPECT_EQ(2, recorder.destroyed.load());
+
+    BatchRecorder worker_recorder;
+    brpc::InputMessageBatch* batch = new brpc::InputMessageBatch(2);
+    batch->add(NewBatchTestMessage(1, &worker_recorder, true));
+    batch->add(NewBatchTestMessage(2, &worker_recorder));
+    EXPECT_NO_THROW(brpc::ProcessInputMessageBatch(batch));
+    EXPECT_EQ((std::vector<int>{1, 2}), worker_recorder.Snapshot());
+    EXPECT_EQ(2, worker_recorder.destroyed.load());
+}
+
+TEST_F(MessengerTest, input_message_batch_flag_validation) {
+    InputBatchFlagGuard flag_guard;
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption(
+        "input_message_batch_process_size", "-1").empty());
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption(
+        "input_message_batch_process_size", "0").empty());
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption(
+        "input_message_batch_process_size", "1").empty());
+    EXPECT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption(
+        "input_message_batch_process_size", "8").empty());
+    EXPECT_TRUE(GFLAGS_NAMESPACE::SetCommandLineOption(
+        "input_message_batch_process_size", "-2").empty());
+}
+
+TEST_F(MessengerTest, adaptive_input_message_batch_rises_falls_and_caps) {
+    uint32_t ema_q8 = 256;
+    uint32_t batch_size = 1;
+    std::vector<uint32_t> rising_levels(1, batch_size);
+    for (int i = 0; i < 32 && batch_size < 16; ++i) {
+        const uint32_t old_batch_size = batch_size;
+        batch_size = brpc::InputMessengerProcessor::UpdateAdaptiveBatchSize(
+            &ema_q8, batch_size, std::numeric_limits<size_t>::max());
+        if (batch_size != old_batch_size) {
+            rising_levels.push_back(batch_size);
+        }
+    }
+    EXPECT_EQ((std::vector<uint32_t>{1, 2, 4, 8, 16}), rising_levels);
+    EXPECT_LE(ema_q8, 32u * 256);
+
+    std::vector<uint32_t> falling_levels(1, batch_size);
+    for (int i = 0; i < 32 && batch_size > 1; ++i) {
+        const uint32_t old_batch_size = batch_size;
+        batch_size = brpc::InputMessengerProcessor::UpdateAdaptiveBatchSize(
+            &ema_q8, batch_size, 1);
+        if (batch_size != old_batch_size) {
+            falling_levels.push_back(batch_size);
+        }
+    }
+    EXPECT_EQ((std::vector<uint32_t>{16, 8, 4, 2, 1}), falling_levels);
+
+    brpc::SocketId id;
+    ASSERT_EQ(0, brpc::Socket::Create(brpc::SocketOptions(), &id));
+    brpc::SocketUniquePtr socket;
+    ASSERT_EQ(0, brpc::Socket::Address(id, &socket));
+    brpc::InputMessengerProcessor& processor = socket->fd_input_processor();
+    processor._input_messages_per_read_ema_q8 = ema_q8;
+    processor._adaptive_input_message_batch_size = batch_size;
+    ASSERT_EQ(0, socket->ResetFileDescriptor(-1));
+    EXPECT_EQ(0u, processor._input_messages_per_read_ema_q8);
+    EXPECT_EQ(0u, processor._adaptive_input_message_batch_size);
+}
+
+TEST_F(MessengerTest, batching_consumes_the_last_message) {
+    InputBatchFlagGuard flag_guard;
+    brpc::FLAGS_input_message_batch_process_size = 8;
+    brpc::FLAGS_usercode_in_coroutine = false;
+
+    BatchRecorder recorder;
+    brpc::InputMessenger messenger(4);
+    ASSERT_EQ(0, messenger.AddNonProtocolHandler(
+        MakeBatchTestHandler(&recorder)));
+    brpc::SocketId id;
+    brpc::SocketUniquePtr socket = CreateBatchTestSocket(&messenger, &id);
+    ASSERT_TRUE(socket);
+    brpc::InputMessengerProcessor& processor = socket->fd_input_processor();
+    processor.read_buf().append("abcd", 4);
+
+    brpc::InputMessageClosure last_msg;
+    ASSERT_EQ(0, processor.ProcessNewMessage(
+        4, false, 123, 456, last_msg));
+    brpc::DestroyingPtr<brpc::InputMessageBase> leftover(last_msg.release());
+    EXPECT_EQ(nullptr, leftover.get());
+    ASSERT_TRUE(recorder.WaitForSize(4));
+    EXPECT_EQ((std::vector<int>{'a', 'b', 'c', 'd'}), recorder.Snapshot());
+
+    socket->SetFailed();
+    ASSERT_TRUE(recorder.WaitForDestroyed(4));
+}
+
+TEST_F(MessengerTest, disabled_and_progressive_paths_remain_individual) {
+    InputBatchFlagGuard flag_guard;
+    brpc::FLAGS_usercode_in_coroutine = false;
+
+    {
+        brpc::FLAGS_input_message_batch_process_size = 0;
+        BatchRecorder recorder;
+        brpc::InputMessenger messenger(4);
+        ASSERT_EQ(0, messenger.AddNonProtocolHandler(
+            MakeBatchTestHandler(&recorder)));
+        brpc::SocketId id;
+        brpc::SocketUniquePtr socket = CreateBatchTestSocket(&messenger, &id);
+        ASSERT_TRUE(socket);
+        brpc::InputMessengerProcessor& processor =
+            socket->fd_input_processor();
+        processor.read_buf().append("ab", 2);
+        brpc::InputMessageClosure last_msg;
+        ASSERT_EQ(0, processor.ProcessNewMessage(
+            2, false, 123, 456, last_msg));
+        brpc::DestroyingPtr<brpc::InputMessageBase> leftover(last_msg.release());
+        EXPECT_NE(nullptr, leftover.get());
+        leftover.reset();
+        ASSERT_TRUE(recorder.WaitForDestroyed(2));
+        socket->SetFailed();
+    }
+
+    {
+        brpc::FLAGS_input_message_batch_process_size = 8;
+        BatchRecorder recorder;
+        brpc::InputMessenger messenger(4);
+        ASSERT_EQ(0, messenger.AddNonProtocolHandler(
+            MakeBatchTestHandler(&recorder)));
+        brpc::SocketId id;
+        brpc::SocketUniquePtr socket = CreateBatchTestSocket(&messenger, &id);
+        ASSERT_TRUE(socket);
+        socket->read_will_be_progressive(brpc::CONNECTION_TYPE_SINGLE);
+        brpc::InputMessengerProcessor& processor =
+            socket->fd_input_processor();
+        processor.read_buf().append("abc", 3);
+        brpc::InputMessageClosure last_msg;
+        ASSERT_EQ(0, processor.ProcessNewMessage(
+            3, false, 123, 456, last_msg));
+        EXPECT_EQ(nullptr, last_msg.release());
+        ASSERT_TRUE(recorder.WaitForSize(3));
+        std::vector<int> values = recorder.Snapshot();
+        std::sort(values.begin(), values.end());
+        EXPECT_EQ((std::vector<int>{'a', 'b', 'c'}), values);
+        socket->SetFailed();
+        ASSERT_TRUE(recorder.WaitForDestroyed(3));
+    }
+}
+
+TEST_F(MessengerTest, transport_batch_helper_handles_inline_and_empty_batches) {
+    InputBatchFlagGuard flag_guard;
+    brpc::FLAGS_usercode_in_coroutine = true;
+
+    brpc::InputMessenger messenger;
+    brpc::SocketId id;
+    brpc::SocketUniquePtr socket = CreateBatchTestSocket(&messenger, &id);
+    ASSERT_TRUE(socket);
+
+    BatchRecorder recorder;
+    int num_bthread_created = 0;
+    brpc::InputMessageBatch* batch = new brpc::InputMessageBatch(2);
+    batch->add(NewBatchTestMessage(1, &recorder));
+    batch->add(NewBatchTestMessage(2, &recorder));
+    socket->_transport->QueueMessages(batch, &num_bthread_created);
+    EXPECT_EQ((std::vector<int>{1, 2}), recorder.Snapshot());
+    EXPECT_EQ(0, num_bthread_created);
+
+    socket->_transport->QueueMessages(
+        new brpc::InputMessageBatch, &num_bthread_created);
+    EXPECT_EQ(0, num_bthread_created);
+
+    brpc::FLAGS_usercode_in_coroutine = false;
+    batch = new brpc::InputMessageBatch(2);
+    batch->add(NewBatchTestMessage(3, &recorder));
+    batch->add(NewBatchTestMessage(4, &recorder));
+    socket->_transport->QueueMessages(batch, &num_bthread_created);
+    EXPECT_EQ(1, num_bthread_created);
+    bthread_flush();
+    ASSERT_TRUE(recorder.WaitForSize(4));
+    EXPECT_EQ((std::vector<int>{1, 2, 3, 4}), recorder.Snapshot());
+
+    socket->SetFailed();
+}
 
 #define USE_UNIX_DOMAIN_SOCKET 1
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related work:

- https://gitcode.com/boostkit/brpc/merge_requests/32

Problem Summary:

`InputMessenger` currently schedules each parsed input message in a separate
bthread. For short message handlers and bursty traffic on a single connection,
bthread creation and scheduling may account for a significant portion of the
request-processing overhead.

This PR introduces optional input message batching. Messages parsed from the
same socket can be processed sequentially in one bthread, reducing scheduling
overhead while preserving the existing behavior by default.

### What is changed and the side effects?

### Design

```text
Parsed messages
  m1  m2  m3  ...  mN
           |
           v
+--------------------------+
| Batch Size Controller    |
| fixed or adaptive (EMA)  |
| size: 1 / 2 / 4 / 8 / 16|
+------------+-------------+
             |
             v
+--------------------------+
| InputMessageBatch        |
| [m1, m2, ... , mk]       |
+------------+-------------+
             |
             v
      One bthread
             |
             v
  m1 -> m2 -> ... -> mk
  processed sequentially
```

Changed:

- Add the experimental `input_message_batch_process_size` gflag:
  - `0` or `1`: preserve the original one-message-per-bthread behavior.
  - Values greater than `1`: use a fixed batch size.
  - `-1`: adaptively select a batch size from `1`, `2`, `4`, `8`, and `16`.
  - Values smaller than `-1` are rejected.
- Add `InputMessageBatch` to own and process messages in their original order.
- Add per-socket adaptive state based on an exponentially weighted moving
  average of messages parsed from each read.
- Increase the adaptive batch size gradually and decrease it more quickly when
  the observed burst size drops.
- Reset adaptive history after switching away from adaptive mode.
- Support batch scheduling in TCP, RDMA, and UBShm/UBRing transports.
- Preserve the existing last-message scheduling optimization.
- Keep progressive-read messages on the individual-message path.
- Disable batching when user code runs in coroutine mode.
- Fall back to synchronous processing if batch allocation or bthread creation
  fails.

Side effects:

- Performance effects:

  The default value is `0`, so existing deployments retain the original
  scheduling behavior.

  When batching is enabled, it reduces bthread creation and scheduling overhead
  for bursty workloads. A larger fixed batch may increase the time that later
  messages wait behind earlier handlers. Adaptive mode limits the maximum batch
  size to 16 and decreases the batch size quickly when the observed burst size
  drops.

- Breaking backward compatibility:

  There is no change to the public RPC protocol or default runtime behavior.

  The internal `Transport` interface gains a `QueueMessages` virtual method.
  Downstream custom transport implementations derived directly from
  `Transport` must implement this method.



### Performance test

The RDMA performance example was used with a single connection and multiple
outstanding requests on that connection. Each attachment size was tested three
times.

- Baseline: `input_message_batch_process_size=0`
- Optimized: `input_message_batch_process_size=-1`
- `queue_depth` must be greater than 1 to produce message bursts on the same
  connection.
- Latency values are in microseconds.
- CPU utilization may exceed 100% because it represents multi-core process CPU
  usage.
- QPS improvement is calculated against the average QPS of the unoptimized
  baseline.

#### Average results

The following results were measured on a Kunpeng 950 server.
Each attachment size was tested three times, and the reported values are the
arithmetic averages of those runs.

- Baseline: `input_message_batch_process_size=0`
- Optimized: `input_message_batch_process_size=-1`
- Latency values are in microseconds.
- CPU utilization may exceed 100% because it represents multi-core process CPU
  usage.
- QPS improvement is calculated against the average QPS of the baseline.

| Attachment | Avg Latency | P90 | P99 | Baseline QPS | Batched QPS Avg | Server CPU | Client CPU | QPS Improvement |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 bytes | 351.00 | 543.00 | 810.00 | 2684.100 | 2886.265 | 1336.00% | 3950.67% | +7.53% |
| 256 bytes | 398.00 | 610.67 | 927.00 | 2377.408 | 2545.978 | 1315.00% | 4798.00% | +7.09% |
| 1 KB | 438.33 | 683.67 | 1044.67 | 2174.254 | 2320.362 | 1322.67% | 3732.67% | +6.72% |
| 4 KB | 660.67 | 1135.67 | 2123.33 | 1486.802 | 1544.824 | 1270.00% | 2577.33% | +3.90% |
| 8 KB | 1031.00 | 2310.00 | 5289.33 | 1049.357 | 1104.763 | 1177.00% | 1993.33% | +5.28% |
| 100 KB | 7388.67 | 12362.00 | 22406.67 | 134.602 | 138.385 | 925.33% | 988.00% | +2.81% |



---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
