### PR TITLE
Contain malformed Thrift T_EXCEPTION replies on the client

### DIFF
--- a/src/brpc/policy/thrift_protocol.cpp
+++ b/src/brpc/policy/thrift_protocol.cpp
@@ -194,10 +194,10 @@ void ReadThriftException(const butil::IOBuf& body,
         x->read(&iprot);
         iprot.readMessageEnd();
         iprot.getTransport()->readEnd();
-    } catch (std::exception& e) {
-        LOG(WARNING) << "Catched thrift exception while parsing T_EXCEPTION reply: " << e.what();
+    } catch (const std::exception& e) {
+        LOG(WARNING) << "Caught thrift exception while parsing T_EXCEPTION reply: " << e.what();
     } catch (...) {
-        LOG(WARNING) << "Catched unknown thrift exception while parsing T_EXCEPTION reply";
+        LOG(WARNING) << "Caught unknown thrift exception while parsing T_EXCEPTION reply";
     }
 }
 

--- a/src/brpc/policy/thrift_protocol.cpp
+++ b/src/brpc/policy/thrift_protocol.cpp
@@ -184,9 +184,21 @@ void ReadThriftException(const butil::IOBuf& body,
             ::apache::thrift::transport::TMemoryBuffer::TAKE_OWNERSHIP);
     apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TMemoryBuffer> iprot(in_buffer);
 
-    x->read(&iprot);
-    iprot.readMessageEnd();
-    iprot.getTransport()->readEnd();
+    // A malformed exception struct may make the underlying thrift code throw
+    // (e.g. TProtocolException on a bad field or TTransportException /
+    // std::length_error on a bad length). Such an exception must be contained
+    // here: if it propagated out, it would unwind through ProcessThriftResponse
+    // up to the bthread task frame and call std::terminate(), taking down the
+    // whole process along with every other in-flight RPC on it.
+    try {
+        x->read(&iprot);
+        iprot.readMessageEnd();
+        iprot.getTransport()->readEnd();
+    } catch (std::exception& e) {
+        LOG(WARNING) << "Catched thrift exception while parsing T_EXCEPTION reply: " << e.what();
+    } catch (...) {
+        LOG(WARNING) << "Catched unknown thrift exception while parsing T_EXCEPTION reply";
+    }
 }
 
 // The continuation of request processing. Namely send response back to client.

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -24,12 +24,7 @@ COPTS = [
     "-Wno-unused-parameter",
     "-fno-omit-frame-pointer",
     "-fno-access-control",
-] + select({
-    # The thrift framed protocol (and the unit test that exercises it) is only
-    # compiled when the build has Thrift support enabled, matching src/BUILD.
-    "//bazel/config:brpc_with_thrift": ["-DENABLE_THRIFT_FRAMED_PROTOCOL=1"],
-    "//conditions:default": [],
-})
+]
 
 TEST_BUTIL_SOURCES = [
     "at_exit_unittest.cc",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -24,7 +24,12 @@ COPTS = [
     "-Wno-unused-parameter",
     "-fno-omit-frame-pointer",
     "-fno-access-control",
-]
+] + select({
+    # The thrift framed protocol (and the unit test that exercises it) is only
+    # compiled when the build has Thrift support enabled, matching src/BUILD.
+    "//bazel/config:brpc_with_thrift": ["-DENABLE_THRIFT_FRAMED_PROTOCOL=1"],
+    "//conditions:default": [],
+})
 
 TEST_BUTIL_SOURCES = [
     "at_exit_unittest.cc",

--- a/test/brpc_thrift_protocol_unittest.cpp
+++ b/test/brpc_thrift_protocol_unittest.cpp
@@ -17,20 +17,27 @@
 
 // brpc - A framework to host and access services throughout Baidu.
 
-#include <arpa/inet.h>
 #include <gtest/gtest.h>
 #include <gflags/gflags.h>
-#include "butil/macros.h"
-#include "brpc/socket.h"
-#include "brpc/controller.h"
-#include "brpc/policy/most_common_message.h"
-#include "brpc/policy/thrift_protocol.h"
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
     GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
     return RUN_ALL_TESTS();
 }
