### PR TITLE
Fix stream count test cleanup

### DIFF
--- a/test/brpc_streaming_rpc_unittest.cpp
+++ b/test/brpc_streaming_rpc_unittest.cpp
@@ -1448,10 +1448,10 @@ TEST_F(StreamingRpcTest, limit_streams_accepted_per_request) {
         }
 
         for (brpc::StreamId stream_id : service.response_streams) {
-            brpc::StreamClose(stream_id);
+            ASSERT_EQ(0, brpc::StreamClose(stream_id));
         }
         for (brpc::StreamId stream_id : request_streams) {
-            brpc::StreamClose(stream_id);
+            ASSERT_EQ(0, brpc::StreamClose(stream_id));
         }
     }
 

--- a/test/brpc_streaming_rpc_unittest.cpp
+++ b/test/brpc_streaming_rpc_unittest.cpp
@@ -1388,7 +1388,7 @@ public:
         brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
         response->set_message(request->message());
 
-        brpc::StreamIds response_streams;
+        response_streams.clear();
         accept_result.store(
             brpc::StreamAccept(response_streams, *cntl, nullptr),
             std::memory_order_release);
@@ -1398,6 +1398,7 @@ public:
 
     std::atomic<int> accept_result{0};
     std::atomic<size_t> accepted_streams{0};
+    brpc::StreamIds response_streams;
 };
 
 TEST_F(StreamingRpcTest, limit_streams_accepted_per_request) {
@@ -1446,6 +1447,9 @@ TEST_F(StreamingRpcTest, limit_streams_accepted_per_request) {
                               std::memory_order_acquire));
         }
 
+        for (brpc::StreamId stream_id : service.response_streams) {
+            brpc::StreamClose(stream_id);
+        }
         for (brpc::StreamId stream_id : request_streams) {
             brpc::StreamClose(stream_id);
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: resolve

Problem Summary:

`StreamingRpcTest.limit_streams_accepted_per_request` can hang while joining
the server. The service discards the response stream identifiers returned by
`StreamAccept`, so cleanup depends on the timing of close frames from the
client side.

### What is changed and the side effects?

Changed:

- Keep the accepted response stream identifiers in the test service.
- Explicitly close both response and request streams after each request.

Side effects:
- Performance effects: None.

- Breaking backward compatibility: No. This only fixes unit-test cleanup.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).
