### PR TITLE
Fix stale AgentGroup TLS access after bthread migration

### DIFF
--- a/src/bvar/detail/agent_group.h
+++ b/src/bvar/detail/agent_group.h
@@ -113,10 +113,12 @@ public:
     // We need this function to be as fast as possible.
     inline static Agent* get_tls_agent(AgentId id) {
         if (__builtin_expect(id >= 0, 1)) {
-            if (_s_tls_blocks) {
+            std::vector<ThreadBlock*>* tls_blocks =
+                BAIDU_GET_VOLATILE_THREAD_LOCAL(_s_tls_blocks);
+            if (tls_blocks) {
                 const size_t block_id = (size_t)id / ELEMENTS_PER_BLOCK;
-                if (block_id < _s_tls_blocks->size()) {
-                    ThreadBlock* const tb = (*_s_tls_blocks)[block_id];
+                if (block_id < tls_blocks->size()) {
+                    ThreadBlock* const tb = (*tls_blocks)[block_id];
                     if (tb) {
                         return tb->at(id - block_id * ELEMENTS_PER_BLOCK);
                     }
@@ -132,41 +134,46 @@ public:
             CHECK(false) << "Invalid id=" << id;
             return nullptr;
         }
-        if (_s_tls_blocks == nullptr) {
-            _s_tls_blocks = new (std::nothrow) std::vector<ThreadBlock *>;
-            if (__builtin_expect(_s_tls_blocks == nullptr, 0)) {
+        std::vector<ThreadBlock*>* tls_blocks =
+            BAIDU_GET_VOLATILE_THREAD_LOCAL(_s_tls_blocks);
+        if (tls_blocks == nullptr) {
+            tls_blocks = new (std::nothrow) std::vector<ThreadBlock *>;
+            if (__builtin_expect(tls_blocks == nullptr, 0)) {
                 LOG(FATAL) << "Fail to create vector, " << berror();
                 return nullptr;
             }
+            BAIDU_SET_VOLATILE_THREAD_LOCAL(_s_tls_blocks, tls_blocks);
             butil::thread_atexit(_destroy_tls_blocks);
         }
         const size_t block_id = (size_t)id / ELEMENTS_PER_BLOCK; 
-        if (block_id >= _s_tls_blocks->size()) {
+        if (block_id >= tls_blocks->size()) {
             // The 32ul avoid pointless small resizes.
-            _s_tls_blocks->resize(std::max(block_id + 1, 32ul));
+            tls_blocks->resize(std::max(block_id + 1, 32ul));
         }
-        ThreadBlock* tb = (*_s_tls_blocks)[block_id];
+        ThreadBlock* tb = (*tls_blocks)[block_id];
         if (tb == nullptr) {
             ThreadBlock *new_block = new (std::nothrow) ThreadBlock;
             if (__builtin_expect(new_block == nullptr, 0)) {
                 return nullptr;
             }
             tb = new_block;
-            (*_s_tls_blocks)[block_id] = new_block;
+            (*tls_blocks)[block_id] = new_block;
         }
         return tb->at(id - block_id * ELEMENTS_PER_BLOCK);
     }
 
 private:
     static void _destroy_tls_blocks() {
-        if (!_s_tls_blocks) {
+        std::vector<ThreadBlock*>* tls_blocks =
+            BAIDU_GET_VOLATILE_THREAD_LOCAL(_s_tls_blocks);
+        if (!tls_blocks) {
             return;
         }
-        for (size_t i = 0; i < _s_tls_blocks->size(); ++i) {
-            delete (*_s_tls_blocks)[i];
+        for (size_t i = 0; i < tls_blocks->size(); ++i) {
+            delete (*tls_blocks)[i];
         }
-        delete _s_tls_blocks;
-        _s_tls_blocks = nullptr;
+        delete tls_blocks;
+        BAIDU_SET_VOLATILE_THREAD_LOCAL(_s_tls_blocks, nullptr);
     }
 
     inline static std::deque<AgentId> &_get_free_ids() {
@@ -180,7 +187,8 @@ private:
     static pthread_mutex_t                      _s_mutex;
     static AgentId                              _s_agent_kinds;
     static std::deque<AgentId>                  *_s_free_ids;
-    static __thread std::vector<ThreadBlock *>  *_s_tls_blocks;
+    STATIC_MEMBER_BAIDU_VOLATILE_THREAD_LOCAL(
+        std::vector<ThreadBlock*>*, _s_tls_blocks);
 };
 
 template <typename Agent>
@@ -193,7 +201,7 @@ template <typename Agent>
 AgentId AgentGroup<Agent>::_s_agent_kinds = 0;
 
 template <typename Agent>
-__thread std::vector<typename AgentGroup<Agent>::ThreadBlock *>
+BAIDU_THREAD_LOCAL std::vector<typename AgentGroup<Agent>::ThreadBlock *>
 *AgentGroup<Agent>::_s_tls_blocks = nullptr;
 
 }  // namespace detail


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve #3520

Problem Summary:

`bvar::detail::AgentGroup` directly accesses the raw `_s_tls_blocks` thread-local variable from inline functions. When a bthread suspends and resumes on another pthread, Clang may reuse the TLS address resolved for the previous pthread. This can make bvar access another pthread's agent vector and race with its initialization or resize.

### What is changed and the side effects?

Changed:

- Declare `_s_tls_blocks` with the existing static-member volatile TLS accessor mechanism.
- Resolve the current pthread's TLS block vector once in each AgentGroup operation and consistently use that pointer.
- Route TLS initialization and cleanup writes through the existing setter accessor.

Side effects:

- Performance effects: On compiler targets where volatile TLS access is enabled, AgentGroup operations use the existing noinline TLS accessor to prevent the TLS address from being retained across a bthread suspend point. Other targets retain direct TLS access through the existing macros.
- Breaking backward compatibility: None.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
