### PR TITLE
Reject empty MySQL response packets

### DIFF
--- a/src/brpc/policy/mysql/mysql_reply.cpp
+++ b/src/brpc/policy/mysql/mysql_reply.cpp
@@ -200,6 +200,11 @@ ParseError MysqlReply::ConsumePartialIOBuf(butil::IOBuf& buf,
     }
     uint8_t header[4 + 1];  // use the extra byte to judge message type
     const uint8_t* p = (const uint8_t*)buf.fetch(header, sizeof(header));
+    if (_type == MYSQL_RSP_UNKNOWN &&
+        (p == nullptr || mysql_uint3korr(p) == 0)) {
+        LOG(ERROR) << "Invalid mysql packet with empty payload";
+        return PARSE_ERROR_ABSOLUTELY_WRONG;
+    }
     uint8_t type = (_type == MYSQL_RSP_UNKNOWN) ? p[4] : (uint8_t)_type;
     // During the connection (auth) phase the server may send an AuthMoreData
     // packet (first byte 0x01) as part of the caching_sha2_password exchange
@@ -243,6 +248,11 @@ ParseError MysqlReply::ConsumePartialIOBuf(butil::IOBuf& buf,
             butil::IOBuf discard;
             buf.cutn(&discard, amd_total);
             const uint8_t* p2 = (const uint8_t*)buf.fetch(header, sizeof(header));
+            if (p2 == nullptr || mysql_uint3korr(p2) == 0) {
+                LOG(ERROR) << "Invalid mysql packet with empty payload after "
+                              "fast-auth marker";
+                return PARSE_ERROR_ABSOLUTELY_WRONG;
+            }
             type = p2[4];
         } else {
             _type = MYSQL_RSP_AUTH_MORE_DATA;

--- a/test/brpc_mysql_reply_parse_unittest.cpp
+++ b/test/brpc_mysql_reply_parse_unittest.cpp
@@ -101,6 +101,47 @@ TEST(MysqlReplyParseTest, RejectOversizedTextFieldLength) {
     ASSERT_EQ(brpc::PARSE_ERROR_ABSOLUTELY_WRONG, rc);
 }
 
+TEST(MysqlReplyParseTest, RejectZeroPayloadPacket) {
+    butil::IOBuf buf;
+    buf.append(std::string("\x00\x00\x00\x01", 4));
+
+    brpc::MysqlReply reply;
+    butil::Arena arena;
+    bool more_results = false;
+    brpc::ParseError rc = reply.ConsumePartialIOBuf(
+        buf, &arena, false, brpc::MYSQL_NORMAL_STATEMENT, &more_results);
+    ASSERT_EQ(brpc::PARSE_ERROR_ABSOLUTELY_WRONG, rc);
+}
+
+TEST(MysqlReplyParseTest, RejectZeroPayloadPacketWithTrailingBytes) {
+    std::string wire("\x00\x00\x00\x01", 4);
+    AppendPacket(&wire, 2, std::string("\x00\x00\x00\x00\x00\x00\x00", 7));
+    butil::IOBuf buf;
+    buf.append(wire);
+
+    brpc::MysqlReply reply;
+    butil::Arena arena;
+    bool more_results = false;
+    brpc::ParseError rc = reply.ConsumePartialIOBuf(
+        buf, &arena, false, brpc::MYSQL_NORMAL_STATEMENT, &more_results);
+    ASSERT_EQ(brpc::PARSE_ERROR_ABSOLUTELY_WRONG, rc);
+}
+
+TEST(MysqlReplyParseTest, RejectZeroPayloadPacketAfterFastAuthMarker) {
+    std::string wire;
+    AppendPacket(&wire, 2, std::string("\x01\x03", 2));
+    wire.append(std::string("\x00\x00\x00\x03", 4));
+    butil::IOBuf buf;
+    buf.append(wire);
+
+    brpc::MysqlReply reply;
+    butil::Arena arena;
+    bool more_results = false;
+    brpc::ParseError rc = reply.ConsumePartialIOBuf(
+        buf, &arena, true, brpc::MYSQL_NORMAL_STATEMENT, &more_results);
+    ASSERT_EQ(brpc::PARSE_ERROR_ABSOLUTELY_WRONG, rc);
+}
+
 // A well-formed field whose length matches the bytes present still parses, so
 // the guard does not reject legitimate result sets.
 TEST(MysqlReplyParseTest, AcceptWellFormedTextField) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

The MySQL response parser reads the response type byte without first
rejecting packets whose declared payload length is zero. When another packet
follows, the parser may treat that packet's first byte as the empty packet's
type.

### What is changed and the side effects?

Changed:

- Reject zero-length MySQL response packets before reading their type.
- Apply the same validation after a fast-auth marker.
- Cover standalone and followed-by-another-packet cases.

Side effects:

- Performance effects: One payload-length check while determining a response
  type.
- Breaking backward compatibility: Invalid zero-length response packets are
  rejected instead of being interpreted using following bytes.

---
### Check List:
- Please make sure your changes are compilable.
- When providing us with a new feature, it is best to add related tests.
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).