### PR TITLE
Replace popen('uname -ap') with uname() syscall in bvar kernel_version

### DIFF
--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -20,6 +20,7 @@
 #include <unistd.h>                        // getpagesize
 #include <sys/types.h>
 #include <sys/resource.h>                  // getrusage
+#include <sys/utsname.h>                   // uname
 #include <dirent.h>                        // dirent
 #include <iomanip>                         // setw
 #include <stdio.h>
@@ -617,11 +618,15 @@ static void get_cmdline(std::ostream& os, void*) {
 struct ReadVersion {
     std::string content;
     ReadVersion() {
-        std::ostringstream oss;
-        if (butil::read_command_output(oss, "uname -ap") != 0) {
+        struct utsname buf;
+        if (uname(&buf) != 0) {
             LOG(ERROR) << "Fail to read kernel version";
             return;
         }
+        std::ostringstream oss;
+        oss << buf.sysname << ' ' << buf.nodename << ' '
+            << buf.release << ' ' << buf.version << ' '
+            << buf.machine << ' ' << buf.machine;
         content.append(oss.str());
     }
 };

--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -633,7 +633,11 @@ struct ReadVersion {
         std::ostringstream oss;
         oss << buf.sysname << ' ' << buf.nodename << ' '
             << buf.release << ' ' << buf.version << ' '
-            << buf.machine << ' ' << processor << '\n';
+            << buf.machine << ' ' << processor;
+#if !defined(__APPLE__)
+        oss << " GNU/Linux";
+#endif
+        oss << '\n';
         content.append(oss.str());
     }
 };

--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -623,10 +623,17 @@ struct ReadVersion {
             LOG(ERROR) << "Fail to read kernel version";
             return;
         }
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+        const char* processor = "arm";
+#elif defined(__APPLE__) && defined(__x86_64__)
+        const char* processor = "i386";
+#else
+        const char* processor = buf.machine;
+#endif
         std::ostringstream oss;
         oss << buf.sysname << ' ' << buf.nodename << ' '
             << buf.release << ' ' << buf.version << ' '
-            << buf.machine << ' ' << buf.machine;
+            << buf.machine << ' ' << processor << '\n';
         content.append(oss.str());
     }
 };

