### PR TITLE
fix: release AccessThreadArgs array in parallel_http to avoid memory leak

### DIFF
--- a/tools/parallel_http/parallel_http.cpp
+++ b/tools/parallel_http/parallel_http.cpp
@@ -207,5 +207,7 @@ int main(int argc, char** argv) {
             usleep(10000);
         }
     }
+
+    delete[] args;
     return 0;
 }


### PR DESCRIPTION
Fixes #2793

`main()` in `tools/parallel_http/parallel_http.cpp` allocates `AccessThreadArgs* args = new AccessThreadArgs[FLAGS_thread_num]` but never releases it before `return 0`, leaking the array (and each `AccessThreadArgs` output queue) when the tool exits.

Add `delete[] args;` before `return 0`.

brpc has no bounty program, so no wallet address appended.