### PR TITLE
Release the RTMP peer key after key agreement

### DIFF
--- a/src/brpc/policy/dh.cpp
+++ b/src/brpc/policy/dh.cpp
@@ -81,9 +81,9 @@ int DHWrapper::copy_shared_key(const void* ppkey, int ppkey_size,
     }
     // @see https://github.com/ossrs/srs/issues/165
     int key_size = DH_compute_key((unsigned char*)skey, ppk, _pdh);
+    BN_free(ppk);
     if (key_size < 0 || key_size > *skey_size) {
         LOG(ERROR) << "Fail to compute shared key";
-        BN_free(ppk);
         return -1;
     }
     *skey_size = key_size;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve

Problem Summary:

`DHWrapper::copy_shared_key` only released the temporary peer public key
when `DH_compute_key` failed. Successful RTMP complex handshakes retained the
allocation.

### What is changed and the side effects?

Changed:

Release the temporary peer public key immediately after `DH_compute_key`
returns, covering both success and failure paths.

Side effects:
- Performance effects: Negligible; this only releases an allocation when its
  last use completes.

- Breaking backward compatibility: No.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).