--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -620,7 +620,8 @@ struct ReadVersion {
     ReadVersion() {
         struct utsname buf;
         if (uname(&buf) != 0) {
-            LOG(ERROR) << "Fail to read kernel version";
+            LOG(ERROR) << "Fail to read kernel version, errno=" << errno
+                       << " (" << strerror(errno) << ")";
             return;
         }
 #if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
@@ -635,7 +636,7 @@ struct ReadVersion {
         oss << buf.sysname << ' ' << buf.nodename << ' '
             << buf.release << ' ' << buf.version << ' '
             << buf.machine << ' ' << processor;
-#if !defined(__APPLE__)
+#if defined(__linux__) && !defined(__ANDROID__)
         oss << ' ' << hardware_platform << " GNU/Linux";
 #endif
         oss << '\n';

--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -621,8 +621,9 @@ struct ReadVersion {
     ReadVersion() {
         struct utsname buf;
         if (uname(&buf) != 0) {
-            LOG(ERROR) << "Fail to read kernel version, errno=" << errno
-                       << " (" << strerror(errno) << ")";
+            const int saved_errno = errno;
+            LOG(ERROR) << "Failed to read kernel version, errno=" << saved_errno
+                        << " (" << berror(saved_errno) << ")";
             return;
         }
         content.append(make_kernel_version_string(buf));

--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -40,6 +40,7 @@
 #include "butil/process_util.h"            // ReadCommandLine
 #include "butil/popen.h"                   // read_command_output
 #include "bvar/passive_status.h"
+#include "bvar/default_variables.h"          // make_kernel_version_string
 
 namespace bvar {
 
@@ -624,23 +625,7 @@ struct ReadVersion {
                        << " (" << strerror(errno) << ")";
             return;
         }
-#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
-        const char* processor = "arm";
-#elif defined(__APPLE__) && defined(__x86_64__)
-        const char* processor = "i386";
-#else
-        const char* processor = buf.machine;
-#endif
-        const char* hardware_platform = buf.machine;
-        std::ostringstream oss;
-        oss << buf.sysname << ' ' << buf.nodename << ' '
-            << buf.release << ' ' << buf.version << ' '
-            << buf.machine << ' ' << processor;
-#if defined(__linux__) && !defined(__ANDROID__)
-        oss << ' ' << hardware_platform << " GNU/Linux";
-#endif
-        oss << '\n';
-        content.append(oss.str());
+        content.append(make_kernel_version_string(buf));
     }
 };
 static void get_kernel_version(std::ostream& os, void*) {

--- a/src/bvar/default_variables.cpp
+++ b/src/bvar/default_variables.cpp
@@ -630,12 +630,13 @@ struct ReadVersion {
 #else
         const char* processor = buf.machine;
 #endif
+        const char* hardware_platform = buf.machine;
         std::ostringstream oss;
         oss << buf.sysname << ' ' << buf.nodename << ' '
             << buf.release << ' ' << buf.version << ' '
             << buf.machine << ' ' << processor;
 #if !defined(__APPLE__)
-        oss << " GNU/Linux";
+        oss << ' ' << hardware_platform << " GNU/Linux";
 #endif
         oss << '\n';
         content.append(oss.str());

--- a/src/bvar/default_variables.h
+++ b/src/bvar/default_variables.h
@@ -25,9 +25,13 @@
 namespace bvar {
 
 // Build the value of the `kernel_version` bvar from a uname(2) result.
-// The field layout mirrors `uname -ap` on the major platforms:
+// The field layout matches `uname -ap` on Linux and macOS:
 //   Linux : sysname nodename release version machine processor machine GNU/Linux
 //   macOS : sysname nodename release version machine processor
+//
+// uname(2) exposes no separate processor (-p) or hardware-platform (-i)
+// field, so both fall back to `machine`. That matches `uname -ap` on the
+// platforms brpc targets (Linux/macOS); treat it as best-effort elsewhere.
 //
 // This is intentionally a header-only helper so that it is shared by both
 // default_variables.cpp and the unit tests. default_variables.o is stripped
@@ -46,7 +50,7 @@ inline std::string make_kernel_version_string(const struct utsname& buf) {
     oss << buf.sysname << ' ' << buf.nodename << ' '
         << buf.release << ' ' << buf.version << ' '
         << buf.machine << ' ' << processor;
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__)
     // `uname -a` appends the hardware platform and the operating-system
     // identifier on Linux; the hardware platform equals `machine` here.
     oss << ' ' << buf.machine << " GNU/Linux";

--- a/src/bvar/default_variables.h
+++ b/src/bvar/default_variables.h
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef BVAR_DEFAULT_VARIABLES_H
+#define BVAR_DEFAULT_VARIABLES_H
+
+#include <sys/utsname.h>                   // struct utsname
+#include <sstream>                         // std::ostringstream
+#include <string>                          // std::string
+
+namespace bvar {
+
+// Build the value of the `kernel_version` bvar from a uname(2) result.
+// The field layout mirrors `uname -ap` on the major platforms:
+//   Linux : sysname nodename release version machine processor machine GNU/Linux
+//   macOS : sysname nodename release version machine processor
+//
+// This is intentionally a header-only helper so that it is shared by both
+// default_variables.cpp and the unit tests. default_variables.o is stripped
+// from unit-test binaries (see BVAR_NOT_LINK_DEFAULT_VARIABLES in
+// variable.cpp), so keeping the formatting logic here lets tests exercise the
+// exact production formatter without depending on that object being linked.
+inline std::string make_kernel_version_string(const struct utsname& buf) {
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    const char* processor = "arm";
+#elif defined(__APPLE__) && defined(__x86_64__)
+    const char* processor = "i386";
+#else
+    const char* processor = buf.machine;
+#endif
+    std::ostringstream oss;
+    oss << buf.sysname << ' ' << buf.nodename << ' '
+        << buf.release << ' ' << buf.version << ' '
+        << buf.machine << ' ' << processor;
+#if defined(__linux__) && !defined(__ANDROID__)
+    // `uname -a` appends the hardware platform and the operating-system
+    // identifier on Linux; the hardware platform equals `machine` here.
+    oss << ' ' << buf.machine << " GNU/Linux";
+#endif
+    oss << '\n';
+    return oss.str();
+}
+
+}  // namespace bvar
+
+#endif  // BVAR_DEFAULT_VARIABLES_H

--- a/test/bvar_variable_unittest.cpp
+++ b/test/bvar_variable_unittest.cpp
@@ -476,10 +476,17 @@ TEST_F(VariableTest, uname_returns_valid_kernel_info) {
     ASSERT_GT(strlen(buf.machine), 0u);
 
     // Build the string the same way ReadVersion does in default_variables.cpp
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    const char* processor = "arm";
+#elif defined(__APPLE__) && defined(__x86_64__)
+    const char* processor = "i386";
+#else
+    const char* processor = buf.machine;
+#endif
     std::ostringstream oss;
     oss << buf.sysname << ' ' << buf.nodename << ' '
         << buf.release << ' ' << buf.version << ' '
-        << buf.machine << ' ' << buf.machine;
+        << buf.machine << ' ' << processor << '\n';
     std::string content = oss.str();
 
     // The result should contain all key fields

--- a/test/bvar_variable_unittest.cpp
+++ b/test/bvar_variable_unittest.cpp
@@ -20,7 +20,7 @@
 #include <pthread.h>                                // pthread_*
 #include <unistd.h>                                 // usleep
 #include <sys/utsname.h>                            // uname
-
+#include <string.h>                                 // strlen
 #include <cstddef>
 #include <memory>
 #include <thread>

--- a/test/bvar_variable_unittest.cpp
+++ b/test/bvar_variable_unittest.cpp
@@ -486,7 +486,11 @@ TEST_F(VariableTest, uname_returns_valid_kernel_info) {
     std::ostringstream oss;
     oss << buf.sysname << ' ' << buf.nodename << ' '
         << buf.release << ' ' << buf.version << ' '
-        << buf.machine << ' ' << processor << '\n';
+        << buf.machine << ' ' << processor;
+#if !defined(__APPLE__)
+    oss << " GNU/Linux";
+#endif
+    oss << '\n';
     std::string content = oss.str();
 
     // The result should contain all key fields

--- a/test/bvar_variable_unittest.cpp
+++ b/test/bvar_variable_unittest.cpp
@@ -19,6 +19,7 @@
 
 #include <pthread.h>                                // pthread_*
 #include <unistd.h>                                 // usleep
+#include <sys/utsname.h>                            // uname
 
 #include <cstddef>
 #include <memory>
@@ -461,6 +462,37 @@ TEST_F(VariableTest, dtor_waits_for_inflight_describe) {
     destroyer.join();
 
     ASSERT_TRUE(destructed.load());
+}
+
+TEST_F(VariableTest, uname_returns_valid_kernel_info) {
+    struct utsname buf;
+    ASSERT_EQ(0, uname(&buf));
+
+    // Each field should be non-empty
+    ASSERT_GT(strlen(buf.sysname), 0u);
+    ASSERT_GT(strlen(buf.nodename), 0u);
+    ASSERT_GT(strlen(buf.release), 0u);
+    ASSERT_GT(strlen(buf.version), 0u);
+    ASSERT_GT(strlen(buf.machine), 0u);
+
+    // Build the string the same way ReadVersion does in default_variables.cpp
+    std::ostringstream oss;
+    oss << buf.sysname << ' ' << buf.nodename << ' '
+        << buf.release << ' ' << buf.version << ' '
+        << buf.machine << ' ' << buf.machine;
+    std::string content = oss.str();
+
+    // The result should contain all key fields
+    ASSERT_NE(content.find(buf.sysname), std::string::npos);
+    ASSERT_NE(content.find(buf.release), std::string::npos);
+    ASSERT_NE(content.find(buf.machine), std::string::npos);
+
+    // On Linux, sysname should be "Linux"; on macOS, "Darwin"
+#if defined(__linux__)
+    ASSERT_STREQ(buf.sysname, "Linux");
+#elif defined(__APPLE__)
+    ASSERT_STREQ(buf.sysname, "Darwin");
+#endif
 }
 } // namespace
 

--- a/test/bvar_variable_unittest.cpp
+++ b/test/bvar_variable_unittest.cpp
@@ -20,7 +20,7 @@
 #include <pthread.h>                                // pthread_*
 #include <unistd.h>                                 // usleep
 #include <sys/utsname.h>                            // uname
-#include <string.h>                                 // strlen
+#include <cstring>                                 // strlen
 #include <cstddef>
 #include <memory>
 #include <thread>
@@ -30,6 +30,7 @@
 #include "butil/macros.h"
 
 #include "bvar/bvar.h"
+#include "bvar/default_variables.h"                // make_kernel_version_string
 
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
@@ -469,34 +470,40 @@ TEST_F(VariableTest, uname_returns_valid_kernel_info) {
     ASSERT_EQ(0, uname(&buf));
 
     // Each field should be non-empty
-    ASSERT_GT(strlen(buf.sysname), 0u);
-    ASSERT_GT(strlen(buf.nodename), 0u);
-    ASSERT_GT(strlen(buf.release), 0u);
-    ASSERT_GT(strlen(buf.version), 0u);
-    ASSERT_GT(strlen(buf.machine), 0u);
+    ASSERT_GT(std::strlen(buf.sysname), 0u);
+    ASSERT_GT(std::strlen(buf.nodename), 0u);
+    ASSERT_GT(std::strlen(buf.release), 0u);
+    ASSERT_GT(std::strlen(buf.version), 0u);
+    ASSERT_GT(std::strlen(buf.machine), 0u);
 
-    // Read the actual exported bvar instead of duplicating ReadVersion's
-    // formatting logic in the test. This keeps the test aligned with the
-    // externally visible behavior of kernel_version.
-    std::ostringstream kernel_version_os;
-    bvar::Variable::describe_exposed("kernel_version", kernel_version_os);
-    const std::string content = kernel_version_os.str();
-
+    // Exercise the exact formatter that backs the kernel_version bvar. It is a
+    // header-only helper shared with default_variables.cpp, so this validates
+    // the real production formatting without depending on default_variables.o
+    // being linked into the unit-test binary: that object is stripped via
+    // BVAR_NOT_LINK_DEFAULT_VARIABLES, so the bvar is not registered here and
+    // describe_exposed("kernel_version") would return nothing.
+    const std::string content = bvar::make_kernel_version_string(buf);
     ASSERT_FALSE(content.empty());
 
-    // The exported value should contain the key uname fields.
+    // The formatted value should contain all the key uname fields.
     ASSERT_NE(content.find(buf.sysname), std::string::npos);
     ASSERT_NE(content.find(buf.nodename), std::string::npos);
     ASSERT_NE(content.find(buf.release), std::string::npos);
     ASSERT_NE(content.find(buf.version), std::string::npos);
     ASSERT_NE(content.find(buf.machine), std::string::npos);
 
-    // On Linux, sysname should be "Linux"; on macOS, "Darwin"
+    // The trailing newline must be preserved to match the previous
+    // popen("uname -ap") output that this bvar used to expose.
+    ASSERT_EQ('\n', content[content.size() - 1]);
+
+    // On Linux, sysname is "Linux" and the OS suffix is appended; on macOS,
+    // sysname is "Darwin" and there is no OS suffix (both match `uname -ap`).
 #if defined(__linux__)
     ASSERT_STREQ(buf.sysname, "Linux");
     ASSERT_NE(content.find("GNU/Linux"), std::string::npos);
 #elif defined(__APPLE__)
     ASSERT_STREQ(buf.sysname, "Darwin");
+    ASSERT_EQ(content.find("GNU/Linux"), std::string::npos);
 #endif
 }
 } // namespace

--- a/test/bvar_variable_unittest.cpp
+++ b/test/bvar_variable_unittest.cpp
@@ -475,32 +475,26 @@ TEST_F(VariableTest, uname_returns_valid_kernel_info) {
     ASSERT_GT(strlen(buf.version), 0u);
     ASSERT_GT(strlen(buf.machine), 0u);
 
-    // Build the string the same way ReadVersion does in default_variables.cpp
-#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
-    const char* processor = "arm";
-#elif defined(__APPLE__) && defined(__x86_64__)
-    const char* processor = "i386";
-#else
-    const char* processor = buf.machine;
-#endif
-    std::ostringstream oss;
-    oss << buf.sysname << ' ' << buf.nodename << ' '
-        << buf.release << ' ' << buf.version << ' '
-        << buf.machine << ' ' << processor;
-#if !defined(__APPLE__)
-    oss << " GNU/Linux";
-#endif
-    oss << '\n';
-    std::string content = oss.str();
+    // Read the actual exported bvar instead of duplicating ReadVersion's
+    // formatting logic in the test. This keeps the test aligned with the
+    // externally visible behavior of kernel_version.
+    std::ostringstream kernel_version_os;
+    bvar::Variable::describe_exposed("kernel_version", kernel_version_os);
+    const std::string content = kernel_version_os.str();
 
-    // The result should contain all key fields
+    ASSERT_FALSE(content.empty());
+
+    // The exported value should contain the key uname fields.
     ASSERT_NE(content.find(buf.sysname), std::string::npos);
+    ASSERT_NE(content.find(buf.nodename), std::string::npos);
     ASSERT_NE(content.find(buf.release), std::string::npos);
+    ASSERT_NE(content.find(buf.version), std::string::npos);
     ASSERT_NE(content.find(buf.machine), std::string::npos);
 
     // On Linux, sysname should be "Linux"; on macOS, "Darwin"
 #if defined(__linux__)
     ASSERT_STREQ(buf.sysname, "Linux");
+    ASSERT_NE(content.find("GNU/Linux"), std::string::npos);
 #elif defined(__APPLE__)
     ASSERT_STREQ(buf.sysname, "Darwin");
 #endif

--- a/test/bvar_variable_unittest.cpp
+++ b/test/bvar_variable_unittest.cpp
@@ -465,7 +465,7 @@ TEST_F(VariableTest, dtor_waits_for_inflight_describe) {
     ASSERT_TRUE(destructed.load());
 }
 
-TEST_F(VariableTest, uname_returns_valid_kernel_info) {
+TEST_F(VariableTest, kernel_version_contains_uname_fields) {
     struct utsname buf;
     ASSERT_EQ(0, uname(&buf));
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When a brpc server has allocated a large amount of memory, the first request to the `/vars` endpoint can cause a significant latency stall. This is because the `kernel_version` bvar variable is lazily initialized on first access, and its constructor calls `popen("uname -ap")` to read the kernel version.

Internally, `popen()` calls `fork()` to spawn a child process. On Linux, `fork()` needs to duplicate the parent process's page tables. For a server with a large memory footprint (e.g., tens of GBs), this can take hundreds of milliseconds or even longer, effectively blocking the bthread that handles the `/vars` request.

This caused a production incident in our environment, where the service appeared to hang when the monitoring system first scraped the `/vars` endpoint after the server had been running for a while with heavy memory usage.

### What is changed and the side effects?

Changed:

Replace `butil::read_command_output(oss, "uname -ap")` (which shells out via `popen` → `fork` → `exec`) with the POSIX `uname()` syscall in `src/bvar/default_variables.cpp`. The `uname()` syscall reads the same kernel information directly via `struct utsname`, without creating any child process. The output format remains equivalent to `uname -ap`. A unit test is added in `test/bvar_variable_unittest.cpp`.

Side effects:
- Performance effects: Eliminates the `fork()` overhead entirely. The `uname()` syscall completes in microseconds regardless of the process's memory usage, whereas the previous `popen()` approach could stall for 100ms+ on large-memory processes.

- Breaking backward compatibility: No. The output format of the `kernel_version` bvar remains the same.
