### PR TITLE
Limit streams accepted per request

### DIFF
--- a/src/brpc/stream.cpp
+++ b/src/brpc/stream.cpp
@@ -40,6 +40,11 @@ DECLARE_int64(socket_max_streams_unconsumed_bytes);
 DEFINE_uint64(stream_write_max_segment_size, 512 * 1024 * 1024,
               "Stream message exceeding this size will be automatically split into smaller segments");
 BRPC_VALIDATE_GFLAG(stream_write_max_segment_size, PositiveInteger);
+DEFINE_int32(stream_max_streams_per_request, 64,
+             "Maximum number of streams that StreamAccept creates for one "
+             "request. Raise this flag if an application needs to accept "
+             "more streams per request");
+BRPC_VALIDATE_GFLAG(stream_max_streams_per_request, PositiveInteger);
 
 const static butil::IOBuf *TIMEOUT_TASK = (butil::IOBuf*)-1L;
 
@@ -1032,6 +1037,15 @@ int StreamAccept(StreamIds& response_streams, Controller& cntl,
     }
     if (!cntl.has_remote_stream()) {
         LOG(ERROR) << "No stream along with this request";
+        return -1;
+    }
+    const int64_t stream_count = static_cast<int64_t>(
+        cntl._remote_stream_settings->extra_stream_ids_size()) + 1;
+    if (stream_count > FLAGS_stream_max_streams_per_request) {
+        LOG(ERROR) << "Reject " << stream_count
+                   << " streams in one request, exceeding "
+                      "-stream_max_streams_per_request="
+                   << FLAGS_stream_max_streams_per_request;
         return -1;
     }
     StreamOptions opt;

--- a/src/brpc/stream.cpp
+++ b/src/brpc/stream.cpp
@@ -1046,7 +1046,8 @@ int StreamAccept(StreamIds& response_streams, Controller& cntl,
                        "Reject %" PRId64 " streams in one request, exceeding "
                        "-stream_max_streams_per_request=%" PRId64,
                        stream_count,
-                       FLAGS_stream_max_streams_per_request);
+                       static_cast<int64_t>(
+                           FLAGS_stream_max_streams_per_request));
         LOG(ERROR) << "Reject " << stream_count
                    << " streams in one request, exceeding "
                       "-stream_max_streams_per_request="

