### PR TITLE
Speed up CI with build caching and parallel jobs

### DIFF
--- a/.github/actions/init-ut-make-config/action.yml
+++ b/.github/actions/init-ut-make-config/action.yml
@@ -6,9 +6,6 @@ runs:
   using: "composite"
   steps:
   - run: |
-      sudo apt-get update && sudo apt-get install -y clang-12 lldb-12 lld-12 libgtest-dev cmake gdb libstdc++6-11-dbg
-    shell: bash
-  - run: |
       cd /usr/src/gtest && export CC=clang-12 && export CXX=clang++-12 && sudo cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
       sudo make -j ${{env.proc_num}} && sudo mv lib/libgtest* /usr/lib/
     shell: bash

--- a/.github/actions/install-all-dependencies/action.yml
+++ b/.github/actions/install-all-dependencies/action.yml
@@ -2,11 +2,13 @@ runs:
   using: "composite"
   steps:
     - uses: ./.github/actions/install-essential-dependencies
-    - run: sudo apt-get update && sudo apt-get install -y libunwind-dev libgoogle-glog-dev automake bison flex libboost-all-dev libevent-dev libtool pkg-config libibverbs-dev
-      shell: bash
+      with:
+        extra-packages: >-
+          ccache libunwind-dev libgoogle-glog-dev automake bison flex
+          libboost-all-dev libevent-dev libtool pkg-config
     - run: | 
         wget https://archive.apache.org/dist/thrift/0.11.0/thrift-0.11.0.tar.gz && tar -xf thrift-0.11.0.tar.gz && cd thrift-0.11.0/
-        ./configure --prefix=/usr --with-rs=no --with-ruby=no --with-python=no --with-java=no --with-go=no --with-perl=no --with-php=no --with-csharp=no --with-erlang=no --with-lua=no --with-nodejs=no --with-haskell=no --with-dotnetcore=no CXXFLAGS="-Wno-unused-variable"
+        ./configure --prefix=/usr --disable-tests --with-rs=no --with-ruby=no --with-python=no --with-java=no --with-go=no --with-perl=no --with-php=no --with-csharp=no --with-erlang=no --with-lua=no --with-nodejs=no --with-haskell=no --with-dotnetcore=no CXXFLAGS="-Wno-unused-variable"
         make -j ${{env.proc_num}} && sudo make install
       shell: bash
     - run: |

--- a/.github/actions/install-essential-dependencies/action.yml
+++ b/.github/actions/install-essential-dependencies/action.yml
@@ -1,9 +1,18 @@
+inputs:
+  extra-packages:
+    description: Additional apt packages to install in the same transaction
+    required: false
+
 runs:
   using: "composite"
   steps:
     - run: ulimit -c unlimited -S && sudo bash -c "echo 'core.%e.%p' > /proc/sys/kernel/core_pattern"
       shell: bash
-    - run: sudo apt-get update && sudo apt-get install -y git g++ make libssl-dev libgflags-dev libprotobuf-dev libprotoc-dev protobuf-compiler libleveldb-dev redis-server mysql-server libibverbs-dev
+    - run: |
+        sudo apt-get update
+        sudo apt-get install -y git g++ make libssl-dev libgflags-dev \
+          libprotobuf-dev libprotoc-dev protobuf-compiler libleveldb-dev \
+          redis-server mysql-server libibverbs-dev ${{ inputs.extra-packages }}
       shell: bash
     - run: redis-server --version && mysqld --version
       shell: bash

--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -5,6 +5,9 @@ inputs:
   kind:
     description: Cache backend to configure (ccache or bazel)
     required: true
+  cache-key:
+    description: Cache namespace override for matrix jobs
+    required: false
 
 runs:
   using: composite
@@ -14,10 +17,9 @@ runs:
       uses: actions/cache@v6
       with:
         path: ~/.cache/ccache