+
+// The malformed T_EXCEPTION reply is decoded by the Thrift framed protocol,
+// which is only compiled in when the build has THRIFT support enabled (the
+// WITH_THRIFT build flag / brpc_with_thrift config, off by default). Keep this
+// test a trivial pass on builds without Thrift so it links cleanly there too.
+#ifdef ENABLE_THRIFT_FRAMED_PROTOCOL
+
+#include <arpa/inet.h>
+#include "butil/macros.h"
+#include "brpc/socket.h"
+#include "brpc/controller.h"
+#include "brpc/policy/most_common_message.h"
+#include "brpc/policy/thrift_protocol.h"
 
 namespace {
 
@@ -118,3 +125,14 @@ TEST_F(ThriftProtocolTest, malformed_exception_reply_sets_failed) {
 }
 
 }  // namespace
+
+#else
+
+namespace {
+// Trivial placeholder so the test links successfully on builds without
+// THRIFT support (the guarded code above is compiled out).
+class ThriftProtocolTest : public ::testing::Test {};
+TEST_F(ThriftProtocolTest, skipped_without_thrift_support) {}
+}  // namespace
+
+#endif

--- a/test/brpc_thrift_protocol_unittest.cpp
+++ b/test/brpc_thrift_protocol_unittest.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <gflags/gflags.h>
+#include <unistd.h>
 
 int main(int argc, char* argv[]) {
     testing::InitGoogleTest(&argc, argv);
@@ -48,6 +49,7 @@ static const uint32_t THRIFT_HEAD_VERSION_1 = 0x80010000;
 class ThriftProtocolTest : public ::testing::Test {
 protected:
     ThriftProtocolTest() {
+        _pipe_fds[0] = _pipe_fds[1] = -1;
         EXPECT_EQ(0, pipe(_pipe_fds));
         brpc::SocketId id;
         brpc::SocketOptions options;
@@ -57,7 +59,19 @@ protected:
     }
 
     virtual void SetUp() {}
-    virtual void TearDown() {}
+    virtual void TearDown() {
+        // Close the pipe fds and destroy the test socket so no OS resources
+        // are leaked across tests.
+        if (_pipe_fds[0] >= 0) {
+            close(_pipe_fds[0]);
+            _pipe_fds[0] = -1;
+        }
+        if (_pipe_fds[1] >= 0) {
+            close(_pipe_fds[1]);
+            _pipe_fds[1] = -1;
+        }
+        _socket.reset();
+    }
 
     // Attach the test socket to the message so that ProcessThriftResponse
     // can read the correlation_id out of it.

--- a/test/brpc_thrift_protocol_unittest.cpp
+++ b/test/brpc_thrift_protocol_unittest.cpp
@@ -60,16 +60,14 @@ protected:
 
     virtual void SetUp() {}
     virtual void TearDown() {
-        // Close the pipe fds and destroy the test socket so no OS resources
-        // are leaked across tests.
+        // The test socket owns `_pipe_fds[1]` (SocketOptions::fd takes
+        // ownership and Socket closes it on destruction), so only the read
+        // end `_pipe_fds[0]` is closed here to avoid double-close.
         if (_pipe_fds[0] >= 0) {
             close(_pipe_fds[0]);
             _pipe_fds[0] = -1;
         }
-        if (_pipe_fds[1] >= 0) {
-            close(_pipe_fds[1]);
-            _pipe_fds[1] = -1;
-        }
+        _pipe_fds[1] = -1;
         _socket.reset();
     }
 

--- a/test/brpc_thrift_protocol_unittest.cpp
+++ b/test/brpc_thrift_protocol_unittest.cpp
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// brpc - A framework to host and access services throughout Baidu.
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <gflags/gflags.h>
+#include "butil/macros.h"
+#include "brpc/socket.h"
+#include "brpc/controller.h"
+#include "brpc/policy/most_common_message.h"
+#include "brpc/policy/thrift_protocol.h"
+
+int main(int argc, char* argv[]) {
+    testing::InitGoogleTest(&argc, argv);
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
+    return RUN_ALL_TESTS();
+}
+
+namespace {
+
+// A nominal thrift message-type value for a T_EXCEPTION reply.
+static const uint32_t THRIFT_TYPE_EXCEPTION = 3;
+static const uint32_t THRIFT_HEAD_VERSION_1 = 0x80010000;
+
+class ThriftProtocolTest : public ::testing::Test {
+protected:
+    ThriftProtocolTest() {
+        EXPECT_EQ(0, pipe(_pipe_fds));
+        brpc::SocketId id;
+        brpc::SocketOptions options;
+        options.fd = _pipe_fds[1];
+        EXPECT_EQ(0, brpc::Socket::Create(options, &id));
+        EXPECT_EQ(0, brpc::Socket::Address(id, &_socket));
+    }
+
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+
+    // Attach the test socket to the message so that ProcessThriftResponse
+    // can read the correlation_id out of it.
+    void AttachMessage(brpc::InputMessageBase* msg) {
+        if (msg->_socket == nullptr) {
+            _socket->ReAddress(&msg->_socket);
+        }
+    }
+
+    // Build a MostCommonMessage whose payload is a thrift T_EXCEPTION reply
+    // whose exception struct is malformed (a T_STRING field whose length is
+    // huge and never bounded by real bytes).
+    brpc::policy::MostCommonMessage* MakeMalformedExceptionMessage() {
+        const char method_name[] = "echo";
+        const uint32_t version_and_type = htonl(
+            THRIFT_HEAD_VERSION_1 | THRIFT_TYPE_EXCEPTION);
+        const uint32_t method_name_length = htonl(sizeof(method_name) - 1);
+        const uint32_t seq_id = htonl(0);
+        // Malformed exception struct body: one field, id 1, type T_STRING,
+        // string length 0x7FFFFFFF and no following bytes.
+        static const uint8_t malformed_body[] =
+            { 0x0B, 0x00, 0x01, 0x7F, 0xFF, 0xFF, 0xFF };
+
+        brpc::policy::MostCommonMessage* msg =
+                brpc::policy::MostCommonMessage::Get();
+        msg->payload.append(&version_and_type, sizeof(version_and_type));
+        msg->payload.append(&method_name_length, sizeof(method_name_length));
+        msg->payload.append(method_name, sizeof(method_name) - 1);
+        msg->payload.append(&seq_id, sizeof(seq_id));
+        msg->payload.append(malformed_body, sizeof(malformed_body));
+        return msg;
+    }
+
+    int _pipe_fds[2];
+    brpc::SocketUniquePtr _socket;
+};
+
+TEST_F(ThriftProtocolTest, malformed_exception_reply_does_not_crash_client) {
+    brpc::Controller cntl;
+    // Simulate a real client: the socket's correlation_id matches the
+    // controller's call_id so that ProcessThriftResponse can find the
+    // controller.
+    _socket->set_correlation_id(cntl.call_id().value);
+
+    brpc::policy::MostCommonMessage* msg = MakeMalformedExceptionMessage();
+    AttachMessage(msg);
+
+    // Before the fix, ReadThriftException lets the malformed reply unwind out
+    // of ProcessThriftResponse as an uncaught thrift exception (in production
+    // that reaches the bthread task frame and calls std::terminate). After the
+    // fix it must be contained and reported as a normal RPC failure instead.
+    EXPECT_NO_THROW(brpc::policy::ProcessThriftResponse(msg));
+}
+
+TEST_F(ThriftProtocolTest, malformed_exception_reply_sets_failed) {
+    brpc::Controller cntl;
+    _socket->set_correlation_id(cntl.call_id().value);
+
+    brpc::policy::MostCommonMessage* msg = MakeMalformedExceptionMessage();
+    AttachMessage(msg);
+    brpc::policy::ProcessThriftResponse(msg);
+    // After the fix the malformed exception reply must be surfaced to the
+    // caller as a failed RPC rather than crashing the process.
+    EXPECT_TRUE(cntl.Failed());
+}
+
+}  // namespace


### PR DESCRIPTION
## What problem does this PR solve?

Problem Summary:

A bRPC Thrift client can be brought down by a peer reply that carries a
malformed `T_EXCEPTION`. The exception struct is decoded in
`ReadThriftException` without a try/catch; a bad field or an oversized
length makes the underlying thrift library throw (`TProtocolException`,
`TTransportException` or `std::length_error`). The exception is not caught
anywhere on the return path and eventually reaches the bthread task frame,
where `std::terminate()` is called, terminating the whole process.

This only affects builds with `WITH_THRIFT` enabled (off by default).

## What is changed and the side effects?

Changed:

`ReadThriftException` now wraps the decode of the exception struct in the
same `try/catch` that `ReadThriftStruct` already uses for the normal reply
body. A malformed `T_EXCEPTION` reply is reported as a failed RPC instead
of crashing the process.

Side effects:

- None. The fix only contains an otherwise-uncaught exception.

- Performance effects: none.

- Breaking backward compatibility: none.

## Check List

- [x] The change is compilable.
- [x] A unit test is added in `test/brpc_thrift_protocol_unittest.cpp`
      that feeds a malformed `T_EXCEPTION` reply through the client
      response path and asserts the call does not crash and marks the
      controller failed.
- [x] Follows the Contributor Covenant Code of Conduct.