### PR TITLE
Fix hang in stream ID validation test

### DIFF
--- a/test/brpc_streaming_rpc_unittest.cpp
+++ b/test/brpc_streaming_rpc_unittest.cpp
@@ -1366,11 +1366,12 @@ public:
             settings->add_extra_stream_ids(settings->extra_stream_ids(0));
         }
 
-        brpc::StreamIds response_streams;
         ASSERT_EQ(0, brpc::StreamAccept(response_streams, *cntl, nullptr));
         ASSERT_EQ((int)_stream_count + _adjustment,
                   (int)response_streams.size());
     }
+
+    brpc::StreamIds response_streams;
 
 private:
     size_t _stream_count;
@@ -1485,6 +1486,9 @@ TEST_F(StreamingRpcTest, reject_mismatched_returned_stream_identifiers) {
         for (brpc::StreamId stream_id : request_streams) {
             brpc::StreamUniquePtr stream;
             ASSERT_NE(0, brpc::Stream::Address(stream_id, &stream));
+        }
+        for (brpc::StreamId stream_id : service.response_streams) {
+            ASSERT_EQ(0, brpc::StreamClose(stream_id));
         }
 
         server.Stop(0);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

The mismatched returned stream ID test could hang in `Server::Join`. The
intentionally rejected response left server-side accepted streams open.

Related discussion: https://github.com/apache/brpc/pull/3485#discussion_r3889720756

### What is changed and the side effects?

Changed:

The test now retains and closes the server-side accepted streams before
stopping and joining the server.

Side effects:
- Performance effects: None. The change only affects a unit test.

- Breaking backward compatibility: No.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).