### PR TITLE
Freeze bvar dump path flags and cap pprof duration by FLAGS_max_profiling_seconds

### DIFF
--- a/src/brpc/builtin/common.cpp
+++ b/src/brpc/builtin/common.cpp
@@ -26,12 +26,16 @@
 #include "butil/third_party/murmurhash3/murmurhash3.h"
 #include "butil/process_util.h"              // ReadCommandLine
 #include "brpc/server.h"
+#include "brpc/reloadable_flags.h"
 #include "brpc/builtin/common.h"
 
 namespace brpc {
 
 DEFINE_string(rpc_profiling_dir, "./rpc_data/profiling",
               "For storing profiling results.");
+
+DEFINE_int32(max_profiling_seconds, 300, "upper limit of running time of profilers");
+BRPC_VALIDATE_GFLAG(max_profiling_seconds, PositiveInteger);
 
 bool UseHTML(const HttpHeader& header) {
     const std::string* console = header.uri().GetQuery(CONSOLE_STR);

--- a/src/brpc/builtin/common.h
+++ b/src/brpc/builtin/common.h
@@ -56,6 +56,7 @@ enum ProfilingType {
 };
 
 DECLARE_string(rpc_profiling_dir);
+DECLARE_int32(max_profiling_seconds);
 
 bool UseHTML(const HttpHeader& header);
 bool MatchAnyWildcard(const std::string& name,

--- a/src/brpc/builtin/hotspots_service.cpp
+++ b/src/brpc/builtin/hotspots_service.cpp
@@ -106,9 +106,6 @@ static std::string GeneratePerlScriptPath(const std::string& filename) {
 
 extern bool cpu_profiler_enabled;
 
-DEFINE_int32(max_profiling_seconds, 300, "upper limit of running time of profilers");
-BRPC_VALIDATE_GFLAG(max_profiling_seconds, NonNegativeInteger);
-
 DEFINE_int32(max_profiles_kept, 32,
              "max profiles kept for cpu/heap/growth/contention respectively");
 BRPC_VALIDATE_GFLAG(max_profiles_kept, PassValidate);

--- a/src/brpc/builtin/pprof_service.cpp
+++ b/src/brpc/builtin/pprof_service.cpp
@@ -68,7 +68,7 @@ static int ReadSeconds(Controller* cntl) {
         }
     }
 
-    return seconds;
+    return std::min(seconds, FLAGS_max_profiling_seconds);
 }
 
 int MakeProfName(ProfilingType type, char* buf, size_t buf_len) {

--- a/src/bvar/variable.cpp
+++ b/src/bvar/variable.cpp
@@ -54,10 +54,34 @@ DEFINE_bool(bvar_abort_on_same_name, false, "Abort when names of bvar are same")
 BUTIL_VALIDATE_GFLAG(bvar_abort_on_same_name, validate_bvar_abort_on_same_name);
 
 
-DEFINE_bool(bvar_log_dumpped,  false,
-            "[For debugging] print dumpped info"
-            " into logstream before call Dumpper");
+DEFINE_bool(bvar_log_dumpped,  false, "[For debugging] print dumpped info "
+                                      "into logstream before call Dumpper");
 BUTIL_VALIDATE_GFLAG(bvar_log_dumpped, butil::PassValidate);
+
+DEFINE_bool(bvar_dump, false, "Create a background thread dumping all bvar periodically, "
+                              "all bvar_dump_* flags are not effective when this flag is off");
+DEFINE_int32(bvar_dump_interval, 10, "Seconds between consecutive dump");
+DEFINE_string(bvar_dump_file, "monitor/bvar.<app>.data",
+              "Dump bvar into this file, not settable at runtime");
+DEFINE_string(bvar_dump_include, "", "Dump bvar matching these wildcards, separated "
+                                     "by semicolon(;), empty means including all");
+DEFINE_string(bvar_dump_exclude, "", "Dump bvar excluded from these wildcards, "
+                                     "separated by semicolon(;), empty means no exclusion");
+DEFINE_string(bvar_dump_prefix, "<app>", "Every dumped name starts with this prefix");
+DEFINE_string(bvar_dump_tabs, "latency=*_latency*"
+                              ";qps=*_qps*"
+                              ";error=*_error*"
+                              ";system=*process_*,*malloc_*,*kernel_*",
+              "Dump bvar into different tabs according to the filters (separated by semicolon), "
+              "format: *(tab_name=wildcards;), not settable at runtime");
+
+DEFINE_bool(mbvar_dump, false, "Create a background thread dumping(shares the same thread as "
+                               "bvar_dump) all mbvar periodically, all mbvar_dump_* flags are "
+                               "not effective when this flag is off");
+DEFINE_string(mbvar_dump_file, "monitor/mbvar.<app>.data",
+              "Dump mbvar into this file, not settable at runtime");
+DEFINE_string(mbvar_dump_prefix, "<app>", "Every dumped name starts with this prefix");
+DEFINE_string(mbvar_dump_format, "common", "Dump mbvar write format");
 
 const size_t SUB_MAP_COUNT = 32;  // must be power of 2
 BAIDU_CASSERT(!(SUB_MAP_COUNT & (SUB_MAP_COUNT - 1)), must_be_power_of_2);
@@ -120,8 +144,8 @@ inline VarMapWithLock& get_var_map(const std::string& name) {
 }
 
 Variable::~Variable() {
-    CHECK(!hide()) << "Subclass of Variable MUST call hide() manually in their"
-        " dtors to avoid displaying a variable that is just destructing";
+    CHECK(!hide()) << "Subclass of Variable MUST call hide() manually in their "
+                      "dtors to avoid displaying a variable that is just destructing";
 }
 
 int Variable::expose_impl(const butil::StringPiece& prefix,
@@ -741,30 +765,6 @@ static bool created_dumping_thread = false;
 static pthread_mutex_t dump_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t dump_cond = PTHREAD_COND_INITIALIZER;
 
-DEFINE_bool(bvar_dump, false,
-            "Create a background thread dumping all bvar periodically, "
-            "all bvar_dump_* flags are not effective when this flag is off");
-DEFINE_int32(bvar_dump_interval, 10, "Seconds between consecutive dump");
-DEFINE_string(bvar_dump_file, "monitor/bvar.<app>.data", "Dump bvar into this file");
-DEFINE_string(bvar_dump_include, "", "Dump bvar matching these wildcards, "
-              "separated by semicolon(;), empty means including all");
-DEFINE_string(bvar_dump_exclude, "", "Dump bvar excluded from these wildcards, "
-              "separated by semicolon(;), empty means no exclusion");
-DEFINE_string(bvar_dump_prefix, "<app>", "Every dumped name starts with this prefix");
-DEFINE_string(bvar_dump_tabs, "latency=*_latency*"
-                              ";qps=*_qps*"
-                              ";error=*_error*"
-                              ";system=*process_*,*malloc_*,*kernel_*",
-              "Dump bvar into different tabs according to the filters (separated by semicolon), "
-              "format: *(tab_name=wildcards;)");
-
-DEFINE_bool(mbvar_dump, false,
-            "Create a background thread dumping(shares the same thread as bvar_dump) all mbvar periodically, "
-            "all mbvar_dump_* flags are not effective when this flag is off");
-DEFINE_string(mbvar_dump_file, "monitor/mbvar.<app>.data", "Dump mbvar into this file");
-DEFINE_string(mbvar_dump_prefix, "<app>", "Every dumped name starts with this prefix");
-DEFINE_string(mbvar_dump_format, "common", "Dump mbvar write format");
-
 #if !defined(BVAR_NOT_LINK_DEFAULT_VARIABLES)
 // Expose bvar-releated gflags so that they're collected by noah.
 // Maybe useful when debugging process of monitoring.
@@ -951,22 +951,16 @@ static bool wakeup_dumping_thread(const char*, const std::string&) {
     return true;
 }
 
-const bool ALLOW_UNUSED dummy_bvar_dump_file = GFLAGS_NAMESPACE::RegisterFlagValidator(
-    &FLAGS_bvar_dump_file, wakeup_dumping_thread);
 const bool ALLOW_UNUSED dummy_bvar_dump_filter = GFLAGS_NAMESPACE::RegisterFlagValidator(
     &FLAGS_bvar_dump_include, wakeup_dumping_thread);
 const bool ALLOW_UNUSED dummy_bvar_dump_exclude = GFLAGS_NAMESPACE::RegisterFlagValidator(
     &FLAGS_bvar_dump_exclude, wakeup_dumping_thread);
 const bool ALLOW_UNUSED dummy_bvar_dump_prefix = GFLAGS_NAMESPACE::RegisterFlagValidator(
     &FLAGS_bvar_dump_prefix, wakeup_dumping_thread);
-const bool ALLOW_UNUSED dummy_bvar_dump_tabs = GFLAGS_NAMESPACE::RegisterFlagValidator(
-    &FLAGS_bvar_dump_tabs, wakeup_dumping_thread);
 
 BUTIL_VALIDATE_GFLAG(mbvar_dump, validate_bvar_dump);
 const bool ALLOW_UNUSED dummy_mbvar_dump_prefix = GFLAGS_NAMESPACE::RegisterFlagValidator(
     &FLAGS_mbvar_dump_prefix, wakeup_dumping_thread);
-const bool ALLOW_UNUSED dump_mbvar_dump_file = GFLAGS_NAMESPACE::RegisterFlagValidator(
-    &FLAGS_mbvar_dump_file, wakeup_dumping_thread);
 
 static bool validate_mbvar_dump_format(const char*, const std::string& format) {
     if (format != "common"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve 

Problem Summary:

  Two builtin services let whoever reaches them do more than the surrounding
  configuration intends.

  #### `/flags` can repoint the bvar dump files.

  The bvar dump flags carry an accept-anything validator whose only job is to 
  wake the dumping thread:

  ```cpp
  // src/bvar/variable.cpp
  static bool wakeup_dumping_thread(const char*, const std::string&) {
      pthread_cond_signal(&dump_cond);
      return true;
  }
  ```

  The dumping thread re-reads those flags every round and ends up in
  `FileDumper::dump_impl()`:

  ```cpp
  butil::CreateDirectoryAndGetError(dir, &error);   // recursive mkdir
  _fp = fopen(_filename.c_str(), "w");              // truncate
  ```

  So two requests against a server with default options:

  ```
  GET /flags/bvar_dump_file?setvalue=/victim/dir/target
  GET /flags/bvar_dump?setvalue=true
  ```

  create a directory chain anywhere and truncate a file inside it, with the
  privileges of the server. `setvalue` is a GET, so this is reachable from a
  browser as well.

  The primitive is bounded but real. `bvar_dump_file` and `bvar_dump_tabs` get a
  `.data` suffix forced on them by `FilePath::AddExtension()`, and the bytes
  written are bvar names and values, not attacker input. `mbvar_dump_file` is
  used verbatim with no suffix. `bvar_dump_tabs` names files too: its tab names
  go through the same `AddExtension()`, which appends them to the path with no
  sanitization, so `../` in a tab name escapes the configured directory. The
  recursive mkdir and the truncation are unrestricted in every case.

  #### `/pprof` ignores `FLAGS_max_profiling_seconds`, which `/hotspots` enforces.

  ```cpp
  // src/brpc/builtin/pprof_service.cpp, ReadSeconds(), before this PR
      return seconds;                                        // no upper bound
  ```
  ```cpp
  // src/brpc/builtin/hotspots_service.cpp:233
      seconds = std::min(seconds, FLAGS_max_profiling_seconds);
  ```

  `?seconds=2147483647` reaches `bthread_usleep(sleep_sec * 1000000L)`, roughly
  68 years. The profilers are process wide -- gperftools' `ProfilerStart` and
  bthread's `g_cp` are each a single global, so this is not merely one hung
  RPC: it holds the only CPU or contention profiler for as long as it asked for,
  and `/hotspots/cpu` and `/hotspots/contention` answer 503 the whole time. The
  300 second limit was enforced on only one of the two paths to the same
  resource, so the path without it decides the limit for both.

### What is changed and the side effects?

Changed:

- Drop the validator registration for -bvar_dump_file`, `-bvar_dump_tabs` and 
   `FLAGS_mbvar_dump_file`.
- Clamp `ReadSeconds()` to `FLAGS_max_profiling_seconds`.

Side effects:
- Performance effects:

- Breaking backward compatibility: 

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
