### PR TITLE
refactor(butil): replace integer string conversions

### DIFF
--- a/example/baidu_proxy_and_generic_call/proxy.cpp
+++ b/example/baidu_proxy_and_generic_call/proxy.cpp
@@ -17,9 +17,10 @@
 // todo
 // A proxy to receive EchoRequest and send back EchoResponse.
 
+#include <string>
+
 #include <gflags/gflags.h>
 #include <butil/logging.h>
-#include <butil/strings/string_number_conversions.h>
 #include <brpc/server.h>
 #include <brpc/controller.h>
 #include <brpc/channel.h>
@@ -65,7 +66,7 @@ public:
             FLAGS_load_balancer.c_str(), &options) != 0) {
             LOG(ERROR) << "Fail to initialize channel";
             (*cntl->response_user_fields())["x-bd-proxy-error-code"] =
-                butil::IntToString(brpc::EINTERNAL);
+                std::to_string(brpc::EINTERNAL);
             (*cntl->response_user_fields())["x-bd-proxy-error-text"] =
                 "Fail to initialize channel";
             return;
@@ -86,7 +87,7 @@ public:
         // It is ok to use request and response for sync rpc.
         channel.CallMethod(nullptr, &call_cntl, request, response, nullptr);
         (*cntl->response_user_fields())["x-bd-proxy-error-code"] =
-            butil::IntToString(call_cntl.ErrorCode());
+            std::to_string(call_cntl.ErrorCode());
         if (call_cntl.Failed()) {
             (*cntl->response_user_fields())["x-bd-proxy-error-text"] =
                 call_cntl.ErrorText();

--- a/src/butil/location.cc
+++ b/src/butil/location.cc
@@ -4,6 +4,8 @@
 
 #include "butil/build_config.h"
 
+#include <string>
+
 #if defined(COMPILER_MSVC)
 // MSDN says to #include <intrin.h>, but that breaks the VS2005 build.
 extern "C" {
@@ -12,7 +14,6 @@ extern "C" {
 #endif
 
 #include "butil/location.h"
-#include "butil/strings/string_number_conversions.h"
 #include "butil/strings/stringprintf.h"
 
 namespace tracked_objects {
@@ -36,7 +37,7 @@ Location::Location()
 
 std::string Location::ToString() const {
   return std::string(function_name_) + "@" + file_name_ + ":" +
-      butil::IntToString(line_number_);
+      std::to_string(line_number_);
 }
 
 void Location::Write(bool display_filename, bool display_function_name,

--- a/src/butil/strings/string_number_conversions.cc
+++ b/src/butil/strings/string_number_conversions.cc
@@ -343,8 +343,7 @@ bool String16ToIntImpl(const StringPiece16& input, VALUE* output) {
 }  // namespace
 
 std::string IntToString(int value) {
-  return IntToStringT<std::string, int, unsigned int, true>::
-      IntToString(value);
+  return std::to_string(value);
 }
 
 string16 IntToString16(int value) {
@@ -353,8 +352,7 @@ string16 IntToString16(int value) {
 }
 
 std::string UintToString(unsigned int value) {
-  return IntToStringT<std::string, unsigned int, unsigned int, false>::
-      IntToString(value);
+  return std::to_string(value);
 }
 
 string16 UintToString16(unsigned int value) {

--- a/src/butil/threading/simple_thread.cc
+++ b/src/butil/threading/simple_thread.cc
@@ -4,8 +4,9 @@
 
 #include "butil/threading/simple_thread.h"
 
+#include <string>
+
 #include "butil/logging.h"
-#include "butil/strings/string_number_conversions.h"
 #include "butil/threading/platform_thread.h"
 #include "butil/threading/thread_restrictions.h"
 
@@ -51,7 +52,7 @@ void SimpleThread::ThreadMain() {
   tid_ = PlatformThread::CurrentId();
   // Construct our full name of the form "name_prefix_/TID".
   name_.push_back('/');
-  name_.append(IntToString(tid_));
+  name_.append(std::to_string(tid_));
   PlatformThread::SetName(name_.c_str());
 
   // We've initialized our new thread, signal that we're done to Start().

--- a/src/butil/version.cc
+++ b/src/butil/version.cc
@@ -43,7 +43,7 @@ bool ParseVersionNumbers(const std::string& version_str,
       return false;
 
     // This throws out things like +3, or 032.
-    if (IntToString(num) != *it)
+    if (std::to_string(num) != *it)
       return false;
 
     parsed->push_back(static_cast<uint16_t>(num));
@@ -168,10 +168,10 @@ const std::string Version::GetString() const {
   std::string version_str;
   size_t count = components_.size();
   for (size_t i = 0; i < count - 1; ++i) {
-    version_str.append(IntToString(components_[i]));
+    version_str.append(std::to_string(components_[i]));
     version_str.append(".");
   }
-  version_str.append(IntToString(components_[count - 1]));
+  version_str.append(std::to_string(components_[count - 1]));
   return version_str;
 }
 

--- a/test/brpc_http_rpc_protocol_unittest.cpp
+++ b/test/brpc_http_rpc_protocol_unittest.cpp
@@ -2684,7 +2684,7 @@ TEST_F(HttpTest, http_head) {
         brpc::Controller cntl;
         cntl.http_request().set_method(brpc::HTTP_METHOD_HEAD);
         cntl.http_request().uri().set_path("/HttpService/Head");
-        cntl.http_request().SetHeader("x-db-index", butil::IntToString(i));
+        cntl.http_request().SetHeader("x-db-index", std::to_string(i));
         channel.CallMethod(nullptr, &cntl, nullptr, nullptr, nullptr);
 
         ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();

--- a/test/shared_memory_unittest.cc
+++ b/test/shared_memory_unittest.cc
@@ -12,6 +12,9 @@
 #include "multiprocess_test.h"
 #include "butil/threading/platform_thread.h"
 #include "butil/time/time.h"
+
+#include <string>
+
 #include <gtest/gtest.h>
 #include "multiprocess_func_list.h"
 
@@ -575,7 +578,8 @@ TEST(SharedMemoryTest, FilePermissionsNamed) {
   SharedMemory shared_memory;
   SharedMemoryCreateOptions options;
   options.size = kTestSize;
-  std::string shared_mem_name = "shared_perm_test-" + IntToString(getpid()) +
+  std::string shared_mem_name = "shared_perm_test-" +
+      std::to_string(static_cast<int>(getpid())) +
       "-" + Uint64ToString(RandUint64());
   options.name_deprecated = &shared_mem_name;
   // Set a file mode creation mask that gives all permissions.

--- a/test/simple_thread_unittest.cc
+++ b/test/simple_thread_unittest.cc
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 #include "butil/atomic_sequence_num.h"
-#include "butil/strings/string_number_conversions.h"
 #include "butil/synchronization/waitable_event.h"
 #include "butil/threading/simple_thread.h"
+
+#include <string>
+
 #include <gtest/gtest.h>
 
 namespace butil {
@@ -123,7 +125,7 @@ TEST(SimpleThreadTest, NamedWithOptions) {
   thread.Start();
   EXPECT_EQ(thread.name_prefix(), "event_waiter");
   EXPECT_EQ(thread.name(),
-            std::string("event_waiter/") + IntToString(thread.tid()));
+            std::string("event_waiter/") + std::to_string(thread.tid()));
   event.Wait();
 
   EXPECT_TRUE(event.IsSignaled());
@@ -132,7 +134,7 @@ TEST(SimpleThreadTest, NamedWithOptions) {
   // We keep the name and tid, even after the thread is gone.
   EXPECT_EQ(thread.name_prefix(), "event_waiter");
   EXPECT_EQ(thread.name(),
-            std::string("event_waiter/") + IntToString(thread.tid()));
+            std::string("event_waiter/") + std::to_string(thread.tid()));
 }
 
 TEST(SimpleThreadTest, ThreadPool) {


### PR DESCRIPTION
### What problem does this PR solve?

  Problem Summary:

  Replace internal uses of legacy `butil` integer-to-string helpers with `std::to_string` to reduce duplicated conversion logic.

  ### What is changed and the side effects?

  Changed:

  - Use `std::to_string` for internal `IntToString` and `UintToString` call sites.
  - Keep the public `butil::IntToString(int)` and `butil::UintToString(unsigned)` APIs as compatibility wrappers backed by `std::to_string`.
  - Update integer conversion tests while preserving unsigned conversion behavior for negative `int` inputs.

  Side effects:
  - Performance effects: No benchmark was run; no expected material impact.

  - Breaking backward compatibility: No. The existing public helper APIs remain available.

  ---
  ### Check List:
  - [x] Please make sure your changes are compilable.
    - `cmake --build build --target BUTIL_LIB -j6`
    - `cmake --build build --target test_butil -j6`
  - [x] Related tests updated and passed.
    - `StringNumberConversionsTest.IntToString`
    - `HttpTest.http_head`
  - [x] Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).