### PR TITLE
fix(cmake): prefer generated proto headers over in-source leftovers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ set(BRPC_COMMON_COMPILE_OPTIONS)
 set(BRPC_COMMON_DEFINITIONS)
 set(BRPC_COMMON_INCLUDE_DIRS
     ${PROJECT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_BINARY_DIR}
 )
 set(BRPC_COMMON_LINK_OPTIONS)
 set(BRPC_CXX_STANDARD 14)
@@ -417,6 +416,10 @@ endif()
 list(REMOVE_DUPLICATES BRPC_COMMON_INCLUDE_DIRS)
 
 add_library(brpc_common_config INTERFACE)
+# Generated protobuf headers live in the build directory. Search it before src/
+# so leftover in-source *.pb.h (gitignored, produced by Make) cannot shadow
+# updated .proto files such as errno.proto.
+target_include_directories(brpc_common_config BEFORE INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(brpc_common_config INTERFACE ${BRPC_COMMON_INCLUDE_DIRS})
 target_compile_definitions(brpc_common_config INTERFACE ${BRPC_COMMON_DEFINITIONS})
 target_compile_options(brpc_common_config INTERFACE ${BRPC_COMMON_COMPILE_OPTIONS})


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

CMake searched `${PROJECT_SOURCE_DIR}/src` before the build directory. Make generates protobuf headers in-tree (`src/**/*.pb.h`, gitignored). After a `.proto` update, CMake already writes the new header into the build directory, but the compiler still picks the leftover in-source file.

This showed up after #3469 (`EPROGREADTIMEOUT`):

```
src/brpc/controller.cpp:76:28: error: no member named 'EPROGREADTIMEOUT' in namespace 'brpc'
```

`src/brpc/errno.proto` and `build/brpc/errno.pb.h` both had `EPROGREADTIMEOUT = 1019`; the stale `src/brpc/errno.pb.h` still stopped at `EREJECT = 1018`.

### What is changed and the side effects?

Changed:

- Add `${CMAKE_CURRENT_BINARY_DIR}` as a `BEFORE` include on `brpc_common_config`, so generated protobuf headers are searched before `src/` and leftover Make-generated `*.pb.h` cannot shadow them.

Side effects:
- Performance effects: none. Compile-time include order only; no runtime change.

- Breaking backward compatibility: no. Generated headers remain the source of truth. In-source `*.pb.h` from Make is still valid when it is up to date; it just no longer wins over a newer build-dir copy. Existing Make and Bazel flows are unchanged.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).