--- a/src/brpc/stream.cpp
+++ b/src/brpc/stream.cpp
@@ -1042,6 +1042,11 @@ int StreamAccept(StreamIds& response_streams, Controller& cntl,
     const int64_t stream_count = static_cast<int64_t>(
         cntl._remote_stream_settings->extra_stream_ids_size()) + 1;
     if (stream_count > FLAGS_stream_max_streams_per_request) {
+        cntl.SetFailed(EREQUEST,
+                       "Reject %" PRId64 " streams in one request, exceeding "
+                       "-stream_max_streams_per_request=%" PRId64,
+                       stream_count,
+                       FLAGS_stream_max_streams_per_request);
         LOG(ERROR) << "Reject " << stream_count
                    << " streams in one request, exceeding "
                       "-stream_max_streams_per_request="

--- a/test/brpc_streaming_rpc_unittest.cpp
+++ b/test/brpc_streaming_rpc_unittest.cpp
@@ -1260,12 +1260,15 @@ public:
         response->set_message(request->message());
 
         brpc::StreamIds response_streams;
-        accept_result = brpc::StreamAccept(response_streams, *cntl, nullptr);
-        accepted_streams = response_streams.size();
+        accept_result.store(
+            brpc::StreamAccept(response_streams, *cntl, nullptr),
+            std::memory_order_release);
+        accepted_streams.store(
+            response_streams.size(), std::memory_order_release);
     }
 
-    int accept_result{0};
-    size_t accepted_streams{0};
+    std::atomic<int> accept_result{0};
+    std::atomic<size_t> accepted_streams{0};
 };
 
 TEST_F(StreamingRpcTest, limit_streams_accepted_per_request) {
@@ -1299,13 +1302,19 @@ TEST_F(StreamingRpcTest, limit_streams_accepted_per_request) {
         stub.Echo(&cntl, &request, &response, nullptr);
         if (stream_count == 2) {
             ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
-            ASSERT_EQ(0, service.accept_result);
-            ASSERT_EQ(stream_count, service.accepted_streams);
+            ASSERT_EQ(0, service.accept_result.load(
+                             std::memory_order_acquire));
+            ASSERT_EQ(stream_count, service.accepted_streams.load(
+                                        std::memory_order_acquire));
         } else {
             ASSERT_TRUE(cntl.Failed());
             ASSERT_EQ(brpc::EREQUEST, cntl.ErrorCode());
-            ASSERT_EQ(-1, service.accept_result);
-            ASSERT_EQ(0u, service.accepted_streams);
+            ASSERT_NE(std::string::npos, cntl.ErrorText().find(
+                                             "stream_max_streams_per_request"));
+            ASSERT_EQ(-1, service.accept_result.load(
+                              std::memory_order_acquire));
+            ASSERT_EQ(0u, service.accepted_streams.load(
+                              std::memory_order_acquire));
         }
 
         for (brpc::StreamId stream_id : request_streams) {

--- a/test/brpc_streaming_rpc_unittest.cpp
+++ b/test/brpc_streaming_rpc_unittest.cpp
@@ -1249,6 +1249,74 @@ private:
     int _adjustment;
 };
 
+class MyServiceWithStreamCountLimit : public test::EchoService {
+public:
+    void Echo(::google::protobuf::RpcController* controller,
+              const ::test::EchoRequest* request,
+              ::test::EchoResponse* response,
+              ::google::protobuf::Closure* done) override {
+        brpc::ClosureGuard done_guard(done);
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+        response->set_message(request->message());
+
+        brpc::StreamIds response_streams;
+        accept_result = brpc::StreamAccept(response_streams, *cntl, nullptr);
+        accepted_streams = response_streams.size();
+    }
+
+    int accept_result{0};
+    size_t accepted_streams{0};
+};
+
+TEST_F(StreamingRpcTest, limit_streams_accepted_per_request) {
+    std::string old_stream_limit;
+    ASSERT_TRUE(GFLAGS_NAMESPACE::GetCommandLineOption(
+        "stream_max_streams_per_request", &old_stream_limit));
+    BRPC_SCOPE_EXIT {
+        GFLAGS_NAMESPACE::SetCommandLineOption(
+            "stream_max_streams_per_request", old_stream_limit.c_str());
+    };
+    ASSERT_FALSE(GFLAGS_NAMESPACE::SetCommandLineOption(
+        "stream_max_streams_per_request", "2").empty());
+
+    brpc::Server server;
+    MyServiceWithStreamCountLimit service;
+    ASSERT_EQ(0, server.AddService(
+        &service, brpc::SERVER_DOESNT_OWN_SERVICE));
+    ASSERT_EQ(0, server.Start(0, nullptr));
+
+    brpc::Channel channel;
+    ASSERT_EQ(0, channel.Init(server.listen_address(), nullptr));
+
+    for (size_t stream_count : {2u, 3u, 2u}) {
+        brpc::Controller cntl;
+        brpc::StreamIds request_streams;
+        ASSERT_EQ(0, brpc::StreamCreate(
+            request_streams, stream_count, cntl, nullptr));
+        ASSERT_EQ(stream_count, request_streams.size());
+
+        test::EchoService_Stub stub(&channel);
+        stub.Echo(&cntl, &request, &response, nullptr);
+        if (stream_count == 2) {
+            ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+            ASSERT_EQ(0, service.accept_result);
+            ASSERT_EQ(stream_count, service.accepted_streams);
+        } else {
+            ASSERT_TRUE(cntl.Failed());
+            ASSERT_EQ(brpc::EREQUEST, cntl.ErrorCode());
+            ASSERT_EQ(-1, service.accept_result);
+            ASSERT_EQ(0u, service.accepted_streams);
+        }
+
+        for (brpc::StreamId stream_id : request_streams) {
+            brpc::StreamClose(stream_id);
+        }
+    }
+
+    server.Stop(0);
+    server.Join();
+}
+
 TEST_F(StreamingRpcTest, reject_mismatched_returned_stream_identifiers) {
     const size_t STREAM_COUNT = 3;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`StreamAccept` creates one response stream for every stream identifier declared
by a request, without limiting the number created by a single RPC.

### What is changed and the side effects?

Changed:

- Add `stream_max_streams_per_request` with a default value of 64.
- Reject requests exceeding the limit before creating any response streams.
- Cover the boundary, rejection, and a subsequent valid request over the same
  client/server connection.

Side effects:

- Performance effects: one constant-time count check per `StreamAccept` call.
- Breaking backward compatibility: applications accepting more than 64
  streams in one RPC must raise `stream_max_streams_per_request`.

---
### Check List:

- [x] Please make sure your changes are compilable.
- [x] When providing us with a new feature, it is best to add related tests.
- [x] Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
