### PR TITLE
fix(bthread): drop unimplemented barrier and rwlockattr APIs

### DIFF
--- a/src/bthread/bthread.h
+++ b/src/bthread/bthread.h
@@ -249,6 +249,7 @@ extern int bthread_cond_timedwait(
 
 // Initialize read-write lock `rwlock' using attributes `attr', or use
 // the default values if later is nullptr.
+// NOTE: attr is not used in the current implementation.
 extern int bthread_rwlock_init(bthread_rwlock_t* __restrict rwlock,
                                const bthread_rwlockattr_t* __restrict attr);
 
@@ -277,24 +278,6 @@ extern int bthread_rwlock_timedwrlock(bthread_rwlock_t* __restrict rwlock,
 
 // Unlock `rwlock'.
 extern int bthread_rwlock_unlock(bthread_rwlock_t* rwlock);
-
-// ---------------------------------------------------
-// Functions for handling read-write lock attributes.
-// ---------------------------------------------------
-
-// Initialize attribute object `attr' with default values.
-extern int bthread_rwlockattr_init(bthread_rwlockattr_t* attr);
-
-// Destroy attribute object `attr'.
-extern int bthread_rwlockattr_destroy(bthread_rwlockattr_t* attr);
-
-// Return current setting of reader/writer preference.
-extern int bthread_rwlockattr_getkind_np(const bthread_rwlockattr_t* attr,
-                                         int* pref);
-
-// Set reader/write preference.
-extern int bthread_rwlockattr_setkind_np(bthread_rwlockattr_t* attr,
-                                         int pref);
 
 // -------------------------------------------
 // Functions for handling semaphore.
@@ -342,19 +325,6 @@ extern int bthread_sem_post(bthread_sem_t* sem);
 // `n' semaphore unlock operation on that semaphore.
 // Return 0 on success, errno otherwise.
 extern int bthread_sem_post_n(bthread_sem_t* sem, size_t n);
-
-
-// ----------------------------------------------------------------------
-// Functions for handling barrier which is a new feature in 1003.1j-2000.
-// ----------------------------------------------------------------------
-
-extern int bthread_barrier_init(bthread_barrier_t* __restrict barrier,
-                                const bthread_barrierattr_t* __restrict attr,
-                                unsigned count);
-
-extern int bthread_barrier_destroy(bthread_barrier_t* barrier);
-
-extern int bthread_barrier_wait(bthread_barrier_t* barrier);
 
 // ---------------------------------------------------------------------
 // Functions for handling thread-specific data. 

--- a/src/bthread/bthread.h
+++ b/src/bthread/bthread.h
@@ -279,6 +279,24 @@ extern int bthread_rwlock_timedwrlock(bthread_rwlock_t* __restrict rwlock,
 // Unlock `rwlock'.
 extern int bthread_rwlock_unlock(bthread_rwlock_t* rwlock);
 
+// ---------------------------------------------------
+// Functions for handling read-write lock attributes.
+// ---------------------------------------------------
+// TODO: Implement these APIs. bthread_rwlock_init() currently ignores attr.
+
+// Initialize attribute object `attr' with default values.
+// extern int bthread_rwlockattr_init(bthread_rwlockattr_t* attr);
+
+// Destroy attribute object `attr'.
+// extern int bthread_rwlockattr_destroy(bthread_rwlockattr_t* attr);
+
+// Return current setting of reader/writer preference.
+// extern int bthread_rwlockattr_getkind_np(const bthread_rwlockattr_t* attr,
+//                                          int* pref);
+
+// Set reader/write preference.
+// extern int bthread_rwlockattr_setkind_np(bthread_rwlockattr_t* attr, int pref);
+
 // -------------------------------------------
 // Functions for handling semaphore.
 // -------------------------------------------
@@ -325,6 +343,19 @@ extern int bthread_sem_post(bthread_sem_t* sem);
 // `n' semaphore unlock operation on that semaphore.
 // Return 0 on success, errno otherwise.
 extern int bthread_sem_post_n(bthread_sem_t* sem, size_t n);
+
+// ----------------------------------------------------------------------
+// Functions for handling barrier which is a new feature in 1003.1j-2000.
+// ----------------------------------------------------------------------
+// TODO: Implement bthread barrier.
+
+// extern int bthread_barrier_init(bthread_barrier_t* __restrict barrier,
+//                                 const bthread_barrierattr_t* __restrict attr,
+//                                 unsigned count);
+
+// extern int bthread_barrier_destroy(bthread_barrier_t* barrier);
+
+// extern int bthread_barrier_wait(bthread_barrier_t* barrier);
 
 // ---------------------------------------------------------------------
 // Functions for handling thread-specific data. 

--- a/src/bthread/types.h
+++ b/src/bthread/types.h
@@ -247,15 +247,10 @@ typedef struct bthread_rwlock_t {
     unsigned* lock_word;
 } bthread_rwlock_t;
 
+// Kept for ABI compatibility with bthread_rwlock_init(). There is no
+// bthread_rwlockattr_* API; pass nullptr to use the default.
 typedef struct {
 } bthread_rwlockattr_t;
-
-typedef struct {
-    unsigned int count;
-} bthread_barrier_t;
-
-typedef struct {
-} bthread_barrierattr_t;
 
 #if defined(__cplusplus)
 class bthread_once_t;

--- a/src/bthread/types.h
+++ b/src/bthread/types.h
@@ -247,10 +247,18 @@ typedef struct bthread_rwlock_t {
     unsigned* lock_word;
 } bthread_rwlock_t;
 
-// Kept for ABI compatibility with bthread_rwlock_init(). There is no
-// bthread_rwlockattr_* API; pass nullptr to use the default.
+// Kept for ABI compatibility with bthread_rwlock_init(). Pass nullptr
+// for the default. See TODO on bthread_rwlockattr_* in bthread.h.
 typedef struct {
 } bthread_rwlockattr_t;
+
+// TODO: Implement bthread barrier.
+// typedef struct {
+//     unsigned int count;
+// } bthread_barrier_t;
+//
+// typedef struct {
+// } bthread_barrierattr_t;
 
 #if defined(__cplusplus)
 class bthread_once_t;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
`bthread.h` declared POSIX-style barrier APIs (`bthread_barrier_init/destroy/wait`) and rwlock attribute APIs (`bthread_rwlockattr_init/destroy/getkind_np/setkind_np`) that were never defined in `libbrpc`. Compiling against the headers succeeded, then linking failed with `undefined reference`. The headers advertised an API that the library does not provide.

### What is changed and the side effects?

Changed:
- Remove unimplemented `bthread_barrier_*` declarations and the unused `bthread_barrier_t` / `bthread_barrierattr_t` types.
- Remove unimplemented `bthread_rwlockattr_*` declarations.
- Keep `bthread_rwlockattr_t` because it is still the argument type of the implemented `bthread_rwlock_init()`.
- Document that `bthread_rwlock_init()` currently ignores `attr`.

Side effects:
- Performance effects: none.

- Breaking backward compatibility: source-incompatible only for code that called these never-linked symbols. Working programs that already linked against brpc could not have been using them. `bthread_rwlock_init()` signature is unchanged.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
