### PR TITLE
refactor(bthread): make TaskControl metric ownership explicit

### DIFF
--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -258,12 +258,20 @@ int TaskControl::init(int concurrency) {
     for (int i = 0; i < FLAGS_task_group_ntags; ++i) {
         _tagged_ngroup[i].store(0, std::memory_order_relaxed);
         auto tag_str = std::to_string(i);
-        _tagged_nworkers.push_back(new bvar::Adder<int64_t>("bthread_worker_count", tag_str));
-        _tagged_cumulated_worker_time.push_back(new bvar::PassiveStatus<double>(
-            get_cumulated_worker_time_from_this_with_tag, new CumulatedWithTagArgs{this, i}));
-        _tagged_worker_usage_second.push_back(new bvar::PerSecond<bvar::PassiveStatus<double>>(
-            "bthread_worker_usage", tag_str, _tagged_cumulated_worker_time[i], 1));
-        _tagged_nbthreads.push_back(new bvar::Adder<int64_t>("bthread_count", tag_str));
+        _tagged_nworkers.emplace_back(
+            std::make_unique<bvar::Adder<int64_t>>("bthread_worker_count", tag_str));
+        _tagged_cumulated_worker_time_args.emplace_back(
+            std::make_unique<CumulatedWithTagArgs>(this, i));
+        _tagged_cumulated_worker_time.emplace_back(
+            std::make_unique<bvar::PassiveStatus<double>>(
+                get_cumulated_worker_time_from_this_with_tag,
+                _tagged_cumulated_worker_time_args.back().get()));
+        _tagged_worker_usage_second.emplace_back(
+            std::make_unique<bvar::PerSecond<bvar::PassiveStatus<double>>>(
+                "bthread_worker_usage", tag_str,
+                _tagged_cumulated_worker_time.back().get(), 1));
+        _tagged_nbthreads.emplace_back(
+            std::make_unique<bvar::Adder<int64_t>>("bthread_count", tag_str));
     }
 
     if (init_ed_priority_queues() != 0) {

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -41,6 +41,7 @@ DECLARE_int32(task_group_ntags);
 namespace bthread {
 
 class TaskGroup;
+struct CumulatedWithTagArgs;
 
 // Control all task groups
 class TaskControl {
@@ -171,10 +172,14 @@ private:
     bvar::PassiveStatus<std::string> _status;
     bvar::Adder<int64_t> _nbthreads;
 
-    std::vector<bvar::Adder<int64_t>*> _tagged_nworkers;
-    std::vector<bvar::PassiveStatus<double>*> _tagged_cumulated_worker_time;
-    std::vector<bvar::PerSecond<bvar::PassiveStatus<double>>*> _tagged_worker_usage_second;
-    std::vector<bvar::Adder<int64_t>*> _tagged_nbthreads;
+    std::vector<std::unique_ptr<bvar::Adder<int64_t>>> _tagged_nworkers;
+    std::vector<std::unique_ptr<CumulatedWithTagArgs>>
+        _tagged_cumulated_worker_time_args;
+    std::vector<std::unique_ptr<bvar::PassiveStatus<double>>>
+        _tagged_cumulated_worker_time;
+    std::vector<std::unique_ptr<bvar::PerSecond<bvar::PassiveStatus<double>>>>
+        _tagged_worker_usage_second;
+    std::vector<std::unique_ptr<bvar::Adder<int64_t>>> _tagged_nbthreads;
 
     bool _enable_priority_queue;
     int _ed_priority_queue_num_of_each_tag;


### PR DESCRIPTION
### What problem does this PR solve?

  Problem Summary:

  TaskControl stored per-tag bvar metrics as raw pointers. In addition, each cumulative-time PassiveStatus received a heap-allocated callback argument with no explicit  owner. Since PassiveStatus does not own that argument, its lifetime was unclear and could leak when TaskControl is destroyed.

  ### What is changed and the side effects?

  Changed:

  - Replace the four per-tag bvar raw-pointer vectors with std::unique_ptr containers.
  - Add explicit ownership for each CumulatedWithTagArgs callback argument.
  - Preserve metric names, access patterns, and scheduler behavior.
  - Keep callback arguments alive until their corresponding PassiveStatus is destroyed.

  Side effects:

  - Performance effects: No steady-state impact expected. Ownership changes occur only during TaskControl initialization/destruction.
  - Breaking backward compatibility: None; no public API or metric name changes.

  ———

  ### Check List:

  - [x] The modified task_control.cpp CMake object target compiles successfully.
  - [x] git diff --check passes.
  - [ ] Full bthread test suite was not run because the current build is blocked by an unrelated brpc::EPROGREADTIMEOUT compilation error.
  - [ ] No new feature; no additional behavior test required.