-        key: ${{ runner.os }}-ccache-${{ github.job }}-${{ github.sha }}
+        key: ${{ runner.os }}-ccache-${{ inputs.cache-key || github.job }}--${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-ccache-${{ github.job }}-
-          ${{ runner.os }}-ccache-
+          ${{ runner.os }}-ccache-${{ inputs.cache-key || github.job }}--
 
     - name: Configure ccache
       if: inputs.kind == 'ccache'

--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -1,0 +1,75 @@
+name: Setup build cache
+description: Restore and configure the compiler cache used by CI builds
+
+inputs:
+  kind:
+    description: Cache backend to configure (ccache or bazel)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore ccache
+      if: inputs.kind == 'ccache'
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ccache
+        key: ${{ runner.os }}-ccache-${{ github.job }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-${{ github.job }}-
+          ${{ runner.os }}-ccache-
+
+    - name: Configure ccache
+      if: inputs.kind == 'ccache'
+      shell: bash
+      run: |
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
+          brew install ccache
+        else
+          sudo apt-get update
+          sudo apt-get install -y ccache
+        fi
+
+        mkdir -p "${HOME}/.cache/ccache" "${HOME}/.cache/ccache-bin"
+        for compiler in cc c++ gcc g++ clang clang++ clang-12 clang++-12; do
+          ln -sf "$(command -v ccache)" "${HOME}/.cache/ccache-bin/${compiler}"
+        done
+        CCACHE_DIR="${HOME}/.cache/ccache" ccache --max-size=2G
+        CCACHE_DIR="${HOME}/.cache/ccache" ccache --zero-stats
+
+        echo "${HOME}/.cache/ccache-bin" >> "${GITHUB_PATH}"
+        echo "CCACHE_DIR=${HOME}/.cache/ccache" >> "${GITHUB_ENV}"
+        echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}" >> "${GITHUB_ENV}"
+        echo "CCACHE_COMPILERCHECK=content" >> "${GITHUB_ENV}"
+        echo "CCACHE_NOHASHDIR=true" >> "${GITHUB_ENV}"
+
+    - name: Restore Bazel repository cache
+      if: inputs.kind == 'bazel'
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cache/bazel-repository
+          ~/.cache/bazelisk
+        key: ${{ runner.os }}-bazel-repository-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock', 'WORKSPACE') }}
+        restore-keys: |
+          ${{ runner.os }}-bazel-repository-
+
+    - name: Restore Bazel disk cache
+      if: inputs.kind == 'bazel'
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/bazel-disk
+        key: ${{ runner.os }}-bazel-disk-${{ github.job }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-bazel-disk-${{ github.job }}-
+          ${{ runner.os }}-bazel-disk-
+
+    - name: Configure Bazel caches
+      if: inputs.kind == 'bazel'
+      shell: bash
+      run: |
+        mkdir -p "${HOME}/.cache/bazel-repository" "${HOME}/.cache/bazel-disk"
+        cat >> "${HOME}/.bazelrc" <<EOF
+        common --repository_cache=${HOME}/.cache/bazel-repository
+        common --disk_cache=${HOME}/.cache/bazel-disk
+        EOF

--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -74,4 +74,5 @@ runs:
         cat >> "${HOME}/.bazelrc" <<EOF
         common --repository_cache=${HOME}/.cache/bazel-repository
         common --disk_cache=${HOME}/.cache/bazel-disk
+        test --cache_test_results=no
         EOF

--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -27,9 +27,6 @@ runs:
       run: |
         if [[ "${{ runner.os }}" == "macOS" ]]; then
           brew install ccache
-        else
-          sudo apt-get update
-          sudo apt-get install -y ccache
         fi
 
         mkdir -p "${HOME}/.cache/ccache" "${HOME}/.cache/ccache-bin"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - name: gcc-default
@@ -68,6 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - name: gcc-default
@@ -117,25 +119,56 @@ jobs:
       if: always()
       run: ccache --show-stats
 
-  gcc-compile-with-make-protobuf:
-    name: gcc-compile-with-make-protobuf (${{ matrix.name }})
+  compile-with-make-protobuf:
+    name: compile-with-make-protobuf (${{ matrix.compiler }}-${{ matrix.name }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include:
-          - name: protobuf-3.5.1
+          - compiler: gcc
+            name: protobuf-3.5.1
             protobuf-version: 3.5.1
             protobuf-cpp-version: 3.5.1
             protobuf-install-dir: /protobuf-3.5.1
-          - name: protobuf-3.12.4
+            cc: gcc
+            cxx: g++
+          - compiler: gcc
+            name: protobuf-3.12.4
             protobuf-version: 3.12.4
             protobuf-cpp-version: 3.12.4
             protobuf-install-dir: /protobuf-3.12.4
-          - name: protobuf-21.12
+            cc: gcc
+            cxx: g++
+          - compiler: gcc
+            name: protobuf-21.12
             protobuf-version: '21.12'
             protobuf-cpp-version: 3.21.12
             protobuf-install-dir: /protobuf-3.21.12
+            cc: gcc
+            cxx: g++
+          - compiler: clang
+            name: protobuf-3.5.1
+            protobuf-version: 3.5.1
+            protobuf-cpp-version: 3.5.1
+            protobuf-install-dir: /protobuf-3.5.1
+            cc: clang
+            cxx: clang++
+          - compiler: clang
+            name: protobuf-3.12.4
+            protobuf-version: 3.12.4
+            protobuf-cpp-version: 3.12.4
+            protobuf-install-dir: /protobuf-3.12.4
+            cc: clang
+            cxx: clang++
+          - compiler: clang
+            name: protobuf-21.12
+            protobuf-version: '21.12'
+            protobuf-cpp-version: 3.21.12
+            protobuf-install-dir: /protobuf-3.21.12
+            cc: clang
+            cxx: clang++
     steps:
     - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/install-essential-dependencies
@@ -144,7 +177,7 @@ jobs:
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
-        cache-key: gcc-make-${{ matrix.name }}
+        cache-key: ${{ matrix.compiler }}-make-${{ matrix.name }}
 
     - name: Build
       uses: ./.github/actions/compile-with-make-protobuf
@@ -152,7 +185,8 @@ jobs:
         protobuf-version: ${{ matrix.protobuf-version }}
         protobuf-cpp-version: ${{ matrix.protobuf-cpp-version }}
         protobuf-install-dir: ${{ matrix.protobuf-install-dir }}
-        config-brpc-options: --cc=gcc --cxx=g++ --werror
+        config-brpc-options: >-
+          --cc=${{ matrix.cc }} --cxx=${{ matrix.cxx }} --werror
 
     - name: Show ccache statistics
       if: always()
@@ -210,47 +244,6 @@ jobs:
                     --define BRPC_WITH_NO_PTHREAD_MUTEX_HOOK=true \
                     --define with_babylon_counter=true \
                     -- //...
-
-  clang-compile-with-make-protobuf:
-    name: clang-compile-with-make-protobuf (${{ matrix.name }})
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: protobuf-3.5.1
-            protobuf-version: 3.5.1
-            protobuf-cpp-version: 3.5.1
-            protobuf-install-dir: /protobuf-3.5.1
-          - name: protobuf-3.12.4
-            protobuf-version: 3.12.4
-            protobuf-cpp-version: 3.12.4
-            protobuf-install-dir: /protobuf-3.12.4
-          - name: protobuf-21.12
-            protobuf-version: '21.12'
-            protobuf-cpp-version: 3.21.12
-            protobuf-install-dir: /protobuf-3.21.12
-    steps:
-    - uses: actions/checkout@v7.0.1
-    - uses: ./.github/actions/install-essential-dependencies
-      with:
-        extra-packages: ccache
-    - uses: ./.github/actions/setup-build-cache
-      with:
-        kind: ccache
-        cache-key: clang-make-${{ matrix.name }}
-
-    - name: Build
-      uses: ./.github/actions/compile-with-make-protobuf
-      with:
-        protobuf-version: ${{ matrix.protobuf-version }}
-        protobuf-cpp-version: ${{ matrix.protobuf-cpp-version }}
-        protobuf-install-dir: ${{ matrix.protobuf-install-dir }}
-        config-brpc-options: --cc=clang --cxx=clang++ --werror
-
-    - name: Show ccache statistics
-      if: always()
-      run: ccache --show-stats
 
   clang-unittest-with-bazel:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: ccache
     - uses: ./.github/actions/install-all-dependencies
 
     - name: gcc with default options
@@ -53,6 +56,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: ccache
     - uses: ./.github/actions/install-all-dependencies
 
     - name: gcc with default options
@@ -89,6 +95,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: ccache
     - uses: ./.github/actions/install-essential-dependencies
 
     - name: protobuf 3.5.1
@@ -119,6 +128,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: bazel
     # Install redis-server/mysql-server so the integration tests that fork a
     # real server (e.g. brpc_redis_unittest) actually run under bazel instead
     # of skipping. Same shared action the make-based unittest jobs use.
@@ -129,6 +141,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: bazel
     - run: sudo apt-get update && sudo apt-get install -y  libibverbs-dev
     - name: root
       run: |
@@ -166,6 +181,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: ccache
     - uses: ./.github/actions/install-essential-dependencies
 
     - name: protobuf 3.5.1
@@ -196,6 +214,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: bazel
     # Install redis-server/mysql-server so the forked-server integration tests
     # actually run under bazel (see gcc-unittest-with-bazel).
     - uses: ./.github/actions/install-essential-dependencies
@@ -210,6 +231,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: bazel
     - run: sudo apt-get update && sudo apt-get install -y  libibverbs-dev
     - name: root
       run: |
@@ -249,6 +273,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: ccache
     - uses: ./.github/actions/install-essential-dependencies
     - uses: ./.github/actions/init-ut-make-config
       with:
@@ -267,6 +294,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: ccache
     - uses: ./.github/actions/install-essential-dependencies
     - uses: ./.github/actions/init-ut-make-config
       with:
@@ -295,6 +325,9 @@ jobs:
       USE_BAZEL_VERSION: "8.3.1"
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: bazel
     # Install redis-server/mysql-server so the forked-server integration tests
     # actually run under bazel (see gcc-unittest-with-bazel).
     - uses: ./.github/actions/install-essential-dependencies

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -47,7 +47,7 @@ jobs:
               --with-rdma --with-debug-bthread-sche-safety --with-debug-lock
               --with-bthread-tracer --with-asan
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/install-all-dependencies
     - uses: ./.github/actions/setup-build-cache
       with:
@@ -95,7 +95,7 @@ jobs:
               -DWITH_DEBUG_BTHREAD_SCHE_SAFETY=ON -DWITH_DEBUG_LOCK=ON
               -DWITH_BTHREAD_TRACER=ON -DWITH_ASAN=ON
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/install-all-dependencies
     - uses: ./.github/actions/setup-build-cache
       with:
@@ -137,7 +137,7 @@ jobs:
             protobuf-cpp-version: 3.21.12
             protobuf-install-dir: /protobuf-3.21.12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/install-essential-dependencies
       with:
         extra-packages: ccache
@@ -161,7 +161,7 @@ jobs:
   gcc-unittest-with-bazel:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: bazel
@@ -174,7 +174,7 @@ jobs:
   gcc-compile-with-bazel-all-options:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: bazel
@@ -231,7 +231,7 @@ jobs:
             protobuf-cpp-version: 3.21.12
             protobuf-install-dir: /protobuf-3.21.12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/install-essential-dependencies
       with:
         extra-packages: ccache
@@ -255,7 +255,7 @@ jobs:
   clang-unittest-with-bazel:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: bazel
@@ -272,7 +272,7 @@ jobs:
   clang-compile-with-bazel-all-options:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: bazel
@@ -314,7 +314,7 @@ jobs:
   clang-unittest:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/install-essential-dependencies
       with:
         extra-packages: ccache clang-12 lldb-12 lld-12 libgtest-dev cmake gdb libstdc++6-11-dbg
@@ -340,7 +340,7 @@ jobs:
   clang-unittest-asan:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/install-essential-dependencies
       with:
         extra-packages: ccache clang-12 lldb-12 lld-12 libgtest-dev cmake gdb libstdc++6-11-dbg
@@ -376,7 +376,7 @@ jobs:
       # honors USE_BAZEL_VERSION.
       USE_BAZEL_VERSION: "8.3.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: bazel

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -52,6 +52,10 @@ jobs:
                  --with-thrift --with-glog --with-rdma  --with-debug-bthread-sche-safety \
                  --with-debug-lock --with-bthread-tracer --with-asan
 
+    - name: Show ccache statistics
+      if: always()
+      run: ccache --show-stats
+
   compile-with-cmake:
     runs-on: ubuntu-22.04
     steps:
@@ -91,6 +95,10 @@ jobs:
               -DWITH_ASAN=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
         make -j ${{env.proc_num}} && make clean
 
+    - name: Show ccache statistics
+      if: always()
+      run: ccache --show-stats
+
   gcc-compile-with-make-protobuf:
     runs-on: ubuntu-22.04
     steps:
@@ -123,6 +131,10 @@ jobs:
         protobuf-cpp-version: 3.21.12
         protobuf-install-dir: /protobuf-3.21.12
         config-brpc-options: --cc=gcc --cxx=g++ --werror
+
+    - name: Show ccache statistics
+      if: always()
+      run: ccache --show-stats
 
   gcc-unittest-with-bazel:
     runs-on: ubuntu-22.04
@@ -210,6 +222,10 @@ jobs:
         protobuf-install-dir: /protobuf-3.21.12
         config-brpc-options: --cc=clang --cxx=clang++ --werror
 
+    - name: Show ccache statistics
+      if: always()
+      run: ccache --show-stats
+
   clang-unittest-with-bazel:
     runs-on: ubuntu-22.04
     steps:
@@ -289,6 +305,9 @@ jobs:
       run: |
         cd test
         sh ./run_tests.sh
+    - name: Show ccache statistics
+      if: always()
+      run: ccache --show-stats
 
   clang-unittest-asan:
     runs-on: ubuntu-22.04
@@ -314,6 +333,9 @@ jobs:
         # too slowly, so they flake here (connection refused). Skip just those under ASan; the
         # redis codec/server tests still run, and the full suite runs in clang-unittest.
         GTEST_FILTER='-RedisTest.sanity:RedisTest.keys_with_spaces:RedisTest.incr_and_decr:RedisTest.by_components:RedisTest.auth' sh ./run_tests.sh
+    - name: Show ccache statistics
+      if: always()
+      run: ccache --show-stats
 
   clang-unittest-bazel-with-babylon-and-new-pb:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -212,7 +212,24 @@ jobs:
                     -- //...
 
   clang-compile-with-make-protobuf:
+    name: clang-compile-with-make-protobuf (${{ matrix.name }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: protobuf-3.5.1
+            protobuf-version: 3.5.1
+            protobuf-cpp-version: 3.5.1
+            protobuf-install-dir: /protobuf-3.5.1
+          - name: protobuf-3.12.4
+            protobuf-version: 3.12.4
+            protobuf-cpp-version: 3.12.4
+            protobuf-install-dir: /protobuf-3.12.4
+          - name: protobuf-21.12
+            protobuf-version: '21.12'
+            protobuf-cpp-version: 3.21.12
+            protobuf-install-dir: /protobuf-3.21.12
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/install-essential-dependencies
@@ -221,29 +238,14 @@ jobs:
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
+        cache-key: clang-make-${{ matrix.name }}
 
-    - name: protobuf 3.5.1
+    - name: Build
       uses: ./.github/actions/compile-with-make-protobuf
       with:
-        protobuf-version: 3.5.1
-        protobuf-cpp-version: 3.5.1
-        protobuf-install-dir: /protobuf-3.5.1
-        config-brpc-options: --cc=clang --cxx=clang++ --werror
-
-    - name: protobuf 3.12.4
-      uses: ./.github/actions/compile-with-make-protobuf
-      with:
-        protobuf-version: 3.12.4
-        protobuf-cpp-version: 3.12.4
-        protobuf-install-dir: /protobuf-3.12.4
-        config-brpc-options: --cc=clang --cxx=clang++ --werror
-
-    - name: protobuf 21.12
-      uses: ./.github/actions/compile-with-make-protobuf
-      with:
-        protobuf-version: 21.12
-        protobuf-cpp-version: 3.21.12
-        protobuf-install-dir: /protobuf-3.21.12
+        protobuf-version: ${{ matrix.protobuf-version }}
+        protobuf-cpp-version: ${{ matrix.protobuf-cpp-version }}
+        protobuf-install-dir: ${{ matrix.protobuf-install-dir }}
         config-brpc-options: --cc=clang --cxx=clang++ --werror
 
     - name: Show ccache statistics

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -118,36 +118,38 @@ jobs:
       run: ccache --show-stats
 
   gcc-compile-with-make-protobuf:
+    name: gcc-compile-with-make-protobuf (${{ matrix.name }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: protobuf-3.5.1
+            protobuf-version: 3.5.1
+            protobuf-cpp-version: 3.5.1
+            protobuf-install-dir: /protobuf-3.5.1
+          - name: protobuf-3.12.4
+            protobuf-version: 3.12.4
+            protobuf-cpp-version: 3.12.4
+            protobuf-install-dir: /protobuf-3.12.4
+          - name: protobuf-21.12
+            protobuf-version: '21.12'
+            protobuf-cpp-version: 3.21.12
+            protobuf-install-dir: /protobuf-3.21.12
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
+        cache-key: gcc-make-${{ matrix.name }}
     - uses: ./.github/actions/install-essential-dependencies
 
-    - name: protobuf 3.5.1
+    - name: Build
       uses: ./.github/actions/compile-with-make-protobuf
       with:
-        protobuf-version: 3.5.1
-        protobuf-cpp-version: 3.5.1
-        protobuf-install-dir: /protobuf-3.5.1
-        config-brpc-options: --cc=gcc --cxx=g++ --werror
-
-    - name: protobuf 3.12.4
-      uses: ./.github/actions/compile-with-make-protobuf
-      with:
-        protobuf-version: 3.12.4
-        protobuf-cpp-version: 3.12.4
-        protobuf-install-dir: /protobuf-3.12.4
-        config-brpc-options: --cc=gcc --cxx=g++ --werror
-
-    - name: protobuf 21.12
-      uses: ./.github/actions/compile-with-make-protobuf
-      with:
-        protobuf-version: 21.12
-        protobuf-cpp-version: 3.21.12
-        protobuf-install-dir: /protobuf-3.21.12
+        protobuf-version: ${{ matrix.protobuf-version }}
+        protobuf-cpp-version: ${{ matrix.protobuf-cpp-version }}
+        protobuf-install-dir: ${{ matrix.protobuf-install-dir }}
         config-brpc-options: --cc=gcc --cxx=g++ --werror
 
     - name: Show ccache statistics

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -20,37 +20,44 @@ concurrency:
 # https://github.com/actions/runner-images
 jobs:
   compile-with-make:
+    name: compile-with-make (${{ matrix.name }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: gcc-default
+            make-options: >-
+              --headers=/usr/include --libs=/usr/lib /usr/lib64
+              --cc=gcc --cxx=g++ --werror
+          - name: gcc-all-options
+            make-options: >-
+              --headers=/usr/include --libs=/usr/lib /usr/lib64
+              --cc=gcc --cxx=g++ --werror --with-thrift --with-glog
+              --with-rdma --with-debug-bthread-sche-safety --with-debug-lock
+              --with-bthread-tracer --with-asan
+          - name: clang-default
+            make-options: >-
+              --headers=/usr/include --libs=/usr/lib /usr/lib64
+              --cc=clang --cxx=clang++ --werror
+          - name: clang-all-options
+            make-options: >-
+              --headers=/usr/include --libs=/usr/lib /usr/lib64
+              --cc=clang --cxx=clang++ --werror --with-thrift --with-glog
+              --with-rdma --with-debug-bthread-sche-safety --with-debug-lock
+              --with-bthread-tracer --with-asan
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
+        cache-key: make-${{ matrix.name }}
     - uses: ./.github/actions/install-all-dependencies
 
-    - name: gcc with default options
+    - name: Build
       uses: ./.github/actions/compile-with-make
       with:
-        options: --headers=/usr/include --libs=/usr/lib /usr/lib64 --cc=gcc --cxx=g++ --werror
-
-    - name: gcc with all options
-      uses: ./.github/actions/compile-with-make
-      with:
-        options: --headers=/usr/include --libs=/usr/lib /usr/lib64 --cc=gcc --cxx=g++ --werror \
-                 --with-thrift --with-glog --with-rdma  --with-debug-bthread-sche-safety \
-                 --with-debug-lock --with-bthread-tracer --with-asan
-
-    - name: clang with default options
-      uses: ./.github/actions/compile-with-make
-      with:
-        options: --headers=/usr/include --libs=/usr/lib /usr/lib64 --cc=clang --cxx=clang++ --werror
-
-    - name: clang with all options
-      uses: ./.github/actions/compile-with-make
-      with:
-        options: --headers=/usr/include --libs=/usr/lib /usr/lib64 --cc=clang --cxx=clang++ --werror \
-                 --with-thrift --with-glog --with-rdma  --with-debug-bthread-sche-safety \
-                 --with-debug-lock --with-bthread-tracer --with-asan
+        options: ${{ matrix.make-options }}
 
     - name: Show ccache statistics
       if: always()

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -48,11 +48,11 @@ jobs:
               --with-bthread-tracer --with-asan
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/install-all-dependencies
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
         cache-key: make-${{ matrix.name }}
-    - uses: ./.github/actions/install-all-dependencies
 
     - name: Build
       uses: ./.github/actions/compile-with-make
@@ -96,11 +96,11 @@ jobs:
               -DWITH_BTHREAD_TRACER=ON -DWITH_ASAN=ON
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/install-all-dependencies
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
         cache-key: cmake-${{ matrix.name }}
-    - uses: ./.github/actions/install-all-dependencies
 
     - name: Build
       env:
@@ -138,11 +138,13 @@ jobs:
             protobuf-install-dir: /protobuf-3.21.12
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/install-essential-dependencies
+      with:
+        extra-packages: ccache
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
         cache-key: gcc-make-${{ matrix.name }}
-    - uses: ./.github/actions/install-essential-dependencies
 
     - name: Build
       uses: ./.github/actions/compile-with-make-protobuf
@@ -213,10 +215,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/install-essential-dependencies
+      with:
+        extra-packages: ccache
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
-    - uses: ./.github/actions/install-essential-dependencies
 
     - name: protobuf 3.5.1
       uses: ./.github/actions/compile-with-make-protobuf
@@ -309,10 +313,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/install-essential-dependencies
+      with:
+        extra-packages: ccache clang-12 lldb-12 lld-12 libgtest-dev cmake gdb libstdc++6-11-dbg
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
-    - uses: ./.github/actions/install-essential-dependencies
     - uses: ./.github/actions/init-ut-make-config
       with:
         options: --with-bthread-tracer --with-rdma
@@ -333,10 +339,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/install-essential-dependencies
+      with:
+        extra-packages: ccache clang-12 lldb-12 lld-12 libgtest-dev cmake gdb libstdc++6-11-dbg
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
-    - uses: ./.github/actions/install-essential-dependencies
     - uses: ./.github/actions/init-ut-make-config
       with:
         options: --with-bthread-tracer --with-asan

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -57,43 +57,54 @@ jobs:
       run: ccache --show-stats
 
   compile-with-cmake:
+    name: compile-with-cmake (${{ matrix.name }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: gcc-default
+            cc: gcc
+            cxx: g++
+            cmake-options: ''
+          - name: gcc-all-options
+            cc: gcc
+            cxx: g++
+            cmake-options: >-
+              -DWITH_MESALINK=OFF -DWITH_GLOG=ON -DWITH_THRIFT=ON
+              -DWITH_RDMA=ON -DWITH_UBRING=ON
+              -DWITH_DEBUG_BTHREAD_SCHE_SAFETY=ON -DWITH_DEBUG_LOCK=ON
+              -DWITH_BTHREAD_TRACER=ON -DWITH_ASAN=ON
+          - name: clang-default
+            cc: clang
+            cxx: clang++
+            cmake-options: ''
+          - name: clang-all-options
+            cc: clang
+            cxx: clang++
+            cmake-options: >-
+              -DWITH_MESALINK=OFF -DWITH_GLOG=ON -DWITH_THRIFT=ON
+              -DWITH_RDMA=ON -DWITH_UBRING=ON
+              -DWITH_DEBUG_BTHREAD_SCHE_SAFETY=ON -DWITH_DEBUG_LOCK=ON
+              -DWITH_BTHREAD_TRACER=ON -DWITH_ASAN=ON
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
+        cache-key: cmake-${{ matrix.name }}
     - uses: ./.github/actions/install-all-dependencies
 
-    - name: gcc with default options
+    - name: Build
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+        CMAKE_OPTIONS: ${{ matrix.cmake-options }}
       run: |
-        export CC=gcc && export CXX=g++
-        mkdir gcc_build && cd gcc_build && cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
-        make -j ${{env.proc_num}} && make clean
-
-    - name: gcc with all options
-      run: |
-        export CC=gcc && export CXX=g++
-        mkdir gcc_build_all && cd gcc_build_all
-        cmake -DWITH_MESALINK=OFF -DWITH_GLOG=ON -DWITH_THRIFT=ON -DWITH_RDMA=ON -DWITH_UBRING=ON \
-              -DWITH_DEBUG_BTHREAD_SCHE_SAFETY=ON -DWITH_DEBUG_LOCK=ON -DWITH_BTHREAD_TRACER=ON \
-              -DWITH_ASAN=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
-        make -j ${{env.proc_num}} && make clean
-
-    - name: clang with default options
-      run: |
-        export CC=clang && export CXX=clang++
-        mkdir clang_build && cd clang_build && cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
-        make -j ${{env.proc_num}} && make clean
-
-    - name: clang with all options
-      run: |
-        export CC=clang && export CXX=clang++
-        mkdir clang_build_all && cd clang_build_all
-        cmake -DWITH_MESALINK=OFF -DWITH_GLOG=ON -DWITH_THRIFT=ON -DWITH_RDMA=ON -DWITH_UBRING=ON \
-              -DWITH_DEBUG_BTHREAD_SCHE_SAFETY=ON -DWITH_DEBUG_LOCK=ON -DWITH_BTHREAD_TRACER=ON \
-              -DWITH_ASAN=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
-        make -j ${{env.proc_num}} && make clean
+        read -r -a cmake_options <<< "${CMAKE_OPTIONS}"
+        cmake -S . -B build -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+          "${cmake_options[@]}"
+        cmake --build build -j ${{env.proc_num}}
 
     - name: Show ccache statistics
       if: always()

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest # https://github.com/actions/runner-images
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7.0.1
     - uses: ./.github/actions/setup-build-cache
       with:
         kind: ccache
@@ -52,7 +52,7 @@ jobs:
     runs-on: macos-latest # https://github.com/actions/runner-images
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7.0.1
       - uses: ./.github/actions/setup-build-cache
         with:
           kind: ccache
@@ -80,7 +80,7 @@ jobs:
   compile-with-bazel:
     runs-on: macos-latest # https://github.com/actions/runner-images
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7.0.1
       - uses: ./.github/actions/setup-build-cache
         with:
           kind: bazel

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -23,6 +23,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup-build-cache
+      with:
+        kind: ccache
     
     - name: install dependences
       run: |
@@ -46,6 +49,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-build-cache
+        with:
+          kind: ccache
 
       - name: install dependences
         run: |
@@ -67,4 +73,7 @@ jobs:
     runs-on: macos-latest # https://github.com/actions/runner-images
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-build-cache
+        with:
+          kind: bazel
       - run: bazel build --verbose_failures -- //:brpc -//example/...

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -44,6 +44,10 @@ jobs:
         mkdir build && cd build && cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DWITH_UBRING=ON -DCMAKE_PREFIX_PATH=$(brew --prefix protobuf@21) ..
         make -j ${{env.proc_num}} && make clean
 
+    - name: Show ccache statistics
+      if: always()
+      run: ccache --show-stats
+
   compile-with-make-cmake-protobuf29:
     runs-on: macos-latest # https://github.com/actions/runner-images
 
@@ -68,6 +72,10 @@ jobs:
         run: |
           mkdir build && cd build && cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DWITH_UBRING=ON -DCMAKE_PREFIX_PATH=$(brew --prefix protobuf@29) ..
           make -j ${{env.proc_num}} && make clean
+
+      - name: Show ccache statistics
+        if: always()
+        run: ccache --show-stats
 
   compile-with-bazel:
     runs-on: macos-latest # https://github.com/actions/runner-images

--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.1
       - name: Check License
         uses: apache/skywalking-eyes@v0.4.0
         env:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve

Problem Summary:
CI recompiles the same sources, downloads the same Bazel dependencies, and
runs the Make and CMake configurations serially on every run, making build
validation unnecessarily slow.

### What is changed and the side effects?

Changed:
- Add a shared composite action that configures ccache for Make/CMake builds.
- Cache Bazel repository downloads separately from Bazel build outputs.
- Reuse caches in Linux and macOS build jobs.
- Report ccache statistics so cache behavior can be verified from CI logs.
- Run the four Linux CMake compiler/configuration combinations as independent
  matrix jobs.
- Run the four Linux Make compiler/configuration combinations as independent
  matrix jobs.
- Run the GCC and Clang Protobuf compatibility builds as independent matrix
  jobs.
- Consolidate each Linux job's APT dependencies into one update/install
  transaction.
- Upgrade checkout to the Node.js 24-based action release.
- Give each ccache job/configuration an unambiguous namespace so restore
  prefixes cannot select another job's cache.
- Disable Bazel test-result caching so every CI run executes all tests while
  still reusing cached compilation actions.

Measured results:
- The latest successful Linux run reduced the slowest job from a 38:25
  baseline average to 21:43 (43.4%). Total runner time across the measured
  Linux jobs fell from 270:09 to 143:45 (46.8%).
- The Make and CMake matrix critical paths were 4:45 and 4:06, compared with
  serial baseline averages of 16:09 and 18:38. Their total runner times were
  15:30 and 14:37, respectively.
- GCC and Clang Make/Protobuf matrix critical paths were 1:59 and 2:11,
  compared with serial baseline averages of 19:32 and 20:39.
- With Bazel test-result caching disabled, the three Bazel unit-test jobs took
  16:36-20:22, reductions of 35.0%-49.8% from their baseline averages. Every
  test still executed; only downloads and compilation actions were reused.
- The latest successful macOS run reduced total runner time from a 28:28
  baseline average to 9:47 (65.6%).

The baseline is the average of 10 successful runs. The post-change values are
from the latest successful run, so they represent the current configuration
rather than a multi-run post-change average.

Side effects:
- Performance effects: Subsequent CI runs can reuse compiler outputs and Bazel
  downloads/build outputs. Ccache is bounded to 2 GiB. Bazel repository caches
  are shared per platform, while build caches remain separated by job. Bazel
  tests always execute; only their compilation actions remain cacheable.

- Breaking backward compatibility: None.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
