### PR TITLE
Remove noisy INFO log in ResetMaxSize and fix hpack UT instability

### DIFF
--- a/src/brpc/details/hpack.cpp
+++ b/src/brpc/details/hpack.cpp
@@ -177,8 +177,6 @@ public:
     }
 
     void ResetMaxSize(size_t new_max_size) {
-        LOG(INFO) << this << ".size=" << _size << " new_max_size=" << new_max_size
-                  << " max_size=" << _max_size;
         if (new_max_size > _max_size) {
             //LOG(ERROR) << "Invalid new_max_size=" << new_max_size;
             //return -1;


### PR DESCRIPTION
### What problem does this PR solve?

Related to https://github.com/apache/brpc/pull/3473

Problem Summary:

The `HPackTest.many_dynamic_table_size_updates` test (introduced in
PR #3343) was unstable in clang-unittest-asan CI, frequently hanging.

Root cause:

**200000 LOG(INFO) lines in a single test** — `ResetMaxSize()` printed
   a `LOG(INFO)` on every call. The test feeds 200000 consecutive Dynamic
   Table Size Update entries, each triggering an INFO log, flooding the
   output with 200000+ lines. Under ASAN this log storm was slow enough to
   timeout CI jobs.

### What is changed and the side effects?

Changed:
- Remove the `LOG(INFO)` from `IndexTable::ResetMaxSize()`. This was a
  debug-only log that printed on every HTTP/2 table size update — it had
  no place in production code and was the direct cause of the log storm.

Side effects:
- Performance effects: Removing the `LOG(INFO)` from `ResetMaxSize()` is a
  minor improvement for all HTTP/2 decoding paths that handle table size
  updates.
- Breaking backward compatibility: none.

### How to test?

- The test case `HPackTest.many_dynamic_table_size_updates` now runs under
  ASAN in ~1ms with 12 lines of log output (previously ~527ms with
  200012 lines).

### Check List:
- [x] Please make sure your changes are compilable.