### PR TITLE
Validate returned stream identifiers

### DIFF
--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -1711,6 +1711,12 @@ void Controller::HandleStreamConnection(Socket *host_socket) {
             if (!FailedInline()) {
                 SetFailed(EREQUEST, "The server didn't accept the stream");
             }
+        } else if (_remote_stream_settings->extra_stream_ids_size() !=
+                   (int)stream_num - 1) {
+            SetFailed(ERESPONSE, "Server returned %d extra_stream_ids, "
+                      "expected %d",
+                      _remote_stream_settings->extra_stream_ids_size(),
+                      (int)stream_num - 1);
         } else {
             for (size_t i = 0; i < stream_num; ++i) {
                 if (Stream::Address(_request_streams[i], &ptrs[i]) != 0) {

--- a/src/brpc/controller.cpp
+++ b/src/brpc/controller.cpp
@@ -1705,18 +1705,20 @@ void Controller::HandleStreamConnection(Socket *host_socket) {
         return;
     }
     size_t stream_num = _request_streams.size();
+    const size_t expected_extra_streams = stream_num - 1;
     std::vector<StreamUniquePtr> ptrs(stream_num);
     if (!FailedInline()) {
         if (_remote_stream_settings == nullptr) {
             if (!FailedInline()) {
                 SetFailed(EREQUEST, "The server didn't accept the stream");
             }
-        } else if (_remote_stream_settings->extra_stream_ids_size() !=
-                   (int)stream_num - 1) {
+        } else if (static_cast<size_t>(
+                       _remote_stream_settings->extra_stream_ids_size()) !=
+                   expected_extra_streams) {
             SetFailed(ERESPONSE, "Server returned %d extra_stream_ids, "
-                      "expected %d",
+                      "expected %zu",
                       _remote_stream_settings->extra_stream_ids_size(),
-                      (int)stream_num - 1);
+                      expected_extra_streams);
         } else {
             for (size_t i = 0; i < stream_num; ++i) {
                 if (Stream::Address(_request_streams[i], &ptrs[i]) != 0) {

--- a/test/brpc_streaming_rpc_unittest.cpp
+++ b/test/brpc_streaming_rpc_unittest.cpp
@@ -1186,8 +1186,10 @@ TEST_F(StreamingRpcTest, reject_mismatched_returned_stream_identifiers) {
         stub.Echo(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
         ASSERT_EQ(brpc::ERESPONSE, cntl.ErrorCode());
+        const std::string expected_error =
+            "extra_stream_ids, expected " + std::to_string(STREAM_COUNT - 1);
         ASSERT_NE(std::string::npos,
-                  cntl.ErrorText().find("extra_stream_ids, expected 2"));
+                  cntl.ErrorText().find(expected_error));
 
         for (brpc::StreamId stream_id : request_streams) {
             brpc::StreamUniquePtr stream;

--- a/test/brpc_streaming_rpc_unittest.cpp
+++ b/test/brpc_streaming_rpc_unittest.cpp
@@ -27,6 +27,7 @@
 #include "brpc/controller.h"
 #include "brpc/channel.h"
 #include "brpc/callback.h"
+#include "brpc/details/controller_private_accessor.h"
 #include "brpc/socket.h"
 #include "brpc/stream_impl.h"
 #include "brpc/policy/streaming_rpc_protocol.h"
@@ -1129,6 +1130,74 @@ private:
     size_t _stream_count;
     int _n;
 };
+
+class MyServiceWithMismatchedExtraStreamIds : public test::EchoService {
+public:
+    MyServiceWithMismatchedExtraStreamIds(size_t stream_count, int adjustment)
+        : _stream_count(stream_count), _adjustment(adjustment) {}
+
+    void Echo(::google::protobuf::RpcController* controller,
+              const ::test::EchoRequest* request,
+              ::test::EchoResponse* response,
+              ::google::protobuf::Closure* done) override {
+        brpc::ClosureGuard done_guard(done);
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+        response->set_message(request->message());
+
+        brpc::ControllerPrivateAccessor accessor(cntl);
+        brpc::StreamSettings* settings = accessor.remote_stream_settings();
+        if (_adjustment < 0) {
+            settings->mutable_extra_stream_ids()->RemoveLast();
+        } else {
+            settings->add_extra_stream_ids(settings->extra_stream_ids(0));
+        }
+
+        brpc::StreamIds response_streams;
+        ASSERT_EQ(0, brpc::StreamAccept(response_streams, *cntl, nullptr));
+        ASSERT_EQ((int)_stream_count + _adjustment,
+                  (int)response_streams.size());
+    }
+
+private:
+    size_t _stream_count;
+    int _adjustment;
+};
+
+TEST_F(StreamingRpcTest, reject_mismatched_returned_stream_identifiers) {
+    const size_t STREAM_COUNT = 3;
+
+    for (int adjustment : {-1, 1}) {
+        brpc::Server server;
+        MyServiceWithMismatchedExtraStreamIds service(STREAM_COUNT, adjustment);
+        ASSERT_EQ(0, server.AddService(
+            &service, brpc::SERVER_DOESNT_OWN_SERVICE));
+        ASSERT_EQ(0, server.Start(0, nullptr));
+
+        brpc::Channel channel;
+        ASSERT_EQ(0, channel.Init(server.listen_address(), nullptr));
+
+        brpc::Controller cntl;
+        brpc::StreamIds request_streams;
+        ASSERT_EQ(0, brpc::StreamCreate(request_streams, STREAM_COUNT, cntl,
+                                        nullptr));
+        ASSERT_EQ(STREAM_COUNT, request_streams.size());
+
+        test::EchoService_Stub stub(&channel);
+        stub.Echo(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ(brpc::ERESPONSE, cntl.ErrorCode());
+        ASSERT_NE(std::string::npos,
+                  cntl.ErrorText().find("extra_stream_ids, expected 2"));
+
+        for (brpc::StreamId stream_id : request_streams) {
+            brpc::StreamUniquePtr stream;
+            ASSERT_NE(0, brpc::Stream::Address(stream_id, &stream));
+        }
+
+        server.Stop(0);
+        server.Join();
+    }
+}
 
 TEST_F(StreamingRpcTest, batch_create_extra_stream) {
     const size_t STREAM_COUNT = 3;  // 1 first stream + 2 extra streams


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve

Problem Summary:

When a client creates multiple streams in one RPC, it expects the server response to return exactly one `extra_stream_id` for every stream after the first. The response path indexed this list using the number of locally created streams without first validating its size. A malformed response could therefore read past the returned identifiers, while surplus identifiers had no valid client-stream mapping.

### What is changed and the side effects?

Changed:

- Require the number of returned `extra_stream_ids` to exactly match the number of additional client streams.
- Fail the RPC with `ERESPONSE` and use the existing stream cleanup path when the counts differ.
- Add full client/server regression coverage for both missing and surplus returned stream identifiers.

Side effects:
- Performance effects: One integer comparison is added when completing a multi-stream RPC.

- Breaking backward compatibility: Malformed responses with missing or surplus stream identifiers are now rejected instead of being partially processed.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
